### PR TITLE
refactor(settings): typed Supabase cast abbau slice 1

### DIFF
--- a/app/dashboard/settings/actions.ts
+++ b/app/dashboard/settings/actions.ts
@@ -90,9 +90,7 @@ export async function updateProfile(formData: FormData) {
     .single()
 
   const parsedRoles = parseProfileRoles(profileRow ?? {})
-  const existingPhone = String(
-    (profileRow as { phone?: string | null })?.phone ?? '',
-  ).trim()
+  const existingPhone = String(profileRow?.phone ?? '').trim()
 
   const firstName = formData.get('firstName')?.toString()?.trim()
   const lastName = formData.get('lastName')?.toString()?.trim()

--- a/app/dashboard/settings/invite-actions.ts
+++ b/app/dashboard/settings/invite-actions.ts
@@ -14,6 +14,7 @@ import {
   type InviteRoleDimensions,
 } from '@/lib/roles/invite-roles'
 import { parseProfileRoles } from '@/lib/roles/profile-roles'
+import type { Json } from '@/lib/database.types'
 import { log } from '@/lib/observability/logger'
 
 const INVITE_VALID_DAYS = 7
@@ -24,6 +25,44 @@ function formatInviteExpiresAt(expiresAt: Date): string {
     month: '2-digit',
     year: 'numeric',
   })
+}
+
+type InviteRpcFields = {
+  id?: string
+  email?: string | null
+  token?: string | null
+  system_role?: string | null
+  function_role?: string | null
+}
+
+/** RPC `get_organization_invite_for_resend` / pending-invite rows sind `Json`. */
+function parseInviteRpcObject(data: Json | null | undefined): InviteRpcFields | null {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return null
+  const obj = data as Record<string, unknown>
+  return {
+    id: typeof obj.id === 'string' ? obj.id : undefined,
+    email: typeof obj.email === 'string' ? obj.email : obj.email === null ? null : undefined,
+    token: typeof obj.token === 'string' ? obj.token : obj.token === null ? null : undefined,
+    system_role:
+      typeof obj.system_role === 'string'
+        ? obj.system_role
+        : obj.system_role === null
+          ? null
+          : undefined,
+    function_role:
+      typeof obj.function_role === 'string'
+        ? obj.function_role
+        : obj.function_role === null
+          ? null
+          : undefined,
+  }
+}
+
+function parsePendingInviteRows(data: Json | null | undefined): InviteRpcFields[] {
+  if (!Array.isArray(data)) return []
+  return data
+    .map((row) => parseInviteRpcObject(row))
+    .filter((row): row is InviteRpcFields => Boolean(row?.id))
 }
 
 export type CreateInviteResult =
@@ -261,16 +300,7 @@ export async function resendInviteEmail(params: {
 
   if (inviteErr) return { success: false, error: inviteErr.message }
 
-  const parsed = inviteDataRaw as unknown
-  const invite =
-    parsed && typeof parsed === 'object'
-      ? (parsed as {
-          email?: string | null
-          token?: string | null
-          system_role?: string | null
-          function_role?: string | null
-        })
-      : null
+  const invite = parseInviteRpcObject(inviteDataRaw)
 
   const email = invite?.email?.trim().toLowerCase() || ''
   const token = invite?.token?.trim() || ''
@@ -378,29 +408,22 @@ export async function getTeamMembers(): Promise<TeamMemberRow[]> {
     )
   }
 
-  const rawPending = invitesRpc.data as unknown
-  const pendingRows = Array.isArray(rawPending) ? rawPending : []
-
-  const pending: TeamMemberRow[] = pendingRows.flatMap((row) => {
-    const i = row as {
-      id?: string
-      email?: string | null
-      system_role?: string | null
-      function_role?: string | null
-    }
-    if (!i?.id) return []
-    const roles = parseInviteRoleDimensions(i)
-    return [
-      {
-        id: i.id,
-        email: i.email ?? '',
-        name: null,
-        status: 'pending' as const,
-        systemRole: roles.systemRole,
-        functionRole: roles.functionRole,
-      },
-    ]
-  })
+  const pending: TeamMemberRow[] = parsePendingInviteRows(invitesRpc.data).flatMap(
+    (i) => {
+      if (!i.id) return []
+      const roles = parseInviteRoleDimensions(i)
+      return [
+        {
+          id: i.id,
+          email: i.email ?? '',
+          name: null,
+          status: 'pending' as const,
+          systemRole: roles.systemRole,
+          functionRole: roles.functionRole,
+        },
+      ]
+    },
+  )
 
   return [...active, ...pending]
 }

