### PR TITLE
Account-Gedächtnis: Outcome-Capture + Beweis-Historie (T1–T3)

### DIFF
--- a/app/dashboard/accounts/account-proof-memory-actions.ts
+++ b/app/dashboard/accounts/account-proof-memory-actions.ts
@@ -1,0 +1,37 @@
+'use server'
+
+import { getCachedAccountProofMemory, type AccountProofMemory } from '@/lib/accounts/account-proof-memory'
+import { loadReferenceVisibilityForUser } from '@/lib/roles/load-reference-visibility'
+import { createServerSupabaseClient } from '@/lib/supabase/server'
+
+export async function fetchAccountProofMemoryAction(
+  companyId: string
+): Promise<{ success: true; memory: AccountProofMemory } | { success: false; error: string }> {
+  const supabase = await createServerSupabaseClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return { success: false, error: 'Nicht angemeldet.' }
+
+  const visibility = await loadReferenceVisibilityForUser(supabase, user.id)
+  if (!visibility) return { success: false, error: 'Keine Organisation zugeordnet.' }
+
+  const { data: company, error: companyErr } = await supabase
+    .from('companies')
+    .select('id')
+    .eq('id', companyId)
+    .eq('organization_id', visibility.organizationId)
+    .maybeSingle()
+
+  if (companyErr || !company) {
+    return { success: false, error: 'Account nicht gefunden oder keine Berechtigung.' }
+  }
+
+  const memory = await getCachedAccountProofMemory({
+    organizationId: visibility.organizationId,
+    companyId,
+    salesVisibleOnly: visibility.salesVisibleOnly,
+  })
+
+  return { success: true, memory }
+}

