### PR TITLE
refactor(references): typed Supabase cast abbau slice 5

### DIFF
--- a/docs/tech-debt-offen-backlog.md
+++ b/docs/tech-debt-offen-backlog.md
@@ -10,8 +10,8 @@
 
 | Status | Themen |
 |--------|--------|
-| **Erledigt** | Inventar-Hygiene (#0); E4 Hotspot-Audit (#1); E7 Schema-Sync (#2); **P1-6** Accounts Naming App/Lib (#4); Welle-5 Rollen (Invite/`AppRole`/Mapping); Typed-Supabase **Accounts** + **Deals** + References **Slice 1–4** (Dashboard/Sharing/Approvals/Cache/Complete/Requests) |
-| **In Arbeit** | Typed-Supabase Cast-Abbau (#3) — References-Rest + weitere Domänen |
+| **Erledigt** | Inventar-Hygiene (#0); E4 Hotspot-Audit (#1); E7 Schema-Sync (#2); **P1-6** Accounts Naming App/Lib (#4); Welle-5 Rollen (Invite/`AppRole`/Mapping); Typed-Supabase **Accounts** + **Deals** + References **Slice 1–5** (Dashboard/Sharing/Approvals/Cache/Complete/Requests/Follow-up/Notify/Form) |
+| **In Arbeit** | Typed-Supabase Cast-Abbau (#3) — weitere Domänen (Settings/Match/…) |
 | **Offen (Queue)** | #3 Rest · #5 God-Files (Boy-Scout) · #6 `{ ok }` → `{ success }` (Boy-Scout) · #7 DE/EN-Dateinamen (Boy-Scout) · #8 `references`/`evidence` Rename · #9 Invite-SQL-Kosmetik (optional) |
 | **Geparkt** | Pilot (H3/E1/G2); Massen-Renames; produktweite `evidence`↔`references`-Entscheidung |
 
@@ -26,7 +26,7 @@
 | **0** | Inventar-Hygiene | ✅ | — | — | — |
 | **1** | E4 Service-Role | ✅ Audit + Hotspots | Boy-Scout: Kommentar an neuen Service-Role-Callern | XS ongoing | bei Touch |
 | **2** | E7 Schema-Sync | ✅ T1–T4 | Types bei Migrationen regenerieren (`db:types`) | XS ongoing | bei Schema-Change |
-| **3** | Typed-Supabase Cast-Abbau | **🟡 aktiv** | References Follow-up/Notify/Form + andere Domänen; zuletzt **T4** CI-Gate | L | Slice 5: Follow-up / Notify / Form |
+| **3** | Typed-Supabase Cast-Abbau | **🟡 aktiv** | Nächste Domäne (Settings/Match/DealDesk/Shared); zuletzt **T4** CI-Gate | L | Settings oder Match nach Cast-Count |
 | **4** | P1-6 Accounts Naming | ✅ App/Lib | DB-Tabelle `companies` / `company_id` / Firmennamen-Helfer **bewusst offen** | — | nicht anfassen ohne Produktentscheid |
 | **5** | God-File-Nacharbeit | offen (Boy-Scout) | Overview / Share-Link / MS-Feed weiter slicen **nur bei Feature-Touch** | M ongoing | kein eigener Big-Bang-PR |
 | **6** | `{ ok }` → `{ success }` | offen (Boy-Scout) | ~130 Matches in Libs/Cron | S–M | bei Lib-Berührung mitziehen |
@@ -46,15 +46,15 @@
 |--------|-------|------------------------|
 | Accounts | ✅ Slices 1–4 | wenig: CRM-JSON, External-Contacts-Fallback, Error-Shapes |
 | Deals | ✅ Slices 1–2 | wenig: Eligibility/JSON-API-Responses (bewusst) |
-| References | 🟡 Slice 1–4 ✅ | Follow-up / Notify / Form |
+| References | ✅ Slice 1–5 | Rest-Hotspots vereinzelt (Dashboard-Fallback, trash RPC, Quote/JSON-APIs) |
 | Andere | offen | Settings, Match, DealDesk, Command-Center, Notifications, … |
 | **T4 CI** | offen | `typecheck` in CI **scharf**, wenn Domänen-Casts weitgehend weg / typecheck stabil 0 |
 
 **Empfohlene nächsten PRs (klein halten):**
 
-1. References Slice 5 — Follow-up / Notify / Form (Boy-Scout mit Feature ok)  
-2. Nächste Domäne nach Cast-Count (Settings oder Match)  
-3. Typed-Supabase **T4** — CI-`typecheck`-Gate
+1. Nächste Domäne nach Cast-Count (Settings oder Match)  
+2. Typed-Supabase **T4** — CI-`typecheck`-Gate  
+3. Optional: References-Rest (Dashboard-Fallback / trash / Quote) nur Boy-Scout
 
 ---
 
@@ -97,7 +97,7 @@ Bei Feature-PRs mitnehmen, **kein** Massen-PR:
 | P1-6 | ✅ App/Lib; DB `companies` bleibt |
 | E4 / E7 | ✅ |
 | E6 Logger | ✅ App/Lib; Sink/Scripts bewusst |
-| Typed-Supabase T3 | 🟡 aktiv (Accounts/Deals ✅, References teilweise) |
+| Typed-Supabase T3 | 🟡 aktiv (Accounts/Deals/References ✅; andere Domänen offen) |
 | Typed-Supabase T4 | offen (nach T3-Ruhe) |
 | Welle 5 T3 Paths | → Queue #8 |
 | Welle 5 T4 `workspace_state` | vor Start erneut `grep`en |

--- a/lib/references/approval-workflow-notify-recipients.ts
+++ b/lib/references/approval-workflow-notify-recipients.ts
@@ -1,10 +1,13 @@
 import 'server-only'
 
 import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database, Json } from '@/lib/database.types'
 
 import { createServiceRoleSupabaseClient } from '@/lib/supabase/service-role'
 import { parseProfileRoles } from '@/lib/roles/profile-roles'
 import { profileCanManageOrgData } from '@/lib/roles/profile-guards'
+
+type AdminClient = SupabaseClient<Database>
 
 function normalizeEmail(email: string): string {
   return email.trim().toLowerCase()
@@ -14,15 +17,14 @@ function isValidEmail(email: string): boolean {
   return normalizeEmail(email).includes('@')
 }
 
-function wantsApprovalUpdateEmails(notificationSettings: unknown): boolean {
+function wantsApprovalUpdateEmails(notificationSettings: Json | null | undefined): boolean {
   if (!notificationSettings || typeof notificationSettings !== 'object') return true
-  const flag = (notificationSettings as { email_on_approval_update?: unknown })
-    .email_on_approval_update
-  return flag !== false
+  if (Array.isArray(notificationSettings)) return true
+  return notificationSettings.email_on_approval_update !== false
 }
 
 async function resolveCoordinatorEmail(
-  admin: SupabaseClient,
+  admin: AdminClient,
   companyId: string,
   organizationId: string,
   coordinatorEmail?: string | null,
@@ -37,9 +39,7 @@ async function resolveCoordinatorEmail(
     .eq('organization_id', organizationId)
     .maybeSingle()
 
-  const contactId = (
-    companyRow as { internal_reference_approval_contact_id?: string | null } | null
-  )?.internal_reference_approval_contact_id
+  const contactId = companyRow?.internal_reference_approval_contact_id
   if (!contactId) return null
 
   const { data: person } = await admin
@@ -54,7 +54,7 @@ async function resolveCoordinatorEmail(
 }
 
 async function resolveRequesterEmail(
-  admin: SupabaseClient,
+  admin: AdminClient,
   requesterId: string | null,
   organizationId: string,
 ): Promise<string | null> {
@@ -70,11 +70,7 @@ async function resolveRequesterEmail(
 
   const { systemRole, functionRole } = parseProfileRoles(profile)
   if (!profileCanManageOrgData(systemRole, functionRole)) return null
-  if (
-    !wantsApprovalUpdateEmails(
-      (profile as { notification_settings?: unknown } | null)?.notification_settings,
-    )
-  ) {
+  if (!wantsApprovalUpdateEmails(profile?.notification_settings)) {
     return null
   }
 
@@ -92,7 +88,7 @@ async function resolveRequesterEmail(
 
 /** Anfragender (nur Admin/AM, keine Sales) + Accountverantwortlicher der Freigabe. */
 export async function resolveApprovalWorkflowNotifyEmails(
-  admin: SupabaseClient,
+  admin: AdminClient,
   args: {
     companyId: string
     /** Pflicht — ohne Org kein Bypass-Lookup (E4). */

--- a/lib/references/complete-internal-approval.ts
+++ b/lib/references/complete-internal-approval.ts
@@ -1,6 +1,7 @@
 import 'server-only'
 
 import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '@/lib/database.types'
 
 import { notifyInternalTeamInternalApproved } from '@/lib/references/approval-workflow-internal-notifications'
 
@@ -14,7 +15,7 @@ export type ConfirmInternalApprovalResult =
   | { ok: false; reason: 'invalid' | 'not_pending' }
 
 export async function confirmInternalApprovalFromToken(
-  admin: SupabaseClient,
+  admin: SupabaseClient<Database>,
   token: string,
 ): Promise<ConfirmInternalApprovalResult> {
   const trimmed = token.trim()
@@ -34,7 +35,7 @@ export async function confirmInternalApprovalFromToken(
   if (internal === 'approved_internal') {
     return {
       ok: true,
-      referenceId: row.id as string,
+      referenceId: row.id,
       referenceTitle: String(row.title ?? 'Referenz'),
       alreadyApproved: true,
     }
@@ -56,7 +57,7 @@ export async function confirmInternalApprovalFromToken(
 
   if (updateError) return { ok: false, reason: 'invalid' }
 
-  const orgId = (row as { organization_id?: string | null }).organization_id
+  const orgId = row.organization_id
   if (orgId) {
     try {
       await admin.from('evidence_events').insert({
@@ -72,12 +73,12 @@ export async function confirmInternalApprovalFromToken(
 
   void notifyInternalTeamInternalApproved({
     admin,
-    referenceId: row.id as string,
+    referenceId: row.id,
   })
 
   return {
     ok: true,
-    referenceId: row.id as string,
+    referenceId: row.id,
     referenceTitle: String(row.title ?? 'Referenz'),
     alreadyApproved: false,
   }

--- a/lib/references/customer-approval-reminder.ts
+++ b/lib/references/customer-approval-reminder.ts
@@ -1,7 +1,9 @@
 import 'server-only'
 
 import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '@/lib/database.types'
 
+import { companyNameFromReferenceRow } from '@/lib/references/library/approvals-helpers'
 import { notifyInternalTeamCustomerApprovalPendingReminder } from '@/lib/references/approval-workflow-internal-notifications'
 import { log } from '@/lib/observability/logger'
 
@@ -35,21 +37,8 @@ export function isCustomerApprovalReminderDue(args: {
   return true
 }
 
-type PendingReminderRow = {
-  id: string
-  title: string | null
-  company_id: string
-  organization_id: string | null
-  approval_requested_by: string | null
-  approval_coordinator_email: string | null
-  approval_customer_last_sent_at: string | null
-  approval_requested_at: string | null
-  approval_customer_reminder_sent_at: string | null
-  companies?: { name?: string } | { name?: string }[] | null
-}
-
 export async function markCustomerApprovalEmailSent(
-  supabase: SupabaseClient,
+  supabase: SupabaseClient<Database>,
   referenceId: string,
   sentAt?: string,
 ): Promise<void> {
@@ -71,7 +60,7 @@ export async function markCustomerApprovalEmailSent(
 }
 
 export async function processCustomerApprovalReminders(
-  admin: SupabaseClient,
+  admin: SupabaseClient<Database>,
 ): Promise<{ scanned: number; sent: number; skipped: number }> {
   const cutoff = customerApprovalReminderCutoffIso()
 
@@ -109,7 +98,7 @@ export async function processCustomerApprovalReminders(
   let sent = 0
   let skipped = 0
 
-  for (const row of (rows ?? []) as PendingReminderRow[]) {
+  for (const row of rows ?? []) {
     if (
       !isCustomerApprovalReminderDue({
         lastSentAt: row.approval_customer_last_sent_at,
@@ -121,11 +110,7 @@ export async function processCustomerApprovalReminders(
       continue
     }
 
-    const company =
-      Array.isArray(row.companies) && row.companies.length > 0
-        ? row.companies[0]
-        : (row.companies as { name?: string } | null)
-    const companyName = company?.name?.trim() || 'Referenz'
+    const companyName = companyNameFromReferenceRow(row.companies)
     const daysWaiting = CUSTOMER_APPROVAL_REMINDER_AFTER_DAYS
 
     const emailSent = await notifyInternalTeamCustomerApprovalPendingReminder({

--- a/lib/references/delegate-internal-approval.ts
+++ b/lib/references/delegate-internal-approval.ts
@@ -2,7 +2,9 @@ import 'server-only'
 
 import { randomUUID } from 'crypto'
 import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '@/lib/database.types'
 
+import { companyNameFromReferenceRow } from '@/lib/references/library/approvals-helpers'
 import { deriveReferenceGiverNameFromEmail } from '@/lib/references/derive-reference-giver-name-from-email'
 import { sendInternalApprovalReviewEmail } from '@/lib/references/internal-approval-email'
 import { isApprovalRecipientEmail } from '@/lib/references/approval-recipient-input'
@@ -12,7 +14,7 @@ export type DelegateInternalApprovalResult =
   | { ok: false; reason: 'invalid' | 'not_pending' | 'invalid_email' }
 
 export async function delegateInternalApprovalFromToken(
-  admin: SupabaseClient,
+  admin: SupabaseClient<Database>,
   token: string,
   delegateEmail: string,
 ): Promise<DelegateInternalApprovalResult> {
@@ -45,11 +47,7 @@ export async function delegateInternalApprovalFromToken(
   if (internal !== 'pending_internal') return { ok: false, reason: 'not_pending' }
 
   const newToken = randomUUID()
-  const company = Array.isArray(row.companies) ? row.companies[0] : row.companies
-  const accountCompanyName =
-    typeof company?.name === 'string' && company.name.trim()
-      ? company.name.trim()
-      : 'Account'
+  const accountCompanyName = companyNameFromReferenceRow(row.companies, 'Account')
   const requesterName = String(row.approval_requester_name ?? '').trim()
   const previousEmail = String(row.approval_coordinator_email ?? '').trim()
 
@@ -65,7 +63,7 @@ export async function delegateInternalApprovalFromToken(
 
   if (updateError) return { ok: false, reason: 'invalid' }
 
-  const orgId = (row as { organization_id?: string | null }).organization_id
+  const orgId = row.organization_id
   if (orgId) {
     try {
       await admin.from('evidence_events').insert({
@@ -93,7 +91,7 @@ export async function delegateInternalApprovalFromToken(
     requesterName,
     message: typeof row.approval_message === 'string' ? row.approval_message : null,
     internalReviewToken: newToken,
-    referenceId: row.id as string,
+    referenceId: row.id,
   })
 
   return { ok: true, delegatedToEmail: email, emailSent }

--- a/lib/references/library/approvals-customer-follow-up.ts
+++ b/lib/references/library/approvals-customer-follow-up.ts
@@ -18,13 +18,11 @@ import {
 } from '@/lib/email/resend-dev-override'
 import { getRefstackResendFrom } from '@/lib/email/refstack-email-layout'
 import { log } from '@/lib/observability/logger'
+import { companyNameFromReferenceRow } from '@/lib/references/library/approvals-helpers'
 import { buildFollowUpApprovalAfterChangesEmailHtml } from '@/lib/references/library/approvals-email-templates'
 import { getApprovalResendClient } from '@/lib/references/library/approvals-client-email'
 import { resolveContactForApproval } from '@/lib/references/library/approvals-recipient'
-import type {
-  ReferenceApprovalRow,
-  RequestCustomerApprovalAgainResult,
-} from '@/lib/references/library/approvals-types'
+import type { RequestCustomerApprovalAgainResult } from '@/lib/references/library/approvals-types'
 
 export async function requestCustomerApprovalAgainAfterChangesImpl(
   referenceId: string,
@@ -67,13 +65,7 @@ export async function requestCustomerApprovalAgainAfterChangesImpl(
 
   if (fetchError || !row) return { success: false, error: 'Referenz nicht gefunden' }
 
-  const ref = row as unknown as ReferenceApprovalRow & {
-    approval_token?: string | null
-    approval_requested_by?: string | null
-    approval_delegated_to_name?: string | null
-    approval_delegated_to_email?: string | null
-    approval_comment?: string | null
-  }
+  const ref = row
 
   if (!hasActiveCustomerApprovalWorkflow(ref.customer_approval_status, ref.status)) {
     return { success: false, error: 'Es liegt keine aktive Kunden-Freigabe vor.' }
@@ -105,11 +97,7 @@ export async function requestCustomerApprovalAgainAfterChangesImpl(
   const token = typeof ref.approval_token === 'string' ? ref.approval_token.trim() : ''
   if (!token) return { success: false, error: 'Noch kein Freigabelink verfügbar.' }
 
-  const company =
-    Array.isArray(ref.companies) && ref.companies.length > 0
-      ? (ref.companies[0] as { name?: string })
-      : (ref.companies as { name?: string } | null)
-  const companyName = company?.name ?? 'Referenz'
+  const companyName = companyNameFromReferenceRow(ref.companies)
 
   let contactEmail: string
   let firstName: string

--- a/lib/references/library/approvals-internal-notify.ts
+++ b/lib/references/library/approvals-internal-notify.ts
@@ -1,10 +1,11 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '@/lib/database.types'
 
 import { sendInternalApprovalReviewEmail } from '@/lib/references/internal-approval-email'
 
 /** Benachrichtigt den am Account hinterlegten internen Referenzfreigabe-Kontakt (Metadaten → konkreter Mail-Hinweis). */
 export async function notifyInternalReferenceCoordinatorAboutPendingReview(args: {
-  supabase: SupabaseClient
+  supabase: SupabaseClient<Database>
   referenceId: string
   referenceTitle: string
   accountCompanyId: string
@@ -24,9 +25,7 @@ export async function notifyInternalReferenceCoordinatorAboutPendingReview(args:
       .eq('id', args.accountCompanyId)
       .maybeSingle()
 
-    const contactId = (
-      companyRow as { internal_reference_approval_contact_id?: string | null } | null
-    )?.internal_reference_approval_contact_id
+    const contactId = companyRow?.internal_reference_approval_contact_id
     if (!contactId) return
 
     const { data: person } = await args.supabase
@@ -49,9 +48,7 @@ export async function notifyInternalReferenceCoordinatorAboutPendingReview(args:
     .select('approval_internal_review_token')
     .eq('id', args.referenceId)
     .maybeSingle()
-  const internalToken = (
-    refTokenRow as { approval_internal_review_token?: string | null } | null
-  )?.approval_internal_review_token
+  const internalToken = refTokenRow?.approval_internal_review_token
   if (!internalToken) return
 
   await sendInternalApprovalReviewEmail({

--- a/lib/references/library/pending-approvals.ts
+++ b/lib/references/library/pending-approvals.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import { accountFromJoin } from '@/lib/accounts/account-from-join'
 import { createServerSupabaseClient } from '@/lib/supabase/server'
 import { parseProfileRoles } from '@/lib/roles/profile-roles'
 import { profileIsSalesRestricted } from '@/lib/roles/profile-guards'
@@ -57,36 +58,19 @@ export async function getPendingClientApprovalsImpl(): Promise<
 
   const out: PendingClientApprovalRow[] = []
 
-  for (const row of data as Record<string, unknown>[]) {
-    const requesterId = row.requester_id as string | undefined
-    if (salesRestricted && requesterId !== user.id) continue
+  for (const row of data) {
+    if (salesRestricted && row.requester_id !== user.id) continue
 
-    const refRaw = row.reference as
-      | {
-          id?: string
-          title?: string
-          customer_approval_status?: string | null
-          approval_token?: string | null
-          companies?: { name?: string } | { name?: string }[] | null
-        }
-      | null
-      | undefined
-
+    const refRaw = Array.isArray(row.reference) ? row.reference[0] : row.reference
     if (!refRaw?.id) continue
     if (refRaw.customer_approval_status !== 'pending' || !refRaw.approval_token) continue
 
-    const companies = refRaw.companies
-    const companyName =
-      Array.isArray(companies) && companies.length > 0
-        ? (companies[0] as { name?: string }).name
-        : (companies as { name?: string } | null)?.name
-
     out.push({
-      approvalId: row.id as string,
+      approvalId: row.id,
       referenceId: refRaw.id,
       title: refRaw.title ?? '—',
-      companyName: companyName ?? '—',
-      requestedAt: row.created_at as string,
+      companyName: accountFromJoin(refRaw.companies)?.name ?? '—',
+      requestedAt: row.created_at ?? '',
     })
   }
 

--- a/lib/references/reference-form/use-reference-form.ts
+++ b/lib/references/reference-form/use-reference-form.ts
@@ -318,9 +318,7 @@ export function useReferenceForm({
       )
       if (result.success) {
         toast.success('Referenz wurde angelegt.')
-        const refId =
-          (result as unknown as { referenceId?: string; id?: string }).referenceId ??
-          (result as { id?: string }).id
+        const refId = result.referenceId
         if (refId && selectedFile) {
           void (async () => {
             const supabase = createClient()
@@ -331,9 +329,7 @@ export function useReferenceForm({
               .select('organization_id')
               .eq('id', me.user.id)
               .single()
-            const orgId =
-              (profile as { organization_id?: string | null } | null)?.organization_id ??
-              null
+            const orgId = profile?.organization_id ?? null
             if (!orgId) return
             const safeName = selectedFile.name.replace(/[^a-zA-Z0-9.\\-_]/g, '_')
             const storagePath = `${orgId}/${refId}/${Date.now()}-${safeName}`


### PR DESCRIPTION
## Summary
- Remove row casts in customer follow-up, notify recipients, internal notify, pending approvals, reminders, and internal approval token flows
- Form create path uses typed `CreateReferenceResult.referenceId`
- Backlog: References Slice 1–5 ✅; next = Settings/Match domain

## Test plan
- [x] `npm run typecheck`
- [x] vitest: notify-recipients, complete-internal-approval, approvals-helpers

Made with [Cursor](https://cursor.com)