### PR TITLE
refactor: typed Supabase shared portfolio + domain quick wins

### DIFF
--- a/app/approval/[token]/page.tsx
+++ b/app/approval/[token]/page.tsx
@@ -90,11 +90,7 @@ export default async function ApprovalPage({
     return <InvalidLink />
   }
 
-  const companyRaw = row.companies
-  const company =
-    Array.isArray(companyRaw) && companyRaw.length > 0
-      ? (companyRaw[0] as { name?: string; organization_id?: string | null })
-      : (companyRaw as { name?: string; organization_id?: string | null } | null)
+  const company = Array.isArray(row.companies) ? row.companies[0] : row.companies
 
   const orgId = company?.organization_id ?? null
   let orgName = company?.name ?? '—'

--- a/app/dashboard/deal-desk/page.tsx
+++ b/app/dashboard/deal-desk/page.tsx
@@ -34,7 +34,7 @@ export default async function DealDeskPage({
           .eq('organization_id', orgId)
           .maybeSingle()
 
-        const dealId = (project as { deal_id?: string | null } | null)?.deal_id
+        const dealId = project?.deal_id
         if (dealId) {
           redirect(ROUTES.deals.detailRfp(dealId))
         }

--- a/app/dashboard/notifications/inbox.ts
+++ b/app/dashboard/notifications/inbox.ts
@@ -273,7 +273,7 @@ export async function getInboxNotificationsImpl(
     .eq('id', userId)
     .maybeSingle()
 
-  const orgId = (profile as { organization_id?: string | null } | null)?.organization_id
+  const orgId = profile?.organization_id
   if (!orgId) return []
 
   const { data: events, error } = await supabase
@@ -388,10 +388,8 @@ export async function getInboxNotificationsImpl(
     .limit(500)
   const championPersonKeys = new Set(
     (championRows ?? []).flatMap((row) => {
-      const key = normalizeText((row as { person_key?: string | null }).person_key ?? '')
-      const name = normalizeText(
-        (row as { person_name?: string | null }).person_name ?? '',
-      )
+      const key = normalizeText(row.person_key ?? '')
+      const name = normalizeText(row.person_name ?? '')
       return [key, name].filter(Boolean)
     }),
   )

--- a/app/dashboard/references/page.tsx
+++ b/app/dashboard/references/page.tsx
@@ -87,9 +87,7 @@ export default async function ReferencesHubPage() {
     ? filterReferencesForSales(dashboard.references)
     : dashboard.references
 
-  const orgDateDisplayFormat = normalizeOrgDateDisplayFormat(
-    (orgRow as { date_display_format?: string | null } | null)?.date_display_format,
-  )
+  const orgDateDisplayFormat = normalizeOrgDateDisplayFormat(orgRow?.date_display_format)
 
   const complianceDocuments = complianceListed.success ? complianceListed.rows : []
 

--- a/app/p/actions.ts
+++ b/app/p/actions.ts
@@ -2,6 +2,8 @@
 
 import { revalidatePath } from 'next/cache'
 import { cookies, headers } from 'next/headers'
+import { createHash } from 'crypto'
+import type { Json } from '@/lib/database.types'
 import { createServerSupabaseClient } from '@/lib/supabase/server'
 import { nullToUndefined } from '@/lib/supabase/db-types'
 import { createServiceRoleSupabaseClient } from '@/lib/supabase/service-role'
@@ -10,7 +12,6 @@ import { ROUTES } from '@/lib/routes'
 import { publicPortfolioUnlockCookieName } from '@/lib/public-portfolio-cookie'
 import { log } from '@/lib/observability/logger'
 import { writeAuditLog } from '@/lib/audit/log-audit'
-import { createHash } from 'crypto'
 
 /** Referenz-Objekt wie von get_public_portfolio RPC zurückgegeben (kompatibel mit ReferenceRow) */
 export type PublicReference = {
@@ -89,6 +90,91 @@ export type PublicShareOwner =
     }
   | { found: false }
 
+/** RPC-Returns sind `Json` — Record-Guard statt Row-Cast. */
+function rpcRecord(data: Json | null | undefined): Record<string, unknown> | null {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return null
+  return data as Record<string, unknown>
+}
+
+function rpcString(obj: Record<string, unknown>, key: string): string | undefined {
+  const v = obj[key]
+  return typeof v === 'string' ? v : undefined
+}
+
+function rpcBool(obj: Record<string, unknown>, key: string): boolean | undefined {
+  const v = obj[key]
+  return typeof v === 'boolean' ? v : undefined
+}
+
+function rpcNumber(obj: Record<string, unknown>, key: string): number | undefined {
+  const v = obj[key]
+  return typeof v === 'number' && Number.isFinite(v) ? v : undefined
+}
+
+function rpcNullableString(
+  obj: Record<string, unknown>,
+  key: string,
+): string | null | undefined {
+  const v = obj[key]
+  if (v === null) return null
+  return typeof v === 'string' ? v : undefined
+}
+
+function parsePublicReferences(raw: unknown): PublicReference[] {
+  if (!Array.isArray(raw)) return []
+  const out: PublicReference[] = []
+  for (const item of raw) {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) continue
+    const r = item as Record<string, unknown>
+    const id = typeof r.id === 'string' ? r.id : ''
+    if (!id) continue
+    out.push({
+      id,
+      title: typeof r.title === 'string' ? r.title : '',
+      summary: typeof r.summary === 'string' ? r.summary : null,
+      industry: typeof r.industry === 'string' ? r.industry : null,
+      country: typeof r.country === 'string' ? r.country : null,
+      status: typeof r.status === 'string' ? r.status : '',
+      company_name: typeof r.company_name === 'string' ? r.company_name : '',
+      company_logo_url: typeof r.company_logo_url === 'string' ? r.company_logo_url : null,
+      website: typeof r.website === 'string' ? r.website : null,
+      employee_count:
+        typeof r.employee_count === 'number' && Number.isFinite(r.employee_count)
+          ? r.employee_count
+          : null,
+      volume_eur: typeof r.volume_eur === 'string' ? r.volume_eur : null,
+      contract_type: typeof r.contract_type === 'string' ? r.contract_type : null,
+      incumbent_provider:
+        typeof r.incumbent_provider === 'string' ? r.incumbent_provider : null,
+      competitors: typeof r.competitors === 'string' ? r.competitors : null,
+      customer_challenge:
+        typeof r.customer_challenge === 'string' ? r.customer_challenge : null,
+      our_solution: typeof r.our_solution === 'string' ? r.our_solution : null,
+      tags: typeof r.tags === 'string' ? r.tags : null,
+      project_status: typeof r.project_status === 'string' ? r.project_status : null,
+      project_start: typeof r.project_start === 'string' ? r.project_start : null,
+      project_end: typeof r.project_end === 'string' ? r.project_end : null,
+      duration_months:
+        typeof r.duration_months === 'number' && Number.isFinite(r.duration_months)
+          ? r.duration_months
+          : null,
+      approval_quote_approved:
+        typeof r.approval_quote_approved === 'string' ? r.approval_quote_approved : null,
+      approval_reference_giver_name:
+        typeof r.approval_reference_giver_name === 'string'
+          ? r.approval_reference_giver_name
+          : null,
+      approval_token:
+        typeof r.approval_token === 'string'
+          ? r.approval_token
+          : r.approval_token === null
+            ? null
+            : undefined,
+    })
+  }
+  return out
+}
+
 async function getUnlockTokenForSlug(slug: string): Promise<string | null> {
   const jar = await cookies()
   const v = jar.get(publicPortfolioUnlockCookieName(slug))?.value
@@ -110,34 +196,30 @@ export async function getPublicPortfolio(
     ),
   })
   if (error) return { found: false, reason: 'not_found' }
-  const payload = data as {
-    access?: string
-    reason?: string
-    slug?: string
-    found?: boolean
-    view_count?: number
-    references?: PublicReference[]
-  } | null
+  const payload = rpcRecord(data)
+  if (!payload) return { found: false, reason: 'not_found' }
 
-  if (payload?.access === 'denied') {
-    const r = payload.reason === 'expired' ? 'expired' : 'not_found'
+  const access = rpcString(payload, 'access')
+  if (access === 'denied') {
+    const r = rpcString(payload, 'reason') === 'expired' ? 'expired' : 'not_found'
     return { found: false, reason: r }
   }
-  if (payload?.access === 'locked') {
-    const gm = (payload as { gate_mode?: string }).gate_mode
+  if (access === 'locked') {
+    const gm = rpcString(payload, 'gate_mode')
     const gateMode =
       gm === 'email' ? 'email' : gm === 'password' ? 'password' : ('password' as const)
-    return { found: false, reason: 'locked', slug: payload.slug, gateMode }
+    return { found: false, reason: 'locked', slug: rpcString(payload, 'slug'), gateMode }
   }
-  if (payload?.access !== 'ok' || !payload.slug) {
+  const portfolioSlug = rpcString(payload, 'slug')
+  if (access !== 'ok' || !portfolioSlug) {
     return { found: false, reason: 'not_found' }
   }
   return {
     found: true,
-    slug: payload.slug,
-    view_count: payload.view_count ?? 0,
-    canDeactivate: Boolean((payload as { can_deactivate?: boolean }).can_deactivate),
-    references: Array.isArray(payload.references) ? payload.references : [],
+    slug: portfolioSlug,
+    view_count: rpcNumber(payload, 'view_count') ?? 0,
+    canDeactivate: Boolean(rpcBool(payload, 'can_deactivate')),
+    references: parsePublicReferences(payload.references),
   }
 }
 
@@ -174,20 +256,16 @@ export async function getPublicPortfolioBranding(
     p_unlock_token: nullToUndefined(token),
   })
   if (error) return { found: false }
-  const payload = data as {
-    found?: boolean
-    name?: string
-    logo_url?: string | null
-    primary_color?: string
-    secondary_color?: string
-  } | null
-  if (!payload?.found || !payload.name) return { found: false }
+  const payload = rpcRecord(data)
+  if (!payload || !rpcBool(payload, 'found')) return { found: false }
+  const name = rpcString(payload, 'name')
+  if (!name) return { found: false }
   return {
     found: true,
-    name: payload.name,
-    logo_url: payload.logo_url ?? null,
-    primary_color: payload.primary_color ?? '#2563EB',
-    secondary_color: payload.secondary_color ?? '#1D4ED8',
+    name,
+    logo_url: rpcNullableString(payload, 'logo_url') ?? null,
+    primary_color: rpcString(payload, 'primary_color') ?? '#2563EB',
+    secondary_color: rpcString(payload, 'secondary_color') ?? '#1D4ED8',
   }
 }
 
@@ -201,24 +279,19 @@ export async function getPublicPortfolioShareOwner(
     p_unlock_token: nullToUndefined(token),
   })
   if (error) return { found: false }
-  const payload = data as {
-    found?: boolean
-    name?: string
-    position?: string
-    avatar_url?: string | null
-    email?: string | null
-    phone?: string | null
-    booking_url?: string | null
-  } | null
-  if (!payload?.found || !payload.name) return { found: false }
+  const payload = rpcRecord(data)
+  if (!payload || !rpcBool(payload, 'found')) return { found: false }
+  const name = rpcString(payload, 'name')
+  if (!name) return { found: false }
+  const booking = rpcNullableString(payload, 'booking_url')
   return {
     found: true,
-    name: payload.name,
-    position: payload.position ?? 'Sales Ansprechpartner',
-    avatar_url: payload.avatar_url ?? null,
-    email: payload.email ?? null,
-    phone: payload.phone ?? null,
-    booking_url: payload.booking_url?.trim() ? payload.booking_url.trim() : null,
+    name,
+    position: rpcString(payload, 'position') ?? 'Sales Ansprechpartner',
+    avatar_url: rpcNullableString(payload, 'avatar_url') ?? null,
+    email: rpcNullableString(payload, 'email') ?? null,
+    phone: rpcNullableString(payload, 'phone') ?? null,
+    booking_url: booking?.trim() ? booking.trim() : null,
   }
 }
 
@@ -252,17 +325,16 @@ async function getUnlockAuditContext(
     .eq('slug', slug)
     .limit(1)
     .maybeSingle()
-  const referenceId =
-    data && Array.isArray((data as { reference_ids?: unknown }).reference_ids)
-      ? ((data as { reference_ids: string[] }).reference_ids[0] ?? null)
-      : null
+  const referenceId = Array.isArray(data?.reference_ids)
+    ? (data.reference_ids[0] ?? null)
+    : null
   if (!referenceId) return { orgId: null, referenceId: null }
   const { data: ref } = await supabase
     .from('references')
     .select('organization_id')
     .eq('id', referenceId)
     .single()
-  return { orgId: (ref?.organization_id as string | null) ?? null, referenceId }
+  return { orgId: ref?.organization_id ?? null, referenceId }
 }
 
 /** Kundenansicht: Passwort prüfen und Session-Cookie setzen (ohne Login). */
@@ -311,8 +383,9 @@ export async function unlockPublicPortfolio(
     p_password: password,
   })
   if (error) return { success: false, error: 'unknown' }
-  const payload = data as { success?: boolean; token?: string; error?: string } | null
-  if (!payload?.success || !payload.token) {
+  const payload = rpcRecord(data)
+  const token = payload ? rpcString(payload, 'token') : undefined
+  if (!payload || !rpcBool(payload, 'success') || !token) {
     if (ipHash) {
       await supabase.from('portfolio_unlock_attempts').insert({
         slug,
@@ -331,7 +404,7 @@ export async function unlockPublicPortfolio(
         ip_hash: ipHash ?? null,
       },
     })
-    const e = payload?.error
+    const e = payload ? rpcString(payload, 'error') : undefined
     if (e === 'expired') return { success: false, error: 'expired' }
     if (e === 'invalid_password') return { success: false, error: 'invalid_password' }
     if (e === 'no_password_required')
@@ -340,16 +413,16 @@ export async function unlockPublicPortfolio(
     return { success: false, error: 'unknown' }
   }
 
-  const maxAgeRaw = (payload as { max_age_seconds?: number }).max_age_seconds
+  const maxAgeRaw = rpcNumber(payload, 'max_age_seconds')
   const maxAgeSec =
-    typeof maxAgeRaw === 'number' && Number.isFinite(maxAgeRaw)
+    typeof maxAgeRaw === 'number'
       ? Math.max(60, Math.min(2592000, Math.trunc(maxAgeRaw)))
       : 86400
 
   const jar = await cookies()
   const name = publicPortfolioUnlockCookieName(slug)
 
-  jar.set(name, payload.token, {
+  jar.set(name, token, {
     httpOnly: true,
     sameSite: 'lax',
     secure: process.env.NODE_ENV === 'production',
@@ -402,31 +475,25 @@ export async function getPublicPortfolioManageInsights(
     p_reference_id: referenceId?.trim() || undefined,
   })
   if (error) return { found: false }
-  const payload = data as {
-    found?: boolean
-    view_count?: number
-    link_expires_at?: string | null
-    approval_responded_at?: string | null
-    is_anonymous?: boolean | null
-    last_view?: {
-      country_code?: string | null
-      active_seconds?: number
-      started_at?: string
-    } | null
-  } | null
-  if (!payload?.found) return { found: false }
-  const lv = payload.last_view
+  const payload = rpcRecord(data)
+  if (!payload || !rpcBool(payload, 'found')) return { found: false }
+  const lvRaw = payload.last_view
+  const lv =
+    lvRaw && typeof lvRaw === 'object' && !Array.isArray(lvRaw)
+      ? (lvRaw as Record<string, unknown>)
+      : null
+  const startedAt = lv ? rpcString(lv, 'started_at') : undefined
   return {
     found: true,
     viewCount: Number(payload.view_count) || 0,
-    linkExpiresAt: payload.link_expires_at ?? null,
-    approvalRespondedAt: payload.approval_responded_at ?? null,
-    isAnonymous: typeof payload.is_anonymous === 'boolean' ? payload.is_anonymous : null,
-    lastView: lv?.started_at
+    linkExpiresAt: rpcNullableString(payload, 'link_expires_at') ?? null,
+    approvalRespondedAt: rpcNullableString(payload, 'approval_responded_at') ?? null,
+    isAnonymous: rpcBool(payload, 'is_anonymous') ?? null,
+    lastView: startedAt
       ? {
-          countryCode: lv.country_code ?? null,
-          activeSeconds: Number(lv.active_seconds) || 0,
-          startedAt: String(lv.started_at),
+          countryCode: rpcNullableString(lv!, 'country_code') ?? null,
+          activeSeconds: Number(lv!.active_seconds) || 0,
+          startedAt,
         }
       : null,
   }
@@ -443,22 +510,16 @@ export async function resolvePublicPortfolioRecipient(
     p_token: token.trim(),
   })
   if (error) return { found: false }
-  const payload = data as {
-    found?: boolean
-    recipient_id?: string
-    label?: string
-    company_id?: string | null
-    company_name?: string | null
-    company_logo_url?: string | null
-  } | null
-  if (!payload?.found || !payload.recipient_id) return { found: false }
+  const payload = rpcRecord(data)
+  const recipientId = payload ? rpcString(payload, 'recipient_id') : undefined
+  if (!payload || !rpcBool(payload, 'found') || !recipientId) return { found: false }
   return {
     found: true,
-    recipientId: payload.recipient_id,
-    label: payload.label ?? '',
-    companyId: payload.company_id ?? null,
-    companyName: payload.company_name ?? null,
-    companyLogoUrl: payload.company_logo_url ?? null,
+    recipientId,
+    label: rpcString(payload, 'label') ?? '',
+    companyId: rpcNullableString(payload, 'company_id') ?? null,
+    companyName: rpcNullableString(payload, 'company_name') ?? null,
+    companyLogoUrl: rpcNullableString(payload, 'company_logo_url') ?? null,
   }
 }
 
@@ -475,29 +536,23 @@ export async function unlockPublicPortfolioEmail(
     p_email: email,
   })
   if (error) return { success: false, error: 'unknown' }
-  const payload = data as {
-    success?: boolean
-    token?: string
-    error?: string
-    max_age_seconds?: number
-    visitor_name?: string
-    visitor_email?: string
-  } | null
-  if (!payload?.success || !payload.token) {
-    const e = payload?.error
+  const payload = rpcRecord(data)
+  const unlockToken = payload ? rpcString(payload, 'token') : undefined
+  if (!payload || !rpcBool(payload, 'success') || !unlockToken) {
+    const e = payload ? rpcString(payload, 'error') : undefined
     if (e === 'expired') return { success: false, error: 'expired' }
     if (e === 'not_found') return { success: false, error: 'not_found' }
     return { success: false, error: 'unknown' }
   }
 
-  const maxAgeRaw = payload.max_age_seconds
+  const maxAgeRaw = rpcNumber(payload, 'max_age_seconds')
   const maxAgeSec =
-    typeof maxAgeRaw === 'number' && Number.isFinite(maxAgeRaw)
+    typeof maxAgeRaw === 'number'
       ? Math.max(60, Math.min(2592000, Math.trunc(maxAgeRaw)))
       : 604800
 
   const jar = await cookies()
-  jar.set(publicPortfolioUnlockCookieName(slug), payload.token, {
+  jar.set(publicPortfolioUnlockCookieName(slug), unlockToken, {
     httpOnly: true,
     sameSite: 'lax',
     secure: process.env.NODE_ENV === 'production',
@@ -507,7 +562,10 @@ export async function unlockPublicPortfolioEmail(
 
   jar.set(
     `portfolio_email_gate_${slug}`,
-    JSON.stringify({ name: payload.visitor_name, email: payload.visitor_email }),
+    JSON.stringify({
+      name: rpcNullableString(payload, 'visitor_name'),
+      email: rpcNullableString(payload, 'visitor_email'),
+    }),
     {
       httpOnly: true,
       sameSite: 'lax',

--- a/docs/tech-debt-offen-backlog.md
+++ b/docs/tech-debt-offen-backlog.md
@@ -10,8 +10,8 @@
 
 | Status | Themen |
 |--------|--------|
-| **Erledigt** | Inventar-Hygiene (#0); E4 Hotspot-Audit (#1); E7 Schema-Sync (#2); **P1-6** Accounts Naming App/Lib (#4); Welle-5 Rollen (Invite/`AppRole`/Mapping); Typed-Supabase **Accounts** + **Deals** + References **Slice 1–5** + Settings **Slice 1** (Page/Profile/MS-Manage/Invites) |
-| **In Arbeit** | Typed-Supabase Cast-Abbau (#3) — weitere Domänen (Notifications/Match/DealDesk/…) |
+| **Erledigt** | Inventar-Hygiene (#0); E4 Hotspot-Audit (#1); E7 Schema-Sync (#2); **P1-6** Accounts Naming App/Lib (#4); Welle-5 Rollen (Invite/`AppRole`/Mapping); Typed-Supabase **Accounts** + **Deals** + References **1–5** + Settings **1** + Shared Portfolio **1** + Deal-Desk/Notifications Quick Wins |
+| **In Arbeit** | Typed-Supabase Cast-Abbau (#3) — Rest-Domänen (Market Signals / Command Center / Cron) + **T4** |
 | **Offen (Queue)** | #3 Rest · #5 God-Files (Boy-Scout) · #6 `{ ok }` → `{ success }` (Boy-Scout) · #7 DE/EN-Dateinamen (Boy-Scout) · #8 `references`/`evidence` Rename · #9 Invite-SQL-Kosmetik (optional) |
 | **Geparkt** | Pilot (H3/E1/G2); Massen-Renames; produktweite `evidence`↔`references`-Entscheidung |
 
@@ -26,7 +26,7 @@
 | **0** | Inventar-Hygiene | ✅ | — | — | — |
 | **1** | E4 Service-Role | ✅ Audit + Hotspots | Boy-Scout: Kommentar an neuen Service-Role-Callern | XS ongoing | bei Touch |
 | **2** | E7 Schema-Sync | ✅ T1–T4 | Types bei Migrationen regenerieren (`db:types`) | XS ongoing | bei Schema-Change |
-| **3** | Typed-Supabase Cast-Abbau | **🟡 aktiv** | Notifications / Match / DealDesk / Shared; zuletzt **T4** CI-Gate | L | Notifications Inbox oder Match nach Cast-Count |
+| **3** | Typed-Supabase Cast-Abbau | **🟡 aktiv** | Market Signals / Command Center / Cron / Register-RPC; zuletzt **T4** CI-Gate | M | Market-Signals Instant Alerts oder T4-Check |
 | **4** | P1-6 Accounts Naming | ✅ App/Lib | DB-Tabelle `companies` / `company_id` / Firmennamen-Helfer **bewusst offen** | — | nicht anfassen ohne Produktentscheid |
 | **5** | God-File-Nacharbeit | offen (Boy-Scout) | Overview / Share-Link / MS-Feed weiter slicen **nur bei Feature-Touch** | M ongoing | kein eigener Big-Bang-PR |
 | **6** | `{ ok }` → `{ success }` | offen (Boy-Scout) | ~130 Matches in Libs/Cron | S–M | bei Lib-Berührung mitziehen |
@@ -46,16 +46,19 @@
 |--------|-------|------------------------|
 | Accounts | ✅ Slices 1–4 | wenig: CRM-JSON, External-Contacts-Fallback, Error-Shapes |
 | Deals | ✅ Slices 1–2 | wenig: Eligibility/JSON-API-Responses (bewusst) |
-| References | ✅ Slice 1–5 | Rest-Hotspots vereinzelt (Dashboard-Fallback, trash RPC, Quote/JSON-APIs) |
-| Settings | ✅ Slice 1 | Stripe/HubSpot/Push-JSON bewusst; ggf. Rest-Actions Boy-Scout |
-| Andere | offen | Notifications, Match, DealDesk, Command-Center, Shared Portfolio, … |
+| References | ✅ Slice 1–5 | Rest vereinzelt (trash/Quote/JSON); Page date_format ✅ |
+| Settings | ✅ Slice 1 | Stripe/HubSpot/Push-JSON bewusst |
+| Shared Portfolio | ✅ Slice 1 | `app/p/actions` RPC-Json-Guards |
+| Deal-Desk | ✅ Quick | workspace-persistence typed; page redirect |
+| Notifications | ✅ Quick | Inbox org/champion rows |
+| Andere | offen | Market Signals, Command Center, Cron Digests, Onboarding/Register RPC |
 | **T4 CI** | offen | `typecheck` in CI **scharf**, wenn Domänen-Casts weitgehend weg / typecheck stabil 0 |
 
 **Empfohlene nächsten PRs (klein halten):**
 
-1. Notifications Inbox (org/profile row casts) oder Match nach Cast-Count  
-2. Typed-Supabase **T4** — CI-`typecheck`-Gate  
-3. Optional: References-Rest / Settings-HTTP-JSON nur Boy-Scout
+1. Market Signals Instant Alerts / Champion-Display Casts  
+2. Typed-Supabase **T4** — CI-`typecheck`-Gate (wenn Rest ruhig)  
+3. Optional: Command Center / Cron Boy-Scout
 
 ---
 
@@ -98,7 +101,7 @@ Bei Feature-PRs mitnehmen, **kein** Massen-PR:
 | P1-6 | ✅ App/Lib; DB `companies` bleibt |
 | E4 / E7 | ✅ |
 | E6 Logger | ✅ App/Lib; Sink/Scripts bewusst |
-| Typed-Supabase T3 | 🟡 aktiv (Accounts/Deals/References/Settings ✅; andere Domänen offen) |
+| Typed-Supabase T3 | 🟡 aktiv (Kern-Domänen weitgehend ✅; Market Signals/CC/Cron Rest) |
 | Typed-Supabase T4 | offen (nach T3-Ruhe) |
 | Welle 5 T3 Paths | → Queue #8 |
 | Welle 5 T4 `workspace_state` | vor Start erneut `grep`en |

--- a/lib/deal-desk/workspace-persistence.ts
+++ b/lib/deal-desk/workspace-persistence.ts
@@ -1,6 +1,7 @@
 import 'server-only'
 
 import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '@/lib/database.types'
 
 import type { BidTeamAssignment, DealDeskRedFlag } from '@/lib/deal-desk/mock-analysis'
 import type { DealDeskSmeAssignment } from '@/lib/deal-desk/sme-routing'
@@ -11,6 +12,8 @@ import {
   type NormalizedWorkspaceOverlay,
 } from '@/lib/deal-desk/workspace-merge'
 import { log } from '@/lib/observability/logger'
+
+type DbClient = SupabaseClient<Database>
 
 function isProfileUuid(value: string | null | undefined): value is string {
   if (!value?.trim()) return false
@@ -32,7 +35,7 @@ function isMissingNormalizedTableError(message: string | undefined): boolean {
 }
 
 export async function loadNormalizedWorkspaceOverlaysBatch(
-  supabase: SupabaseClient,
+  supabase: DbClient,
   projectIds: string[],
   organizationId: string,
 ): Promise<Map<string, NormalizedWorkspaceOverlay>> {
@@ -71,33 +74,29 @@ export async function loadNormalizedWorkspaceOverlaysBatch(
   }
 
   for (const row of projectsRes.data ?? []) {
-    const id = String((row as { id: string }).id)
-    const decision = bidDecisionFromDb(
-      (row as { bid_decision?: string | null }).bid_decision,
-    )
-    if (decision) map.set(id, { ...(map.get(id) ?? {}), decision })
+    const decision = bidDecisionFromDb(row.bid_decision)
+    if (decision) map.set(row.id, { ...(map.get(row.id) ?? {}), decision })
   }
 
   for (const row of flagsRes.data ?? []) {
-    const projectId = String((row as { project_id: string }).project_id)
+    const projectId = row.project_id
     const cur = map.get(projectId) ?? {}
     const flags = cur.redFlags ?? []
     flags.push({
-      id: String((row as { flag_key?: string | null }).flag_key ?? row.id),
-      severity: ((row as { severity?: string }).severity ??
-        'medium') as DealDeskRedFlag['severity'],
-      title: String((row as { label?: string }).label ?? 'Red Flag'),
+      id: String(row.flag_key ?? row.id),
+      severity: (row.severity ?? 'medium') as DealDeskRedFlag['severity'],
+      title: String(row.label ?? 'Red Flag'),
       excerpt: '',
-      markedForLegal: Boolean((row as { sent_to_legal?: boolean }).sent_to_legal),
+      markedForLegal: Boolean(row.sent_to_legal),
     })
     map.set(projectId, { ...cur, redFlags: flags })
   }
 
   for (const row of smeRes.data ?? []) {
-    const projectId = String((row as { project_id: string }).project_id)
+    const projectId = row.project_id
     const cur = map.get(projectId) ?? {}
-    const key = String((row as { requirement_key: string }).requirement_key)
-    const profileId = (row as { assignee_profile_id?: string | null }).assignee_profile_id
+    const key = row.requirement_key
+    const profileId = row.assignee_profile_id
     const smeRoutes = { ...(cur.smeRoutes ?? {}), [key]: 'routed' }
     const smeAssignments: Record<string, DealDeskSmeAssignment> = {
       ...(cur.smeAssignments ?? {}),
@@ -113,11 +112,11 @@ export async function loadNormalizedWorkspaceOverlaysBatch(
   }
 
   for (const row of bidRes.data ?? []) {
-    const projectId = String((row as { project_id: string }).project_id)
+    const projectId = row.project_id
     const cur = map.get(projectId) ?? {}
     const team = cur.bidTeam ?? []
-    const role = String((row as { role?: string | null }).role ?? `member_${team.length}`)
-    const profileId = (row as { profile_id?: string | null }).profile_id
+    const role = String(row.role ?? `member_${team.length}`)
+    const profileId = row.profile_id
     team.push({
       role: role as BidTeamAssignment['role'],
       label: role,
@@ -131,7 +130,7 @@ export async function loadNormalizedWorkspaceOverlaysBatch(
 }
 
 export async function loadNormalizedWorkspaceOverlay(
-  supabase: SupabaseClient,
+  supabase: DbClient,
   projectId: string,
   organizationId: string,
 ): Promise<NormalizedWorkspaceOverlay | null> {
@@ -144,7 +143,7 @@ export async function loadNormalizedWorkspaceOverlay(
 }
 
 export async function persistNormalizedWorkspace(
-  supabase: SupabaseClient,
+  supabase: DbClient,
   projectId: string,
   organizationId: string,
   workspace: DealDeskWorkspaceState,


### PR DESCRIPTION
## Summary
- Replace `app/p/actions` RPC row casts with Json record/reference guards
- Type Deal-Desk workspace persistence via `SupabaseClient<Database>`
- Quick wins: notifications inbox, deal-desk redirect, approval company join, references date format
- Backlog updated for Shared Portfolio / Deal-Desk / Notifications

## Test plan
- [x] `npm run typecheck`
- [ ] Spot-check public portfolio unlock/load if convenient

Made with [Cursor](https://cursor.com)