--- a/app/dashboard/settings/market-signals/page.tsx
+++ b/app/dashboard/settings/market-signals/page.tsx
@@ -5,26 +5,6 @@ import { resolveChampionPersonTitle } from '@/lib/market-signals/champion-displa
 import { MarketSignalsManageClient } from './watchlist-manage-client'
 import type { NewsroomSummary } from './newsrooms-card'
 
-type CompanyRow = {
-  id: string
-  name: string
-  logo_url: string | null
-  is_favorite: boolean | null
-  account_status: string | null
-  website_url: string | null
-  newsroom_urls: string[] | null
-  newsroom_discovered_at: string | null
-}
-
-type ChampionWatchRow = {
-  person_key: string
-  person_name: string
-  company_name: string | null
-  person_title: string | null
-  created_at: string
-  is_active: boolean | null
-}
-
 export default async function MarketSignalsManagePage() {
   const supabase = await createServerSupabaseClient()
   const {
@@ -45,7 +25,7 @@ export default async function MarketSignalsManagePage() {
     .select('organization_id')
     .eq('id', user.id)
     .maybeSingle()
-  const orgId = (profile as { organization_id?: string | null } | null)?.organization_id
+  const orgId = profile?.organization_id
   if (!orgId) {
     return (
       <MarketSignalsManageClient
@@ -76,16 +56,17 @@ export default async function MarketSignalsManagePage() {
     .order('published_on', { ascending: false })
     .limit(500)
 
-  const initialFollowingCount = ((data ?? []) as CompanyRow[]).filter((row) =>
-    Boolean(row.is_favorite),
-  ).length
+  const companyRows = [...(data ?? [])]
+  const initialFollowingCount = companyRows.filter((row) => Boolean(row.is_favorite)).length
   if (initialFollowingCount === 0) {
-    const knownCompanyIds = new Set(((data ?? []) as CompanyRow[]).map((row) => row.id))
+    const knownCompanyIds = new Set(companyRows.map((row) => row.id))
     const bootstrapCompanyIds = Array.from(
       new Set(
         [...(execRows ?? []), ...(newsRows ?? [])]
-          .map((row) => String((row as { company_id?: string | null }).company_id ?? ''))
-          .filter((companyId) => companyId && knownCompanyIds.has(companyId)),
+          .map((row) => row.company_id)
+          .filter((companyId): companyId is string =>
+            Boolean(companyId && knownCompanyIds.has(companyId)),
+          ),
       ),
     ).slice(0, 8)
     if (bootstrapCompanyIds.length > 0) {
@@ -94,7 +75,7 @@ export default async function MarketSignalsManagePage() {
         .update({ is_favorite: true })
         .eq('organization_id', orgId)
         .in('id', bootstrapCompanyIds)
-      for (const row of (data ?? []) as CompanyRow[]) {
+      for (const row of companyRows) {
         if (bootstrapCompanyIds.includes(row.id)) row.is_favorite = true
       }
     }
@@ -107,7 +88,7 @@ export default async function MarketSignalsManagePage() {
     .order('created_at', { ascending: false })
     .limit(500)
 
-  const companies = ((data ?? []) as CompanyRow[]).map((row) => ({
+  const companies = companyRows.map((row) => ({
     id: row.id,
     name: row.name ?? 'Unbekannt',
     logoUrl: row.logo_url ?? null,
@@ -115,7 +96,6 @@ export default async function MarketSignalsManagePage() {
     accountStatus: row.account_status ?? null,
   }))
 
-  const companyRows = (data ?? []) as CompanyRow[]
   const withWebsite = companyRows.filter((row) =>
     Boolean(String(row.website_url ?? '').trim()),
   ).length
@@ -144,9 +124,8 @@ export default async function MarketSignalsManagePage() {
       }),
   }
 
-  const championRows = (championWatchRows ?? []) as ChampionWatchRow[]
   const watchedStakeholders = await Promise.all(
-    championRows.map(async (row) => {
+    (championWatchRows ?? []).map(async (row) => {
       let title = row.person_title?.trim() || null
       if (!title) {
         title = await resolveChampionPersonTitle(

--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -202,30 +202,15 @@ export default async function SettingsPage() {
     .single()
 
   const organizationId = profileRow?.organization_id ?? null
-  let orgRow: {
-    id: string
-    name: string
-    logo_url: string | null
-    primary_color: string | null
-    secondary_color: string | null
-    date_display_format: string
-    export_settings: unknown
-    stripe_subscription_id: string | null
-    subscription_status: string | null
-    subdomain: string | null
-    api_settings: unknown
-    workflow_settings: unknown
-  } | null = null
-  if (organizationId) {
-    const { data } = await supabase
-      .from('organizations')
-      .select(
-        'id, name, logo_url, primary_color, secondary_color, date_display_format, export_settings, stripe_subscription_id, subscription_status, subdomain, api_settings, workflow_settings',
-      )
-      .eq('id', organizationId)
-      .single()
-    orgRow = data
-  }
+  const { data: orgRow } = organizationId
+    ? await supabase
+        .from('organizations')
+        .select(
+          'id, name, logo_url, primary_color, secondary_color, date_display_format, export_settings, stripe_subscription_id, subscription_status, subdomain, api_settings, workflow_settings',
+        )
+        .eq('id', organizationId)
+        .single()
+    : { data: null }
 
   const teamMembers = await getTeamMembers()
 
@@ -275,12 +260,8 @@ export default async function SettingsPage() {
   const [firstName = '', ...rest] = fullName.trim().split(/\s+/)
   const lastName = rest.join(' ') ?? ''
 
-  const apiSettingsParsed = parseOrganizationApiSettings(
-    (orgRow as { api_settings?: unknown } | null)?.api_settings,
-  )
-  const capabilitySettings = parseOrgCapabilitySettings(
-    (orgRow as { workflow_settings?: unknown } | null)?.workflow_settings,
-  )
+  const apiSettingsParsed = parseOrganizationApiSettings(orgRow?.api_settings)
+  const capabilitySettings = parseOrgCapabilitySettings(orgRow?.workflow_settings)
 
   return (
     <div className="flex flex-col space-y-6">
@@ -299,52 +280,36 @@ export default async function SettingsPage() {
             userEmail: user.email ?? '',
             firstName,
             lastName,
-            avatarUrl: (profileRow as { avatar_url?: string | null })?.avatar_url ?? null,
-            bookingUrl:
-              (profileRow as { booking_url?: string | null })?.booking_url ?? null,
-            phone: (profileRow as { phone?: string | null })?.phone ?? null,
-            jobTitle: (profileRow as { job_title?: string | null })?.job_title ?? null,
+            avatarUrl: profileRow?.avatar_url ?? null,
+            bookingUrl: profileRow?.booking_url ?? null,
+            phone: profileRow?.phone ?? null,
+            jobTitle: profileRow?.job_title ?? null,
             salesRequired: profileIsSalesRestricted(
               serverRoles.systemRole,
               serverRoles.functionRole,
             ),
             notificationSettings: parseProfileNotificationSettings(
-              (profileRow as { notification_settings?: unknown } | null)
-                ?.notification_settings,
+              profileRow?.notification_settings,
             ),
           }}
           org={{
             id: orgRow?.id ?? null,
             name: orgRow?.name ?? '',
             logoUrl: orgRow?.logo_url ?? null,
-            primaryColor:
-              (orgRow as { primary_color?: string | null } | null)?.primary_color ??
-              '#2563EB',
-            secondaryColor:
-              (orgRow as { secondary_color?: string | null } | null)?.secondary_color ??
-              '#1D4ED8',
-            dateDisplayFormat:
-              (orgRow as { date_display_format?: string | null } | null)
-                ?.date_display_format ?? 'de-DE',
-            uiLocale: uiLocaleFromApiSettings(
-              (orgRow as { api_settings?: unknown } | null)?.api_settings,
-            ),
-            exportSettings: parsePdfExportSettings(
-              (orgRow as { export_settings?: unknown } | null)?.export_settings,
-            ),
+            primaryColor: orgRow?.primary_color ?? '#2563EB',
+            secondaryColor: orgRow?.secondary_color ?? '#1D4ED8',
+            dateDisplayFormat: orgRow?.date_display_format ?? 'de-DE',
+            uiLocale: uiLocaleFromApiSettings(orgRow?.api_settings),
+            exportSettings: parsePdfExportSettings(orgRow?.export_settings),
             subscriptionStatus: orgRow?.subscription_status ?? null,
             subscriptionId: orgRow?.stripe_subscription_id ?? null,
-            subdomain: (orgRow as { subdomain?: string | null } | null)?.subdomain ?? '',
-            billingSettings: parseOrganizationBillingSettings(
-              (orgRow as { api_settings?: unknown } | null)?.api_settings,
-            ),
+            subdomain: orgRow?.subdomain ?? '',
+            billingSettings: parseOrganizationBillingSettings(orgRow?.api_settings),
             apiSettings: {
               apiKeyMask: apiSettingsParsed.apiKeyMask,
               useWorkspaceBranding: apiSettingsParsed.useWorkspaceBranding,
             },
-            workflowSettings: parseOrganizationWorkflowSettings(
-              (orgRow as { workflow_settings?: unknown } | null)?.workflow_settings,
-            ),
+            workflowSettings: parseOrganizationWorkflowSettings(orgRow?.workflow_settings),
             capabilitySettings,
           }}
           teamMembers={teamMembers}

--- a/docs/tech-debt-offen-backlog.md
+++ b/docs/tech-debt-offen-backlog.md
@@ -10,8 +10,8 @@
 
 | Status | Themen |
 |--------|--------|
-| **Erledigt** | Inventar-Hygiene (#0); E4 Hotspot-Audit (#1); E7 Schema-Sync (#2); **P1-6** Accounts Naming App/Lib (#4); Welle-5 Rollen (Invite/`AppRole`/Mapping); Typed-Supabase **Accounts** + **Deals** + References **Slice 1–5** (Dashboard/Sharing/Approvals/Cache/Complete/Requests/Follow-up/Notify/Form) |
-| **In Arbeit** | Typed-Supabase Cast-Abbau (#3) — weitere Domänen (Settings/Match/…) |
+| **Erledigt** | Inventar-Hygiene (#0); E4 Hotspot-Audit (#1); E7 Schema-Sync (#2); **P1-6** Accounts Naming App/Lib (#4); Welle-5 Rollen (Invite/`AppRole`/Mapping); Typed-Supabase **Accounts** + **Deals** + References **Slice 1–5** + Settings **Slice 1** (Page/Profile/MS-Manage/Invites) |
+| **In Arbeit** | Typed-Supabase Cast-Abbau (#3) — weitere Domänen (Notifications/Match/DealDesk/…) |
 | **Offen (Queue)** | #3 Rest · #5 God-Files (Boy-Scout) · #6 `{ ok }` → `{ success }` (Boy-Scout) · #7 DE/EN-Dateinamen (Boy-Scout) · #8 `references`/`evidence` Rename · #9 Invite-SQL-Kosmetik (optional) |
 | **Geparkt** | Pilot (H3/E1/G2); Massen-Renames; produktweite `evidence`↔`references`-Entscheidung |
 
@@ -26,7 +26,7 @@
 | **0** | Inventar-Hygiene | ✅ | — | — | — |
 | **1** | E4 Service-Role | ✅ Audit + Hotspots | Boy-Scout: Kommentar an neuen Service-Role-Callern | XS ongoing | bei Touch |
 | **2** | E7 Schema-Sync | ✅ T1–T4 | Types bei Migrationen regenerieren (`db:types`) | XS ongoing | bei Schema-Change |
-| **3** | Typed-Supabase Cast-Abbau | **🟡 aktiv** | Nächste Domäne (Settings/Match/DealDesk/Shared); zuletzt **T4** CI-Gate | L | Settings oder Match nach Cast-Count |
+| **3** | Typed-Supabase Cast-Abbau | **🟡 aktiv** | Notifications / Match / DealDesk / Shared; zuletzt **T4** CI-Gate | L | Notifications Inbox oder Match nach Cast-Count |
 | **4** | P1-6 Accounts Naming | ✅ App/Lib | DB-Tabelle `companies` / `company_id` / Firmennamen-Helfer **bewusst offen** | — | nicht anfassen ohne Produktentscheid |
 | **5** | God-File-Nacharbeit | offen (Boy-Scout) | Overview / Share-Link / MS-Feed weiter slicen **nur bei Feature-Touch** | M ongoing | kein eigener Big-Bang-PR |
 | **6** | `{ ok }` → `{ success }` | offen (Boy-Scout) | ~130 Matches in Libs/Cron | S–M | bei Lib-Berührung mitziehen |
@@ -47,14 +47,15 @@
 | Accounts | ✅ Slices 1–4 | wenig: CRM-JSON, External-Contacts-Fallback, Error-Shapes |
 | Deals | ✅ Slices 1–2 | wenig: Eligibility/JSON-API-Responses (bewusst) |
 | References | ✅ Slice 1–5 | Rest-Hotspots vereinzelt (Dashboard-Fallback, trash RPC, Quote/JSON-APIs) |
-| Andere | offen | Settings, Match, DealDesk, Command-Center, Notifications, … |
+| Settings | ✅ Slice 1 | Stripe/HubSpot/Push-JSON bewusst; ggf. Rest-Actions Boy-Scout |
+| Andere | offen | Notifications, Match, DealDesk, Command-Center, Shared Portfolio, … |
 | **T4 CI** | offen | `typecheck` in CI **scharf**, wenn Domänen-Casts weitgehend weg / typecheck stabil 0 |
 
 **Empfohlene nächsten PRs (klein halten):**
 
-1. Nächste Domäne nach Cast-Count (Settings oder Match)  
+1. Notifications Inbox (org/profile row casts) oder Match nach Cast-Count  
 2. Typed-Supabase **T4** — CI-`typecheck`-Gate  
-3. Optional: References-Rest (Dashboard-Fallback / trash / Quote) nur Boy-Scout
+3. Optional: References-Rest / Settings-HTTP-JSON nur Boy-Scout
 
 ---
 
@@ -97,7 +98,7 @@ Bei Feature-PRs mitnehmen, **kein** Massen-PR:
 | P1-6 | ✅ App/Lib; DB `companies` bleibt |
 | E4 / E7 | ✅ |
 | E6 Logger | ✅ App/Lib; Sink/Scripts bewusst |
-| Typed-Supabase T3 | 🟡 aktiv (Accounts/Deals/References ✅; andere Domänen offen) |
+| Typed-Supabase T3 | 🟡 aktiv (Accounts/Deals/References/Settings ✅; andere Domänen offen) |
 | Typed-Supabase T4 | offen (nach T3-Ruhe) |
 | Welle 5 T3 Paths | → Queue #8 |
 | Welle 5 T4 `workspace_state` | vor Start erneut `grep`en |


### PR DESCRIPTION
## Summary
- Remove profile/org row casts on Settings page and `updateProfile`
- Type market-signals manage page company/champion queries without `as {…}`
- Parse invite RPC JSON via guards; leave Stripe/HubSpot/Push HTTP JSON as intentional boundaries
- Backlog: Settings Slice 1 ✅

## Test plan
- [x] `npm run typecheck`
- [ ] Spot-check Settings tabs + team invite list if convenient

Made with [Cursor](https://cursor.com)