--- a/app/dashboard/accounts/company-detail-proof-memory-section.tsx
+++ b/app/dashboard/accounts/company-detail-proof-memory-section.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import Link from 'next/link'
+
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { formatDateUtcDe } from '@/lib/format'
+import { ROUTES } from '@/lib/routes'
+
+import type { AccountProofHistoryItem, AccountProofImpactRow } from '@/lib/accounts/account-proof-memory-pure'
+
+export function AccountProofImpactCard({ rows }: { rows: AccountProofImpactRow[] }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Was hier funktioniert hat</CardTitle>
+        <CardDescription>
+          Aggregiert über alle Deals dieses Accounts — unabhängig vom aktuellen Account Manager.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {rows.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            Noch keine Beweis-Wirkung an Deals dieses Accounts — sobald Referenzen verknüpft, geteilt
+            oder Deals abgeschlossen werden, erscheint hier die Historie.
+          </p>
+        ) : (
+          <ul className="space-y-3">
+            {rows.map((row) => (
+              <li
+                key={row.referenceId}
+                className="flex flex-wrap items-start justify-between gap-2 rounded-md border bg-muted/20 px-3 py-2 text-sm"
+              >
+                <div>
+                  <Link
+                    href={ROUTES.references.detail(row.referenceId)}
+                    className="font-medium hover:underline"
+                  >
+                    {row.title}
+                  </Link>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {row.dealCount} Deal{row.dealCount === 1 ? '' : 's'}
+                    {row.wonDealCount > 0 ? ` · ${row.wonDealCount} gewonnen` : ''}
+                    {row.viewCount > 0 ? ` · ${row.viewCount} Öffnung${row.viewCount === 1 ? '' : 'en'}` : ''}
+                  </p>
+                </div>
+                {row.decisiveCount > 0 ? (
+                  <Badge variant="secondary" className="shrink-0">
+                    Entscheidend
+                  </Badge>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+export function AccountProofHistoryCard({ items }: { items: AccountProofHistoryItem[] }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Beweis-Historie</CardTitle>
+        <CardDescription>
+          Chronologisch: geteilt, geöffnet und Deal-Abschlüsse mit Beweisbezug.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {items.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            Noch keine Ereignisse für diesen Account erfasst.
+          </p>
+        ) : (
+          <ul className="space-y-3">
+            {items.map((item) => (
+              <li key={item.id} className="border-l-2 border-muted pl-3 text-sm">
+                <time className="text-xs text-muted-foreground" dateTime={item.at}>
+                  {formatDateUtcDe(item.at)}
+                </time>
+                <p className="font-medium">{item.label}</p>
+                {item.detail ? (
+                  <p className="text-xs text-muted-foreground">{item.detail}</p>
+                ) : null}
+                {item.dealId ? (
+                  <Link
+                    href={ROUTES.deals.detail(item.dealId)}
+                    className="mt-1 inline-block text-xs text-primary hover:underline"
+                  >
+                    Zum Deal
+                  </Link>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/dashboard/accounts/company-detail-proof-points-tab.tsx
+++ b/app/dashboard/accounts/company-detail-proof-points-tab.tsx
@@ -14,10 +14,16 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import type { AccountProofMemory } from '@/lib/accounts/account-proof-memory-pure'
 import { ROUTES } from '@/lib/routes'
 
 import type { CompanyRefRow } from './actions'
+import { fetchAccountProofMemoryAction } from './account-proof-memory-actions'
 import { fetchAccountReferenceFitScoresAction } from './account-reference-fit-actions'
+import {
+  AccountProofHistoryCard,
+  AccountProofImpactCard,
+} from './company-detail-proof-memory-section'
 import { referenceStatusLabel } from './company-detail-constants'
 import type { CompanyDetailCompany } from './company-detail-types'
 
@@ -33,6 +39,9 @@ export function CompanyDetailProofPointsTab({
   const [fitScores, setFitScores] = useState<Record<string, number>>({})
   const [loadingFit, setLoadingFit] = useState(false)
   const [fitError, setFitError] = useState<string | null>(null)
+  const [memory, setMemory] = useState<AccountProofMemory | null>(null)
+  const [loadingMemory, setLoadingMemory] = useState(false)
+  const [memoryError, setMemoryError] = useState<string | null>(null)
 
   const loadFitScores = useCallback(async () => {
     if (!references.length) {
@@ -57,6 +66,27 @@ export function CompanyDetailProofPointsTab({
     }
   }, [company.id, references])
 
+  const loadMemory = useCallback(async () => {
+    setLoadingMemory(true)
+    setMemoryError(null)
+    try {
+      const res = await fetchAccountProofMemoryAction(company.id)
+      if (!res.success) {
+        setMemoryError(res.error)
+        setMemory(null)
+        return
+      }
+      setMemory(res.memory)
+    } finally {
+      setLoadingMemory(false)
+    }
+  }, [company.id])
+
+  useEffect(() => {
+    if (!isActive) return
+    void loadMemory()
+  }, [isActive, loadMemory])
+
   useEffect(() => {
     if (!isActive) return
     void loadFitScores()
@@ -64,6 +94,24 @@ export function CompanyDetailProofPointsTab({
 
   return (
     <div className="space-y-6">
+      {loadingMemory ? (
+        <p className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="size-4 animate-spin" />
+          Account-Gedächtnis laden …
+        </p>
+      ) : null}
+      {memoryError ? (
+        <p className="text-sm text-destructive" role="alert">
+          {memoryError}
+        </p>
+      ) : null}
+      {memory ? (
+        <>
+          <AccountProofImpactCard rows={memory.impact} />
+          <AccountProofHistoryCard items={memory.history} />
+        </>
+      ) : null}
+
       <Card>
         <CardHeader>
           <CardTitle>Referenz-Bibliothek</CardTitle>

--- a/app/dashboard/deals/actions.ts
+++ b/app/dashboard/deals/actions.ts
@@ -14,6 +14,7 @@ import {
   escapeRefstackEmailHtml,
   getRefstackResendFrom,
 } from '@/lib/email/refstack-email-layout'
+import { validateDecisiveReferenceId } from '@/lib/deals/outcome-capture'
 import type { DealRow, DealStatus, DealWithReferences } from './types'
 
 async function getSessionOrgId(
@@ -212,6 +213,8 @@ export async function getDealWithReferences(id: string): Promise<DealWithReferen
       sales_manager_id,
       status,
       expiry_date,
+      outcome_reason,
+      decisive_reference_id,
       created_at,
       updated_at,
       companies ( name )
@@ -298,6 +301,9 @@ export async function getDealWithReferences(id: string): Promise<DealWithReferen
     sales_manager_name: salesManagerName,
     status: normalizeDealStatus(deal.status),
     expiry_date: deal.expiry_date ?? null,
+    outcome_reason: (deal as { outcome_reason?: string | null }).outcome_reason ?? null,
+    decisive_reference_id:
+      (deal as { decisive_reference_id?: string | null }).decisive_reference_id ?? null,
     created_at: deal.created_at ?? '',
     updated_at: deal.updated_at ?? null,
     linked_refs,
@@ -542,9 +548,8 @@ export async function updateDeal(args: {
 export async function recordDealOutcome(args: {
   dealId: string
   outcome: 'won' | 'lost' | 'withdrawn'
-  comment?: string
-  /** `true`/`false`/`null` = gesetzt; weglassen = keine Angabe im Payload. */
-  referenceHelpful?: boolean | null
+  outcomeReason?: string
+  decisiveReferenceId?: string | null
 }): Promise<{ success: boolean; error?: string }> {
   const supabase = await createServerSupabaseClient()
   const {
@@ -560,11 +565,34 @@ export async function recordDealOutcome(args: {
   const orgId = profile?.organization_id
   if (!orgId) return { success: false, error: 'Keine Organisation zugeordnet.' }
 
+  const decisiveReferenceId = args.decisiveReferenceId?.trim() || null
+  if (decisiveReferenceId && args.outcome === 'withdrawn') {
+    return {
+      success: false,
+      error: 'Entscheidende Referenz ist nur bei Gewonnen/Verloren möglich.',
+    }
+  }
+  if (decisiveReferenceId) {
+    const { data: linkedRows } = await supabase
+      .from('deal_references')
+      .select('reference_id')
+      .eq('deal_id', args.dealId)
+
+    const linkedIds = (linkedRows ?? []).map((row) => String(row.reference_id))
+    const validation = validateDecisiveReferenceId(decisiveReferenceId, linkedIds)
+    if (!validation.ok) return { success: false, error: validation.error }
+  }
+
   const status = normalizeDealStatus(args.outcome)
+  const outcomeReason = args.outcomeReason?.trim() || null
 
   const { error: updErr } = await supabase
     .from('deals')
-    .update({ status })
+    .update({
+      status,
+      outcome_reason: outcomeReason,
+      decisive_reference_id: decisiveReferenceId,
+    })
     .eq('id', args.dealId)
     .eq('organization_id', orgId)
   if (updErr) return { success: false, error: updErr.message }
@@ -576,17 +604,18 @@ export async function recordDealOutcome(args: {
         ? 'deal_lost'
         : 'deal_withdrawn'
 
-  const eventPayload: { comment: string | null; reference_helpful?: boolean | null } = {
-    comment: args.comment?.trim() || null,
-  }
-  if (args.referenceHelpful !== undefined) {
-    eventPayload.reference_helpful = args.referenceHelpful
+  const eventPayload: {
+    outcome_reason: string | null
+    decisive_reference_id: string | null
+  } = {
+    outcome_reason: outcomeReason,
+    decisive_reference_id: decisiveReferenceId,
   }
 
   const { error: evErr } = await supabase.from('evidence_events').insert({
     organization_id: orgId,
     deal_id: args.dealId,
-    reference_id: null,
+    reference_id: decisiveReferenceId,
     event_type: eventType,
     payload: eventPayload,
     created_by: user.id,

--- a/app/dashboard/deals/actions.ts
+++ b/app/dashboard/deals/actions.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import { revalidatePath } from 'next/cache'
+import { revalidatePath, revalidateTag } from 'next/cache'
 import { createServerSupabaseClient } from '@/lib/supabase/server'
 import { ROUTES } from '@/lib/routes'
 import { getRequestProfile, getRequestUser } from '@/lib/auth/request-user'
@@ -15,6 +15,7 @@ import {
   getRefstackResendFrom,
 } from '@/lib/email/refstack-email-layout'
 import { validateDecisiveReferenceId } from '@/lib/deals/outcome-capture'
+import { accountProofMemoryTag } from '@/lib/accounts/account-proof-memory'
 import type { DealRow, DealStatus, DealWithReferences } from './types'
 
 async function getSessionOrgId(
@@ -586,7 +587,7 @@ export async function recordDealOutcome(args: {
   const status = normalizeDealStatus(args.outcome)
   const outcomeReason = args.outcomeReason?.trim() || null
 
-  const { error: updErr } = await supabase
+  const { data: updatedDeal, error: updErr } = await supabase
     .from('deals')
     .update({
       status,
@@ -595,6 +596,8 @@ export async function recordDealOutcome(args: {
     })
     .eq('id', args.dealId)
     .eq('organization_id', orgId)
+    .select('company_id')
+    .single()
   if (updErr) return { success: false, error: updErr.message }
 
   const eventType =
@@ -621,6 +624,10 @@ export async function recordDealOutcome(args: {
     created_by: user.id,
   })
   if (evErr) return { success: false, error: evErr.message }
+
+  if (updatedDeal?.company_id) {
+    revalidateTag(accountProofMemoryTag(String(updatedDeal.company_id)), 'max')
+  }
 
   revalidatePath(ROUTES.deals.root)
   revalidatePath(ROUTES.deals.detail(args.dealId))

--- a/app/dashboard/deals/components/outcome-dialog.tsx
+++ b/app/dashboard/deals/components/outcome-dialog.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 import { Trophy } from "@hugeicons/core-free-icons"
@@ -21,35 +21,56 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Textarea } from "@/components/ui/textarea"
 
 import { recordDealOutcome } from "../actions"
+import type { DealStatus } from "../types"
 
-type ReferenceHelpfulChoice = "__none__" | "yes" | "no" | "na"
+type LinkedReference = {
+  id: string
+  title: string
+  company_name: string
+}
 
-export function OutcomeDialog({ dealId }: { dealId: string }) {
+export function OutcomeDialog({
+  dealId,
+  dealStatus,
+  linkedReferences,
+  initialOutcomeReason = null,
+  initialDecisiveReferenceId = null,
+}: {
+  dealId: string
+  dealStatus: DealStatus
+  linkedReferences: LinkedReference[]
+  initialOutcomeReason?: string | null
+  initialDecisiveReferenceId?: string | null
+}) {
   const router = useRouter()
   const [open, setOpen] = useState(false)
   const [outcome, setOutcome] = useState<"won" | "lost" | "withdrawn" | "">("")
-  const [comment, setComment] = useState("")
-  const [referenceHelpful, setReferenceHelpful] = useState<ReferenceHelpfulChoice>("__none__")
+  const [outcomeReason, setOutcomeReason] = useState("")
+  const [decisiveReferenceId, setDecisiveReferenceId] = useState<string>("__none__")
   const [saving, setSaving] = useState(false)
 
-  /** `undefined` = keine Angabe (Feld weglassen im Event-Payload). */
-  function mapReferenceHelpful(): boolean | null | undefined {
-    if (referenceHelpful === "yes") return true
-    if (referenceHelpful === "no") return false
-    if (referenceHelpful === "na") return null
-    return undefined
-  }
+  const isTerminal = dealStatus === "won" || dealStatus === "lost" || dealStatus === "withdrawn"
+
+  useEffect(() => {
+    if (!open) return
+    setOutcomeReason(initialOutcomeReason ?? "")
+    setDecisiveReferenceId(initialDecisiveReferenceId ?? "__none__")
+    if (dealStatus === "won" || dealStatus === "lost" || dealStatus === "withdrawn") {
+      setOutcome(dealStatus)
+    } else {
+      setOutcome("")
+    }
+  }, [open, dealStatus, initialOutcomeReason, initialDecisiveReferenceId])
 
   async function submit() {
     if (!outcome) return
     setSaving(true)
     try {
-      const rh = mapReferenceHelpful()
       const res = await recordDealOutcome({
         dealId,
         outcome,
-        comment,
-        ...(rh !== undefined ? { referenceHelpful: rh } : {}),
+        outcomeReason,
+        decisiveReferenceId: decisiveReferenceId === "__none__" ? null : decisiveReferenceId,
       })
       if (!res.success) {
         toast.error(res.error ?? "Konnte Ausgang nicht speichern.")
@@ -57,34 +78,39 @@ export function OutcomeDialog({ dealId }: { dealId: string }) {
       }
       toast.success("Ausgang gespeichert.")
       setOpen(false)
-      setOutcome("")
-      setComment("")
-      setReferenceHelpful("__none__")
       router.refresh()
     } finally {
       setSaving(false)
     }
   }
 
+  const showDecisiveReference =
+    (outcome === "won" || outcome === "lost") && linkedReferences.length > 0
+
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
         <Button type="button" size="sm" variant="outline" className="w-full">
           <AppIcon icon={Trophy} size={16} className="mr-2" />
-          Ausgang festhalten
+          {isTerminal ? "Ausgang bearbeiten" : "Ausgang festhalten"}
         </Button>
       </DialogTrigger>
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>Ausgang des Deals</DialogTitle>
-          <DialogDescription>Kurz festhalten, wie der Deal ausgegangen ist.</DialogDescription>
+          <DialogDescription>
+            Kurz festhalten, wie der Deal ausgegangen ist. Grund und entscheidender Beweis sind optional
+            — ein Klick auf Speichern reicht.
+          </DialogDescription>
         </DialogHeader>
         <div className="space-y-3">
           <div className="space-y-2">
-            <Label>Outcome</Label>
+            <Label>Ergebnis</Label>
             <Select
               value={outcome || "__none__"}
-              onValueChange={(v) => setOutcome(v === "__none__" ? "" : (v as "won" | "lost" | "withdrawn"))}
+              onValueChange={(v) =>
+                setOutcome(v === "__none__" ? "" : (v as "won" | "lost" | "withdrawn"))
+              }
             >
               <SelectTrigger>
                 <SelectValue placeholder="Auswählen …" />
@@ -98,34 +124,42 @@ export function OutcomeDialog({ dealId }: { dealId: string }) {
             </Select>
           </div>
           <div className="space-y-2">
-            <Label htmlFor="outcome-comment">Grund (Freitext, optional)</Label>
+            <Label htmlFor="outcome-reason">
+              {outcome === "lost"
+                ? "Warum verloren? (optional)"
+                : outcome === "won"
+                  ? "Warum gewonnen? (optional)"
+                  : "Grund (optional)"}
+            </Label>
             <Textarea
-              id="outcome-comment"
-              value={comment}
-              onChange={(e) => setComment(e.target.value)}
+              id="outcome-reason"
+              value={outcomeReason}
+              onChange={(e) => setOutcomeReason(e.target.value)}
               rows={3}
-              placeholder="z. B. Kriterien, Wettbewerber, Lessons Learned …"
+              placeholder="z. B. Kriterien, Wettbewerber, Lessons Learned …"
             />
           </div>
-          <div className="space-y-2">
-            <Label>War die Referenz hilfreich?</Label>
-            <Select
-              value={referenceHelpful}
-              onValueChange={(v) => setReferenceHelpful(v as ReferenceHelpfulChoice)}
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="Optional …" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="__none__">Keine Angabe</SelectItem>
-                <SelectItem value="yes">Ja</SelectItem>
-                <SelectItem value="no">Nein</SelectItem>
-                <SelectItem value="na">Nicht zutreffend</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
+          {showDecisiveReference ? (
+            <div className="space-y-2">
+              <Label>Welcher Beweis war entscheidend? (optional)</Label>
+              <Select value={decisiveReferenceId} onValueChange={setDecisiveReferenceId}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Referenz wählen …" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="__none__">Keine Angabe</SelectItem>
+                  {linkedReferences.map((ref) => (
+                    <SelectItem key={ref.id} value={ref.id}>
+                      {ref.title}
+                      {ref.company_name ? ` · ${ref.company_name}` : ""}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          ) : null}
         </div>
-        <DialogFooter>
+        <DialogFooter className="gap-2 sm:gap-0">
           <Button variant="outline" onClick={() => setOpen(false)} disabled={saving}>
             Abbrechen
           </Button>
@@ -137,4 +171,3 @@ export function OutcomeDialog({ dealId }: { dealId: string }) {
     </Dialog>
   )
 }
-

--- a/app/dashboard/deals/deal-schema-guardrail.test.ts
+++ b/app/dashboard/deals/deal-schema-guardrail.test.ts
@@ -47,6 +47,8 @@ describe('deal schema guardrail (F2)', () => {
       ...DEAL_TABLE_ALLOWED_COLUMNS,
       ...DEAL_ROW_DERIVED_FIELDS,
       'requirements_text',
+      'outcome_reason',
+      'decisive_reference_id',
       'linked_refs',
       'company_logo_url',
     ])

--- a/app/dashboard/deals/rfp-sidebar-panel.tsx
+++ b/app/dashboard/deals/rfp-sidebar-panel.tsx
@@ -41,7 +41,13 @@ export function RfpSidebarPanel({
 
         <LinkReferenceDialog dealId={deal.id} availableRefs={availableRefs} />
 
-        <OutcomeDialog dealId={deal.id} />
+        <OutcomeDialog
+          dealId={deal.id}
+          dealStatus={deal.status}
+          linkedReferences={deal.references}
+          initialOutcomeReason={deal.outcome_reason ?? null}
+          initialDecisiveReferenceId={deal.decisive_reference_id ?? null}
+        />
 
         <Button asChild size="sm" className="w-full">
           <Link href={`${ROUTES.deals.requestNew}?dealId=${encodeURIComponent(deal.id)}`}>

--- a/app/dashboard/deals/types.ts
+++ b/app/dashboard/deals/types.ts
@@ -24,6 +24,8 @@ export type DealRow = {
   sales_manager_name: string | null
   status: DealStatus
   expiry_date: string | null
+  outcome_reason?: string | null
+  decisive_reference_id?: string | null
   created_at: string
   updated_at: string | null
   /** Verknüpfte Referenzen inkl. Logo für Listen-Anzeige */
@@ -51,6 +53,8 @@ export const DEAL_TABLE_ALLOWED_COLUMNS = [
   'sales_manager_id',
   'is_public',
   'incumbent_provider',
+  'outcome_reason',
+  'decisive_reference_id',
   'created_at',
   'updated_at',
   'created_by',

--- a/lib/accounts/account-proof-memory-filters.ts
+++ b/lib/accounts/account-proof-memory-filters.ts
@@ -1,0 +1,23 @@
+import { RPC_SALES_VISIBLE_REFERENCE_STATUSES } from '@/lib/roles/reference-visibility-scope'
+
+/** Spiegelt die Sales-RLS-Einschränkung für Service-Role-Ladevorgänge (kein Draft/NDA/Confidential). */
+export function applySalesVisibleReferenceFilters<
+  Q extends {
+    in: (column: string, values: readonly string[]) => Q
+    eq: (column: string, value: boolean) => Q
+  },
+>(query: Q): Q {
+  return query
+    .in('status', [...RPC_SALES_VISIBLE_REFERENCE_STATUSES])
+    .eq('is_nda_deal', false)
+    .eq('approval_scope_confidential_sales', false)
+}
+
+/** Deals für Account-Gedächtnis: nur Org + Company, nie account_manager_id. */
+export function accountProofMemoryDealFilter<Q extends { eq: (column: string, value: string) => Q }>(
+  query: Q,
+  organizationId: string,
+  companyId: string
+): Q {
+  return query.eq('organization_id', organizationId).eq('company_id', companyId)
+}

--- a/lib/accounts/account-proof-memory-ownership.test.ts
+++ b/lib/accounts/account-proof-memory-ownership.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildAccountProofMemory } from '@/lib/accounts/account-proof-memory-pure'
+
+describe('account proof memory ownership (pure)', () => {
+  it('aggregiert unabhängig vom account_manager_id', () => {
+    const visible = new Set(['ref-1'])
+    const titles = new Map([['ref-1', 'Approved Case']])
+    const dealTitles = new Map([['deal-1', 'PharmaX']])
+
+    const withManager = buildAccountProofMemory({
+      deals: [
+        {
+          id: 'deal-1',
+          title: 'PharmaX',
+          status: 'won',
+          decisive_reference_id: 'ref-1',
+          updated_at: '2026-06-01T12:00:00Z',
+          account_manager_id: 'rep-a',
+        },
+      ],
+      dealReferences: [{ deal_id: 'deal-1', reference_id: 'ref-1' }],
+      events: [],
+      visibleRefIds: visible,
+      refTitleById: titles,
+      dealTitleById: dealTitles,
+    })
+
+    const withoutManager = buildAccountProofMemory({
+      deals: [
+        {
+          id: 'deal-1',
+          title: 'PharmaX',
+          status: 'won',
+          decisive_reference_id: 'ref-1',
+          updated_at: '2026-06-01T12:00:00Z',
+          account_manager_id: null,
+        },
+      ],
+      dealReferences: [{ deal_id: 'deal-1', reference_id: 'ref-1' }],
+      events: [],
+      visibleRefIds: visible,
+      refTitleById: titles,
+      dealTitleById: dealTitles,
+    })
+
+    expect(withoutManager).toEqual(withManager)
+    expect(withoutManager.impact[0]?.decisiveCount).toBe(1)
+  })
+})

--- a/lib/accounts/account-proof-memory-pure.test.ts
+++ b/lib/accounts/account-proof-memory-pure.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildAccountProofMemory,
+  impactSortScore,
+} from '@/lib/accounts/account-proof-memory-pure'
+
+describe('buildAccountProofMemory', () => {
+  const visible = new Set(['ref-1', 'ref-2'])
+  const titles = new Map([
+    ['ref-1', 'Cloud Migration'],
+    ['ref-2', 'Security Case'],
+  ])
+  const dealTitles = new Map([
+    ['deal-a', 'PharmaX'],
+    ['deal-b', 'Beta AG'],
+  ])
+
+  it('liefert leere Struktur ohne Deals', () => {
+    expect(
+      buildAccountProofMemory({
+        deals: [],
+        dealReferences: [],
+        events: [],
+        visibleRefIds: visible,
+        refTitleById: titles,
+        dealTitleById: dealTitles,
+      })
+    ).toEqual({ impact: [], history: [], lastWonWithProof: null })
+  })
+
+  it('aggregiert Deals, Siege, Views und entscheidende Referenz', () => {
+    const result = buildAccountProofMemory({
+      deals: [
+        {
+          id: 'deal-a',
+          title: 'PharmaX',
+          status: 'won',
+          decisive_reference_id: 'ref-1',
+          updated_at: '2026-05-12T10:00:00Z',
+        },
+        {
+          id: 'deal-b',
+          title: 'Beta AG',
+          status: 'lost',
+          decisive_reference_id: null,
+          updated_at: '2026-04-02T10:00:00Z',
+        },
+      ],
+      dealReferences: [
+        { deal_id: 'deal-a', reference_id: 'ref-1' },
+        { deal_id: 'deal-b', reference_id: 'ref-1' },
+        { deal_id: 'deal-b', reference_id: 'ref-2' },
+      ],
+      events: [
+        {
+          id: 'ev-1',
+          created_at: '2026-05-10T08:00:00Z',
+          event_type: 'share_link_viewed',
+          deal_id: 'deal-a',
+          reference_id: 'ref-1',
+          payload: {},
+        },
+        {
+          id: 'ev-2',
+          created_at: '2026-05-11T08:00:00Z',
+          event_type: 'share_link_viewed',
+          deal_id: 'deal-a',
+          reference_id: 'ref-1',
+          payload: {},
+        },
+        {
+          id: 'ev-3',
+          created_at: '2026-05-12T09:00:00Z',
+          event_type: 'deal_won',
+          deal_id: 'deal-a',
+          reference_id: 'ref-1',
+          payload: { decisive_reference_id: 'ref-1', outcome_reason: 'ISO-Nachweis' },
+        },
+      ],
+      visibleRefIds: visible,
+      refTitleById: titles,
+      dealTitleById: dealTitles,
+    })
+
+    expect(result.impact[0]).toMatchObject({
+      referenceId: 'ref-1',
+      dealCount: 2,
+      wonDealCount: 1,
+      viewCount: 2,
+      decisiveCount: 1,
+    })
+    expect(result.history[0]?.label).toContain('gewonnen')
+    expect(result.lastWonWithProof).toMatchObject({
+      dealTitle: 'PharmaX',
+      referenceTitle: 'Cloud Migration',
+    })
+  })
+
+  it('blendet nicht sichtbare Referenzen aus', () => {
+    const result = buildAccountProofMemory({
+      deals: [
+        {
+          id: 'deal-a',
+          title: 'PharmaX',
+          status: 'won',
+          decisive_reference_id: 'ref-hidden',
+          updated_at: '2026-05-12T10:00:00Z',
+        },
+      ],
+      dealReferences: [{ deal_id: 'deal-a', reference_id: 'ref-hidden' }],
+      events: [],
+      visibleRefIds: new Set(['ref-1']),
+      refTitleById: titles,
+      dealTitleById: dealTitles,
+    })
+
+    expect(result.impact).toHaveLength(0)
+    expect(result.lastWonWithProof).toBeNull()
+  })
+})
+
+describe('impactSortScore', () => {
+  it('priorisiert entscheidende Referenzen', () => {
+    const high = impactSortScore({
+      referenceId: 'a',
+      title: 'A',
+      dealCount: 1,
+      wonDealCount: 0,
+      viewCount: 0,
+      decisiveCount: 1,
+    })
+    const low = impactSortScore({
+      referenceId: 'b',
+      title: 'B',
+      dealCount: 5,
+      wonDealCount: 2,
+      viewCount: 10,
+      decisiveCount: 0,
+    })
+    expect(high).toBeGreaterThan(low)
+  })
+})

--- a/lib/accounts/account-proof-memory-pure.ts
+++ b/lib/accounts/account-proof-memory-pure.ts
@@ -34,6 +34,7 @@ type DealRow = {
   status: string
   decisive_reference_id: string | null
   updated_at: string | null
+  account_manager_id?: string | null
 }
 
 type DealReferenceRow = {

--- a/lib/accounts/account-proof-memory-pure.ts
+++ b/lib/accounts/account-proof-memory-pure.ts
@@ -1,0 +1,244 @@
+export type AccountProofImpactRow = {
+  referenceId: string
+  title: string
+  dealCount: number
+  wonDealCount: number
+  viewCount: number
+  decisiveCount: number
+}
+
+export type AccountProofHistoryItem = {
+  id: string
+  at: string
+  label: string
+  detail: string | null
+  referenceId: string | null
+  dealId: string | null
+}
+
+export type AccountProofLastWon = {
+  dealTitle: string
+  referenceTitle: string
+  at: string
+}
+
+export type AccountProofMemory = {
+  impact: AccountProofImpactRow[]
+  history: AccountProofHistoryItem[]
+  lastWonWithProof: AccountProofLastWon | null
+}
+
+type DealRow = {
+  id: string
+  title: string
+  status: string
+  decisive_reference_id: string | null
+  updated_at: string | null
+}
+
+type DealReferenceRow = {
+  deal_id: string
+  reference_id: string
+}
+
+type EvidenceEventRow = {
+  id: string
+  created_at: string
+  event_type: string
+  deal_id: string | null
+  reference_id: string | null
+  payload: unknown
+}
+
+export function impactSortScore(row: AccountProofImpactRow): number {
+  return row.decisiveCount * 1000 + row.wonDealCount * 100 + row.viewCount * 10 + row.dealCount
+}
+
+export function buildAccountProofMemory(input: {
+  deals: DealRow[]
+  dealReferences: DealReferenceRow[]
+  events: EvidenceEventRow[]
+  visibleRefIds: ReadonlySet<string>
+  refTitleById: ReadonlyMap<string, string>
+  dealTitleById: ReadonlyMap<string, string>
+}): AccountProofMemory {
+  const { deals, dealReferences, events, visibleRefIds, refTitleById, dealTitleById } = input
+
+  if (!deals.length) {
+    return { impact: [], history: [], lastWonWithProof: null }
+  }
+
+  const dealIds = new Set(deals.map((d) => d.id))
+  const impactMap = new Map<string, AccountProofImpactRow>()
+
+  const ensureImpact = (referenceId: string): AccountProofImpactRow | null => {
+    if (!visibleRefIds.has(referenceId)) return null
+    let row = impactMap.get(referenceId)
+    if (!row) {
+      row = {
+        referenceId,
+        title: refTitleById.get(referenceId) ?? '—',
+        dealCount: 0,
+        wonDealCount: 0,
+        viewCount: 0,
+        decisiveCount: 0,
+      }
+      impactMap.set(referenceId, row)
+    }
+    return row
+  }
+
+  const dealsPerRef = new Map<string, Set<string>>()
+  const wonDealsPerRef = new Map<string, Set<string>>()
+
+  for (const link of dealReferences) {
+    if (!dealIds.has(link.deal_id) || !visibleRefIds.has(link.reference_id)) continue
+    if (!dealsPerRef.has(link.reference_id)) dealsPerRef.set(link.reference_id, new Set())
+    dealsPerRef.get(link.reference_id)!.add(link.deal_id)
+  }
+
+  for (const deal of deals) {
+    if (deal.status !== 'won') continue
+    for (const [refId, dealSet] of dealsPerRef) {
+      if (dealSet.has(deal.id)) {
+        if (!wonDealsPerRef.has(refId)) wonDealsPerRef.set(refId, new Set())
+        wonDealsPerRef.get(refId)!.add(deal.id)
+      }
+    }
+    if (deal.decisive_reference_id && visibleRefIds.has(deal.decisive_reference_id)) {
+      const row = ensureImpact(deal.decisive_reference_id)
+      if (row) row.decisiveCount += 1
+    }
+  }
+
+  for (const [refId, dealSet] of dealsPerRef) {
+    const row = ensureImpact(refId)
+    if (!row) continue
+    row.dealCount = dealSet.size
+    row.wonDealCount = wonDealsPerRef.get(refId)?.size ?? 0
+  }
+
+  const history: AccountProofHistoryItem[] = []
+  let lastWonWithProof: AccountProofLastWon | null = null
+
+  for (const event of events) {
+    const eventType = String(event.event_type ?? '')
+    const refId = event.reference_id
+    const dealId = event.deal_id
+    const dealTitle = dealId ? (dealTitleById.get(dealId) ?? 'Deal') : null
+
+    if (eventType === 'share_link_viewed') {
+      if (!refId || !visibleRefIds.has(refId)) continue
+      const row = ensureImpact(refId)
+      if (row) row.viewCount += 1
+      history.push({
+        id: event.id,
+        at: event.created_at,
+        label: `„${refTitleById.get(refId) ?? 'Referenz'}" geöffnet`,
+        detail: dealTitle ? `Kontext: ${dealTitle}` : null,
+        referenceId: refId,
+        dealId,
+      })
+      continue
+    }
+
+    if (dealId && !dealIds.has(dealId)) continue
+
+    if (eventType === 'reference_shared') {
+      if (refId && !visibleRefIds.has(refId)) continue
+      history.push({
+        id: event.id,
+        at: event.created_at,
+        label: refId
+          ? `„${refTitleById.get(refId) ?? 'Referenz'}" geteilt`
+          : 'Referenz geteilt',
+        detail: dealTitle ? `Deal: ${dealTitle}` : null,
+        referenceId: refId,
+        dealId,
+      })
+      continue
+    }
+
+    if (eventType === 'deal_won' || eventType === 'deal_lost') {
+      const payload =
+        event.payload && typeof event.payload === 'object' && !Array.isArray(event.payload)
+          ? (event.payload as Record<string, unknown>)
+          : {}
+      const decisiveId =
+        (typeof payload.decisive_reference_id === 'string' ? payload.decisive_reference_id : null) ??
+        refId
+      const outcomeReason =
+        typeof payload.outcome_reason === 'string' ? payload.outcome_reason.trim() : ''
+
+      if (decisiveId && !visibleRefIds.has(decisiveId)) {
+        history.push({
+          id: event.id,
+          at: event.created_at,
+          label:
+            eventType === 'deal_won'
+              ? `Deal „${dealTitle ?? '—'}" gewonnen`
+              : `Deal „${dealTitle ?? '—'}" verloren`,
+          detail: outcomeReason || null,
+          referenceId: null,
+          dealId,
+        })
+        continue
+      }
+
+      const refTitle = decisiveId ? refTitleById.get(decisiveId) : null
+      history.push({
+        id: event.id,
+        at: event.created_at,
+        label:
+          eventType === 'deal_won'
+            ? `Deal „${dealTitle ?? '—'}" gewonnen`
+            : `Deal „${dealTitle ?? '—'}" verloren`,
+        detail: refTitle
+          ? `Entscheidend: ${refTitle}${outcomeReason ? ` — ${outcomeReason}` : ''}`
+          : outcomeReason || null,
+        referenceId: decisiveId,
+        dealId,
+      })
+
+      if (eventType === 'deal_won' && decisiveId && refTitle) {
+        const candidate: AccountProofLastWon = {
+          dealTitle: dealTitle ?? '—',
+          referenceTitle: refTitle,
+          at: event.created_at,
+        }
+        if (!lastWonWithProof || candidate.at > lastWonWithProof.at) {
+          lastWonWithProof = candidate
+        }
+      }
+    }
+  }
+
+  for (const deal of deals) {
+    if (deal.status !== 'won' || !deal.decisive_reference_id) continue
+    if (!visibleRefIds.has(deal.decisive_reference_id)) continue
+    const refTitle = refTitleById.get(deal.decisive_reference_id)
+    if (!refTitle) continue
+    const at = deal.updated_at ?? ''
+    if (!at) continue
+    const candidate: AccountProofLastWon = {
+      dealTitle: deal.title,
+      referenceTitle: refTitle,
+      at,
+    }
+    if (!lastWonWithProof || candidate.at > lastWonWithProof.at) {
+      lastWonWithProof = candidate
+    }
+  }
+
+  const impact = Array.from(impactMap.values()).sort(
+    (a, b) => impactSortScore(b) - impactSortScore(a)
+  )
+
+  history.sort((a, b) => (a.at < b.at ? 1 : a.at > b.at ? -1 : 0))
+
+  return {
+    impact,
+    history: history.slice(0, 80),
+    lastWonWithProof,
+  }
+}

--- a/lib/accounts/account-proof-memory.ts
+++ b/lib/accounts/account-proof-memory.ts
@@ -4,11 +4,14 @@ import { unstable_cache } from 'next/cache'
 import type { SupabaseClient } from '@supabase/supabase-js'
 
 import {
+  accountProofMemoryDealFilter,
+  applySalesVisibleReferenceFilters,
+} from '@/lib/accounts/account-proof-memory-filters'
+import {
   buildAccountProofMemory,
   type AccountProofMemory,
 } from '@/lib/accounts/account-proof-memory-pure'
 import type { Database } from '@/lib/database.types'
-import { RPC_SALES_VISIBLE_REFERENCE_STATUSES } from '@/lib/roles/reference-visibility-scope'
 import { createServiceRoleSupabaseClient } from '@/lib/supabase/service-role'
 import { createServerSupabaseClient } from '@/lib/supabase/server'
 
@@ -30,11 +33,11 @@ async function computeAccountProofMemory(
 ): Promise<AccountProofMemory> {
   const { organizationId, companyId, salesVisibleOnly } = params
 
-  const { data: deals, error: dealsErr } = await supabase
-    .from('deals')
-    .select('id, title, status, decisive_reference_id, updated_at')
-    .eq('organization_id', organizationId)
-    .eq('company_id', companyId)
+  const { data: deals, error: dealsErr } = await accountProofMemoryDealFilter(
+    supabase.from('deals').select('id, title, status, decisive_reference_id, updated_at'),
+    organizationId,
+    companyId
+  )
 
   if (dealsErr || !deals?.length) {
     return { impact: [], history: [], lastWonWithProof: null }
@@ -76,7 +79,7 @@ async function computeAccountProofMemory(
     .is('deleted_at', null)
 
   if (salesVisibleOnly) {
-    refQuery = refQuery.in('status', [...RPC_SALES_VISIBLE_REFERENCE_STATUSES])
+    refQuery = applySalesVisibleReferenceFilters(refQuery)
   }
 
   const { data: refs } = await refQuery
@@ -110,13 +113,32 @@ async function computeAccountProofMemory(
   })
 }
 
+/** Direkt mit Session-Client (RLS) — für Tests und Sales-Sicht. */
+export async function loadAccountProofMemory(
+  supabase: DbClient,
+  params: {
+    organizationId: string
+    companyId: string
+    salesVisibleOnly: boolean
+  }
+): Promise<AccountProofMemory> {
+  return computeAccountProofMemory(supabase, params)
+}
+
 export async function getCachedAccountProofMemory(params: {
   organizationId: string
   companyId: string
   salesVisibleOnly: boolean
 }): Promise<AccountProofMemory> {
   const { organizationId, companyId, salesVisibleOnly } = params
-  const visibilityKey = salesVisibleOnly ? 'sales' : 'all'
+
+  // Sales-Sicht: Session-Client + RLS (kein Draft/NDA-Leak über Service-Role-Cache).
+  if (salesVisibleOnly) {
+    const client = await createServerSupabaseClient()
+    return loadAccountProofMemory(client, params)
+  }
+
+  const visibilityKey = 'all'
   const cacheKey = `account-proof-memory:${organizationId}:${companyId}:${visibilityKey}`
 
   const admin = createServiceRoleSupabaseClient()

--- a/lib/accounts/account-proof-memory.ts
+++ b/lib/accounts/account-proof-memory.ts
@@ -1,0 +1,133 @@
+import 'server-only'
+
+import { unstable_cache } from 'next/cache'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+import {
+  buildAccountProofMemory,
+  type AccountProofMemory,
+} from '@/lib/accounts/account-proof-memory-pure'
+import type { Database } from '@/lib/database.types'
+import { RPC_SALES_VISIBLE_REFERENCE_STATUSES } from '@/lib/roles/reference-visibility-scope'
+import { createServiceRoleSupabaseClient } from '@/lib/supabase/service-role'
+import { createServerSupabaseClient } from '@/lib/supabase/server'
+
+type DbClient = SupabaseClient<Database>
+
+export type { AccountProofMemory, AccountProofHistoryItem, AccountProofImpactRow } from '@/lib/accounts/account-proof-memory-pure'
+
+export function accountProofMemoryTag(companyId: string): string {
+  return `account-proof-memory:${companyId}`
+}
+
+async function computeAccountProofMemory(
+  supabase: DbClient,
+  params: {
+    organizationId: string
+    companyId: string
+    salesVisibleOnly: boolean
+  }
+): Promise<AccountProofMemory> {
+  const { organizationId, companyId, salesVisibleOnly } = params
+
+  const { data: deals, error: dealsErr } = await supabase
+    .from('deals')
+    .select('id, title, status, decisive_reference_id, updated_at')
+    .eq('organization_id', organizationId)
+    .eq('company_id', companyId)
+
+  if (dealsErr || !deals?.length) {
+    return { impact: [], history: [], lastWonWithProof: null }
+  }
+
+  const dealIds = deals.map((d) => d.id)
+  const dealTitleById = new Map(deals.map((d) => [d.id, d.title ?? '—']))
+
+  const { data: drRows } = await supabase
+    .from('deal_references')
+    .select('deal_id, reference_id')
+    .in('deal_id', dealIds)
+
+  const refIdSet = new Set<string>()
+  for (const row of drRows ?? []) {
+    if (row.reference_id) refIdSet.add(String(row.reference_id))
+  }
+  for (const deal of deals) {
+    if (deal.decisive_reference_id) refIdSet.add(String(deal.decisive_reference_id))
+  }
+
+  const refIds = Array.from(refIdSet)
+  if (!refIds.length) {
+    return buildAccountProofMemory({
+      deals,
+      dealReferences: drRows ?? [],
+      events: [],
+      visibleRefIds: new Set(),
+      refTitleById: new Map(),
+      dealTitleById,
+    })
+  }
+
+  let refQuery = supabase
+    .from('references')
+    .select('id, title, status')
+    .eq('organization_id', organizationId)
+    .in('id', refIds)
+    .is('deleted_at', null)
+
+  if (salesVisibleOnly) {
+    refQuery = refQuery.in('status', [...RPC_SALES_VISIBLE_REFERENCE_STATUSES])
+  }
+
+  const { data: refs } = await refQuery
+  const visibleRefIds = new Set((refs ?? []).map((r) => r.id))
+  const refTitleById = new Map((refs ?? []).map((r) => [r.id, r.title ?? '—']))
+
+  const [{ data: dealEvents }, { data: viewEvents }] = await Promise.all([
+    supabase
+      .from('evidence_events')
+      .select('id, created_at, event_type, deal_id, reference_id, payload')
+      .eq('organization_id', organizationId)
+      .in('deal_id', dealIds)
+      .in('event_type', ['reference_shared', 'deal_won', 'deal_lost', 'deal_withdrawn']),
+    supabase
+      .from('evidence_events')
+      .select('id, created_at, event_type, deal_id, reference_id, payload')
+      .eq('organization_id', organizationId)
+      .eq('event_type', 'share_link_viewed')
+      .in('reference_id', refIds),
+  ])
+
+  const events = [...(dealEvents ?? []), ...(viewEvents ?? [])]
+
+  return buildAccountProofMemory({
+    deals,
+    dealReferences: drRows ?? [],
+    events,
+    visibleRefIds,
+    refTitleById,
+    dealTitleById,
+  })
+}
+
+export async function getCachedAccountProofMemory(params: {
+  organizationId: string
+  companyId: string
+  salesVisibleOnly: boolean
+}): Promise<AccountProofMemory> {
+  const { organizationId, companyId, salesVisibleOnly } = params
+  const visibilityKey = salesVisibleOnly ? 'sales' : 'all'
+  const cacheKey = `account-proof-memory:${organizationId}:${companyId}:${visibilityKey}`
+
+  const admin = createServiceRoleSupabaseClient()
+  if (!admin) {
+    const client = await createServerSupabaseClient()
+    return computeAccountProofMemory(client, params)
+  }
+
+  return unstable_cache(
+    () => computeAccountProofMemory(admin, params),
+    [cacheKey],
+    { tags: [accountProofMemoryTag(companyId)], revalidate: 300 }
+  )()
+}

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -876,12 +876,14 @@ export type Database = {
           crm_opportunity_id: string | null
           crm_source: string | null
           crm_synced_at: string | null
+          decisive_reference_id: string | null
           expiry_date: string | null
           id: string
           incumbent_provider: string | null
           industry: string | null
           is_public: boolean
           organization_id: string
+          outcome_reason: string | null
           requirements_text: string | null
           sales_manager_id: string | null
           salesforce_opportunity_id: string | null
@@ -897,12 +899,14 @@ export type Database = {
           crm_opportunity_id?: string | null
           crm_source?: string | null
           crm_synced_at?: string | null
+          decisive_reference_id?: string | null
           expiry_date?: string | null
           id?: string
           incumbent_provider?: string | null
           industry?: string | null
           is_public?: boolean
           organization_id: string
+          outcome_reason?: string | null
           requirements_text?: string | null
           sales_manager_id?: string | null
           salesforce_opportunity_id?: string | null
@@ -918,12 +922,14 @@ export type Database = {
           crm_opportunity_id?: string | null
           crm_source?: string | null
           crm_synced_at?: string | null
+          decisive_reference_id?: string | null
           expiry_date?: string | null
           id?: string
           incumbent_provider?: string | null
           industry?: string | null
           is_public?: boolean
           organization_id?: string
+          outcome_reason?: string | null
           requirements_text?: string | null
           sales_manager_id?: string | null
           salesforce_opportunity_id?: string | null
@@ -945,6 +951,13 @@ export type Database = {
             columns: ["organization_id"]
             isOneToOne: false
             referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "deals_decisive_reference_id_fkey"
+            columns: ["decisive_reference_id"]
+            isOneToOne: false
+            referencedRelation: "references"
             referencedColumns: ["id"]
           },
         ]

--- a/lib/deals/outcome-capture.test.ts
+++ b/lib/deals/outcome-capture.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { validateDecisiveReferenceId } from './outcome-capture'
+
+describe('validateDecisiveReferenceId', () => {
+  it('erlaubt leere Angabe', () => {
+    expect(validateDecisiveReferenceId(null, ['a'])).toEqual({ ok: true })
+    expect(validateDecisiveReferenceId(undefined, [])).toEqual({ ok: true })
+  })
+
+  it('akzeptiert verknüpfte Referenz', () => {
+    expect(validateDecisiveReferenceId('ref-1', ['ref-1', 'ref-2'])).toEqual({ ok: true })
+  })
+
+  it('lehnt nicht verknüpfte Referenz ab', () => {
+    const result = validateDecisiveReferenceId('ref-3', ['ref-1'])
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toMatch(/verknüpft/)
+    }
+  })
+})

--- a/lib/deals/outcome-capture.ts
+++ b/lib/deals/outcome-capture.ts
@@ -1,0 +1,11 @@
+export function validateDecisiveReferenceId(
+  decisiveReferenceId: string | null | undefined,
+  linkedReferenceIds: readonly string[]
+): { ok: true } | { ok: false; error: string } {
+  if (!decisiveReferenceId) return { ok: true }
+  if (linkedReferenceIds.includes(decisiveReferenceId)) return { ok: true }
+  return {
+    ok: false,
+    error: 'Die entscheidende Referenz muss mit dem Deal verknüpft sein.',
+  }
+}

--- a/supabase/migrations/20260701100000_deals_outcome_capture.sql
+++ b/supabase/migrations/20260701100000_deals_outcome_capture.sql
@@ -1,0 +1,15 @@
+-- Account-Gedächtnis T1: Outcome-Capture beim Deal-Abschluss
+
+ALTER TABLE public.deals
+  ADD COLUMN IF NOT EXISTS outcome_reason text,
+  ADD COLUMN IF NOT EXISTS decisive_reference_id uuid
+    REFERENCES public.references(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_deals_decisive_reference_id
+  ON public.deals(decisive_reference_id)
+  WHERE decisive_reference_id IS NOT NULL;
+
+COMMENT ON COLUMN public.deals.outcome_reason IS
+  'Freitext beim Abschluss (gewonnen/verloren), optional.';
+COMMENT ON COLUMN public.deals.decisive_reference_id IS
+  'Verknüpfte Referenz, die zum Abschluss entscheidend war (muss in deal_references liegen).';

--- a/tests/integration/account-proof-memory.integration.test.ts
+++ b/tests/integration/account-proof-memory.integration.test.ts
@@ -1,0 +1,162 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { getCachedAccountProofMemory, loadAccountProofMemory } from '@/lib/accounts/account-proof-memory'
+import {
+  cleanupIntegrationOrgFixtures,
+  seedIntegrationOrgFixtures,
+  type IntegrationOrgFixtures,
+} from '@/lib/test/integration-fixtures'
+import {
+  createIntegrationServiceClient,
+  isIntegrationSupabaseAvailable,
+  signInIntegrationUser,
+} from '@/lib/test/integration-supabase'
+
+import { fetchAccountProofMemoryAction } from '@/app/dashboard/accounts/account-proof-memory-actions'
+
+const describeIntegration = isIntegrationSupabaseAvailable() ? describe : describe.skip
+
+describeIntegration('account proof memory ownership & visibility', () => {
+  let fixtures: IntegrationOrgFixtures
+  let admin: ReturnType<typeof createIntegrationServiceClient>
+  let dealId: string
+  let approvedRefId: string
+  let draftRefId: string
+
+  beforeAll(async () => {
+    admin = createIntegrationServiceClient()
+    fixtures = await seedIntegrationOrgFixtures(admin)
+
+    approvedRefId = fixtures.references.approvedId
+    draftRefId = fixtures.references.draftByAdminId
+
+    const { data: deal, error: dealError } = await admin
+      .from('deals')
+      .insert({
+        organization_id: fixtures.orgAId,
+        company_id: fixtures.companyAId,
+        title: `Memory Deal ${fixtures.runId}`,
+        status: 'won',
+        account_manager_id: fixtures.salesRep.id,
+        decisive_reference_id: approvedRefId,
+        outcome_reason: 'Referenz überzeugte Economic Buyer',
+      })
+      .select('id')
+      .single()
+
+    if (dealError || !deal?.id) {
+      throw new Error(`Test-Deal konnte nicht angelegt werden: ${dealError?.message ?? 'unknown'}`)
+    }
+    dealId = deal.id
+
+    await admin.from('deal_references').insert([
+      { deal_id: dealId, reference_id: approvedRefId },
+      { deal_id: dealId, reference_id: draftRefId },
+    ])
+
+    await admin.from('evidence_events').insert({
+      organization_id: fixtures.orgAId,
+      deal_id: dealId,
+      reference_id: approvedRefId,
+      event_type: 'deal_won',
+      payload: {
+        outcome_reason: 'Referenz überzeugte Economic Buyer',
+        decisive_reference_id: approvedRefId,
+      },
+      created_by: fixtures.admin.id,
+    })
+  }, 120_000)
+
+  afterAll(async () => {
+    if (dealId) {
+      await admin.from('evidence_events').delete().eq('deal_id', dealId)
+      await admin.from('deal_references').delete().eq('deal_id', dealId)
+      await admin.from('deals').delete().eq('id', dealId)
+    }
+    await cleanupIntegrationOrgFixtures(admin, fixtures)
+  }, 120_000)
+
+  it('behält Historie nach Rep-Wechsel (account_manager_id = NULL)', async () => {
+    const before = await getCachedAccountProofMemory({
+      organizationId: fixtures.orgAId,
+      companyId: fixtures.companyAId,
+      salesVisibleOnly: false,
+    })
+
+    expect(before.impact.some((row) => row.referenceId === approvedRefId)).toBe(true)
+    expect(before.impact.some((row) => row.referenceId === draftRefId)).toBe(true)
+
+    const { error: clearErr } = await admin
+      .from('deals')
+      .update({ account_manager_id: null })
+      .eq('id', dealId)
+    expect(clearErr).toBeNull()
+
+    const after = await getCachedAccountProofMemory({
+      organizationId: fixtures.orgAId,
+      companyId: fixtures.companyAId,
+      salesVisibleOnly: false,
+    })
+
+    expect(after.impact).toEqual(before.impact)
+    expect(after.history.length).toBeGreaterThanOrEqual(before.history.length)
+  })
+
+  it('sales_rep sieht keine Draft-Referenz im Account-Gedächtnis', async () => {
+    const client = await signInIntegrationUser(fixtures.salesRep.email, fixtures.salesRep.password)
+
+    const { data: visibleDraft } = await client
+      .from('references')
+      .select('id')
+      .eq('id', draftRefId)
+      .maybeSingle()
+    expect(visibleDraft).toBeNull()
+
+    const memory = await loadAccountProofMemory(client, {
+      organizationId: fixtures.orgAId,
+      companyId: fixtures.companyAId,
+      salesVisibleOnly: true,
+    })
+
+    expect(memory.impact.some((row) => row.referenceId === approvedRefId)).toBe(true)
+    expect(memory.impact.some((row) => row.referenceId === draftRefId)).toBe(false)
+    expect(memory.impact.find((row) => row.referenceId === approvedRefId)?.decisiveCount).toBe(1)
+  })
+
+  it('fremde Org erhält keinen Zugriff auf Account-Gedächtnis', async () => {
+    const otherEmail = `e3-memory-${fixtures.runId}@refstack-integration.test`
+    const password = `Test-${fixtures.runId}!Aa1`
+
+    const { data: otherUser, error: userError } = await admin.auth.admin.createUser({
+      email: otherEmail,
+      password,
+      email_confirm: true,
+    })
+    if (userError || !otherUser.user?.id) {
+      throw new Error(`Test-User Org B konnte nicht angelegt werden: ${userError?.message}`)
+    }
+
+    const { error: profileError } = await admin.from('profiles').upsert({
+      id: otherUser.user.id,
+      full_name: 'Org B Memory User',
+      organization_id: fixtures.orgBId,
+      system_role: 'admin',
+      function_role: 'sales_leader',
+      capabilities: {},
+    })
+    if (profileError) {
+      throw new Error(`Profil Org B konnte nicht angelegt werden: ${profileError.message}`)
+    }
+
+    try {
+      await signInIntegrationUser(otherEmail, password)
+      const result = await fetchAccountProofMemoryAction(fixtures.companyAId)
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error).toMatch(/nicht gefunden|Berechtigung/i)
+      }
+    } finally {
+      await admin.auth.admin.deleteUser(otherUser.user.id)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- **T1:** `deals.outcome_reason` + `deals.decisive_reference_id` mit optionalem Ausgang-Dialog beim Deal-Abschluss
- **T2:** Account-Gedächtnis im Referenzen-Tab — „Was hier funktioniert hat“ + „Beweis-Historie“ aus bestehenden `deal_references` / `evidence_events`
- **T3:** Org-/Account-Scope (nicht `account_manager_id`), Sales-RLS für Referenzen, Integrationstests für Rep-Wechsel und Fremd-Org

## Test plan
- [x] Migration `20260701100000_deals_outcome_capture.sql` angewendet
- [x] `npm run typecheck` + `npm test` + `npm run build` lokal grün
- [ ] Deal auf gewonnen setzen mit entscheidender Referenz → erscheint in „Was hier funktioniert hat“
- [ ] Account Referenzen-Tab: Historie nach Share/Outcome sichtbar


Made with [Cursor](https://cursor.com)