### PR TITLE
refactor(accounts): Typed-Supabase Cast-Abbau Slice 1

### DIFF
--- a/app/dashboard/accounts/[id]/page.tsx
+++ b/app/dashboard/accounts/[id]/page.tsx
@@ -47,7 +47,7 @@ export default async function AccountDetailPage({
       .select('name')
       .eq('id', orgId)
       .maybeSingle()
-    organizationName = (orgRow as { name?: string } | null)?.name?.trim() || null
+    organizationName = orgRow?.name?.trim() || null
   }
 
   const { data: company } = await supabase
@@ -106,30 +106,29 @@ export default async function AccountDetailPage({
 
   const marketSignals = {
     championMoves: (executiveEventsResult.data ?? []).map((row) => {
-      const ek = String((row as { event_kind?: string }).event_kind ?? 'role_change')
+      const ek = row.event_kind ?? 'role_change'
       return {
-        id: String(row.id),
-        personName: String(row.person_name ?? ''),
-        personTitleBefore: (row.person_title_before as string | null) ?? null,
-        personTitleAfter: (row.person_title_after as string | null) ?? null,
-        changeSummary: String(row.change_summary ?? ''),
-        detectedAt: String(row.detected_at ?? ''),
+        id: row.id,
+        personName: row.person_name ?? '',
+        personTitleBefore: row.person_title_before ?? null,
+        personTitleAfter: row.person_title_after ?? null,
+        changeSummary: row.change_summary ?? '',
+        detectedAt: row.detected_at ?? '',
         eventKind:
           ek === 'news_mention' ? ('news_mention' as const) : ('role_change' as const),
-        sourceUrl:
-          ((row as { source_url?: string | null }).source_url as string | null) ?? null,
+        sourceUrl: row.source_url ?? null,
       }
     }),
     accountNews: (accountNewsResult.data ?? []).map((row) => {
-      const seg = String(row.segment ?? 'customer')
+      const seg = row.segment ?? 'customer'
       const segment: 'customer' | 'prospect' =
         seg === 'prospect' ? 'prospect' : 'customer'
       return {
-        id: String(row.id),
-        body: String(row.body ?? ''),
-        sourceLabel: (row.source_label as string | null) ?? null,
-        sourceUrl: (row.source_url as string | null) ?? null,
-        publishedOn: String(row.published_on ?? ''),
+        id: row.id,
+        body: row.body ?? '',
+        sourceLabel: row.source_label ?? null,
+        sourceUrl: row.source_url ?? null,
+        publishedOn: row.published_on ?? '',
         segment,
       }
     }),
@@ -141,10 +140,7 @@ export default async function AccountDetailPage({
         <AccountDetailClient
           company={{
             ...company,
-            entity_kind:
-              (company as { entity_kind?: string }).entity_kind === 'partner'
-                ? 'partner'
-                : 'account',
+            entity_kind: company.entity_kind === 'partner' ? 'partner' : 'account',
           }}
           organizationName={organizationName}
           strategy={strategy}

--- a/app/dashboard/accounts/account-crud-impl.ts
+++ b/app/dashboard/accounts/account-crud-impl.ts
@@ -29,7 +29,7 @@ export async function updateCompanyAccountStatusImpl(
     .update({
       account_status,
       account_status_source: account_status ? 'manual' : 'crm',
-    } as { account_status: string | null; account_status_source: string | null })
+    })
     .eq('id', companyId)
   if (error) return { success: false, error: error.message }
   revalidatePath(ROUTES.accounts)
@@ -411,7 +411,7 @@ export async function updateCompanyImpl(payload: {
   }
 
   const nextWebsite = payload.website_url?.trim() || null
-  const prevWebsite = (row as { website_url?: string | null }).website_url ?? null
+  const prevWebsite = row.website_url ?? null
 
   const { error } = await supabase
     .from('companies')
@@ -471,9 +471,7 @@ export async function deleteCompanyWithDataImpl(
     .eq('id', companyId)
     .single()
   if (companyErr || !company) return { success: false, error: 'Account nicht gefunden.' }
-  if (
-    (company as { organization_id: string }).organization_id !== profile.organization_id
-  ) {
+  if (company.organization_id !== profile.organization_id) {
     return { success: false, error: 'Keine Berechtigung.' }
   }
 

--- a/app/dashboard/accounts/contacts-impl.ts
+++ b/app/dashboard/accounts/contacts-impl.ts
@@ -82,9 +82,7 @@ export async function setCompanyInternalReferenceApprovalContactImpl(
     .eq('id', companyId)
     .single()
   if (cErr || !company) return { success: false, error: 'Account nicht gefunden.' }
-  if (
-    (company as { organization_id: string }).organization_id !== profile.organization_id
-  ) {
+  if (company.organization_id !== profile.organization_id) {
     return { success: false, error: 'Keine Berechtigung.' }
   }
 
@@ -95,7 +93,7 @@ export async function setCompanyInternalReferenceApprovalContactImpl(
       .eq('id', contactPersonId)
       .single()
     if (cpErr || !cp) return { success: false, error: 'Kontakt nicht gefunden.' }
-    if ((cp as { company_id: string }).company_id !== companyId) {
+    if (cp.company_id !== companyId) {
       return { success: false, error: 'Kontakt gehört nicht zu diesem Account.' }
     }
   }
@@ -146,9 +144,7 @@ export async function createContactPersonImpl(
     supabase.from('profiles').select('organization_id').eq('id', user.id).single(),
   ])
   const organization_id =
-    (company as { organization_id?: string | null } | null)?.organization_id ??
-    (profile as { organization_id?: string | null } | null)?.organization_id ??
-    null
+    company?.organization_id ?? profile?.organization_id ?? null
 
   const insertRow: Record<string, unknown> = {
     company_id: companyId,

--- a/docs/tech-debt-offen-backlog.md
+++ b/docs/tech-debt-offen-backlog.md
@@ -24,7 +24,7 @@
 | **0** | Inventar-Hygiene | P0/P2/Mapping-Zeilen auf Ist-Stand bringen (viele ✅ fehlen in den Tabellen); Header-Datum | XS | Verhindert Doppelarbeit und falsche Prioritäten | [`tech-debt-inventar.md`](./tech-debt-inventar.md) — **✅ 2026-08-06** |
 | **1** | E4 Service-Role-Audit | Alle `service-role`-Nutzungen rechtfertigen + fehlende Org/Token-Grenzen schließen | M | Cross-Tenant-Risiko; unabhängig von Naming; vor Pilot | [`arbeitspaket-service-role-audit-e4.md`](./arbeitspaket-service-role-audit-e4.md) — **Audit + Hotspot-Härtung ✅**; Rest Boy-Scout Kommentare |
 | **2** | E7 Schema-Sync / Drift-Gate | Remote vs. Repo-Migrationen; `looseSelect`-Löcher; CI-Migrations-Gate festziehen | M | Schützt das schon vorhandene `database.types.ts`-Fundament | [`arbeitspaket-schema-sync-e7.md`](./arbeitspaket-schema-sync-e7.md) — **✅ T1–T4** (2026-08-06 verifiziert) |
-| **3** | Typed-Supabase Cast-Abbau | `as { … }`-Row-Casts schrumpfen; Clients/`from()` stärker an `Database` koppeln | L (scheibenweise) | Verhindert die Fehlerklasse der role-Spalten-Drift; hoher Hebel nach E7 | [`arbeitspaket-typed-supabase.md`](./arbeitspaket-typed-supabase.md) |
+| **3** | Typed-Supabase Cast-Abbau | `as { … }`-Row-Casts schrumpfen; Clients/`from()` stärker an `Database` koppeln | L (scheibenweise) | Verhindert die Fehlerklasse der role-Spalten-Drift; hoher Hebel nach E7 | [`arbeitspaket-typed-supabase.md`](./arbeitspaket-typed-supabase.md) — **Slice 1** Accounts server reads/writes in Arbeit |
 | **4** | **P1-6** Accounts Naming | App/Lib: `company*` → `account*` wo Domäne „Account“; **DB `companies` bleibt** | L (3–5 PRs) | Letzter klarer Inventar-Welle-5-Block; rein mechanisch → nach Security/Typen, bevor noch größere Renames | Inventar P1-6 — **✅** Slices 1–5; DB/`company_id`/Firmennamen bewusst offen |
 | **5** | God-File-Nacharbeit | Overview (~719), Share-Link (~420), MS-Feed (~429) weiter slicen **nur bei Feature-Touch** | M (ongoing) | Kein eigener Big-Bang; Effizienz = bei Feature-PRs mitnehmen | Inventar God-Files / E5 |
 | **6** | Result `{ ok }` → `{ success }` | ~27 Dateien / ~136 Matches in Libs/Cron | S–M Boy-Scout | Kein Massen-PR; bei jeder Lib-Berührung | Inventar Result-Konvention; Guide §3.1 |
@@ -77,5 +77,5 @@ Nicht ein PR. Reihenfolge minimiert Konflikte und hält Reviews lesbar:
 | P0 Quick Wins, P1-1…5/7–10, P2 Quick Wins, P3-1/2/4/5 | **erledigt** — nicht erneut anfassen |
 | P1-6 | **✅** App/Lib (Slices 1–5); DB `companies` bleibt |
 | E6 Logger heiße Pfade | **erledigt**; Rest Boy-Scout |
-| E4 / E7 / Typed-Supabase Vertiefung | **offen** → Queue #1–3 |
+| E4 / E7 / Typed-Supabase Vertiefung | E4/E7 ✅; Typed-Supabase → Queue #3 (Slice 1 Accounts) |
 | Welle 5 T3/T4 | T1/T2 Rollen weitgehend erledigt; T3 → Queue #8; T4 `workspace_state` vor Start erneut `grep`en (kann schon weg sein) |

--- a/lib/accounts/resolve-account-for-import.ts
+++ b/lib/accounts/resolve-account-for-import.ts
@@ -413,9 +413,7 @@ export async function resolveOrCreateAccountForImport(
   scheduleCompanyNewsroomDiscovery(
     supabase,
     inserted.id,
-    (inserted as { website_url?: string | null }).website_url ??
-      insertPayload.website_url ??
-      null,
+    inserted.website_url ?? insertPayload.website_url ?? null,
   )
 
   return {

--- a/lib/accounts/sync-computed-account-statuses.ts
+++ b/lib/accounts/sync-computed-account-statuses.ts
@@ -84,7 +84,7 @@ export async function syncComputedAccountStatuses(
             .update({
               account_status: 'at_risk',
               account_status_source: 'crm',
-            } as { account_status: string | null; account_status_source: string })
+            })
             .eq('id', company.id)
         }
       } else {
@@ -102,7 +102,7 @@ export async function syncComputedAccountStatuses(
         .update({
           account_status: computed,
           account_status_source: 'crm',
-        } as { account_status: string | null; account_status_source: string })
+        })
         .eq('id', company.id)
     }
   }


### PR DESCRIPTION
## Summary
- Entfernt redundante `as { … }`-Row-Casts auf typed Supabase-Results in Accounts (CRUD, Contacts, Sync-Status, Import-Resolve, Detail-Page).
- Kein Verhaltenswechsel — Clients liefern bereits `Database`-Rows; Casts waren Restmüll nach E7.
- Backlog Queue #3 auf Slice 1 markiert.

## Test plan
- [ ] `npm run typecheck` grün
- [ ] Account Detail laden (inkl. Market Signals)
- [ ] Account Status manuell setzen / Sync-Pfad unverändert
- [ ] Kontakt als Internal Approval Contact setzen
- [ ] Account-Import (Insert + Newsroom-Schedule)


Made with [Cursor](https://cursor.com)