### PR TITLE
refactor(market-signals): typed Supabase cast abbau slice 1

### DIFF
--- a/app/api/cron/market-signals-digest/route.ts
+++ b/app/api/cron/market-signals-digest/route.ts
@@ -124,22 +124,20 @@ export async function GET(request: Request) {
   const errors: string[] = []
 
   for (const row of subscribers) {
-    const userId = String((row as { id?: string }).id ?? '')
-    const orgId = String(
-      (row as { organization_id?: string | null }).organization_id ?? '',
-    )
+    const userId = row.id
+    const orgId = row.organization_id ?? ''
     if (!userId || !orgId) continue
 
-    const nsRaw = (row as { notification_settings?: unknown }).notification_settings
+    const nsRaw = row.notification_settings
 
     if (!skipDigestTimeWindow) {
       const tz = parseDigestTimezone(
-        nsRaw && typeof nsRaw === 'object'
+        nsRaw && typeof nsRaw === 'object' && !Array.isArray(nsRaw)
           ? (nsRaw as Record<string, unknown>).digest_timezone
           : undefined,
       )
       const { hours: dh, minutes: dm } = parseDigestLocalTime(
-        nsRaw && typeof nsRaw === 'object'
+        nsRaw && typeof nsRaw === 'object' && !Array.isArray(nsRaw)
           ? (nsRaw as Record<string, unknown>).digest_local_time
           : undefined,
       )
@@ -154,7 +152,7 @@ export async function GET(request: Request) {
       : getLocalYmdAndMinutesFromMidnight(
           now,
           parseDigestTimezone(
-            nsRaw && typeof nsRaw === 'object'
+            nsRaw && typeof nsRaw === 'object' && !Array.isArray(nsRaw)
               ? (nsRaw as Record<string, unknown>).digest_timezone
               : undefined,
           ),
@@ -187,9 +185,7 @@ export async function GET(request: Request) {
       continue
     }
 
-    const recipientName = String(
-      (row as { full_name?: string | null }).full_name ?? '',
-    ).trim()
+    const recipientName = String(row.full_name ?? '').trim()
     const hasContent = news.length > 0 || executives.length > 0
 
     const html = hasContent

--- a/app/dashboard/market-signals/data.ts
+++ b/app/dashboard/market-signals/data.ts
@@ -1,5 +1,6 @@
 import 'server-only'
 
+import { accountFromJoin } from '@/lib/accounts/account-from-join'
 import { isMissingEnrichmentColumnsError } from '@/lib/market-signals/enrichment-db'
 import { isActiveDealStatus } from '@/lib/deals/normalize-deal-status'
 import { createServerSupabaseClient } from '@/lib/supabase/server'
@@ -334,16 +335,14 @@ export async function loadMarketSignalsPageData(): Promise<MarketSignalsPageMode
 
   const executives: ExecutiveTrackingRow[] = (execRows ?? []).map(
     (row: Record<string, unknown>) => {
-      const co = Array.isArray(row.companies)
-        ? (row.companies as { name?: string; logo_url?: string | null }[])[0]
-        : (row.companies as { name?: string; logo_url?: string | null } | null)
+      const co = accountFromJoin(row.companies)
       const ek = String(row.event_kind ?? 'role_change')
       return {
         id: String(row.id),
         companyId: String(row.company_id),
-        companyName: co?.name?.trim() ? String(co.name) : '—',
+        companyName: co?.name?.trim() ? co.name : '—',
         companyLogoUrl:
-          (co?.logo_url as string | undefined) ??
+          co?.logoUrl ??
           companyMetaById.get(String(row.company_id))?.logoUrl ??
           null,
         personName: String(row.person_name ?? ''),
@@ -361,16 +360,14 @@ export async function loadMarketSignalsPageData(): Promise<MarketSignalsPageMode
   )
 
   const news: AccountNewsRow[] = (newsRows ?? []).map((row: Record<string, unknown>) => {
-    const co = Array.isArray(row.companies)
-      ? (row.companies as { name?: string; logo_url?: string | null }[])[0]
-      : (row.companies as { name?: string; logo_url?: string | null } | null)
+    const co = accountFromJoin(row.companies)
     const seg = String(row.segment ?? 'customer')
     return {
       id: String(row.id),
       companyId: String(row.company_id),
-      companyName: co?.name?.trim() ? String(co.name) : '—',
+      companyName: co?.name?.trim() ? co.name : '—',
       companyLogoUrl:
-        (co?.logo_url as string | undefined) ??
+        co?.logoUrl ??
         companyMetaById.get(String(row.company_id))?.logoUrl ??
         null,
       body: String(row.body ?? ''),

--- a/app/dashboard/market-signals/signal-inbox-impl.ts
+++ b/app/dashboard/market-signals/signal-inbox-impl.ts
@@ -53,7 +53,7 @@ async function getAuthedOrgContext() {
     supabase,
     user,
     orgId:
-      (profile as { organization_id?: string | null } | null)?.organization_id ?? null,
+      profile?.organization_id ?? null,
   }
 }
 
@@ -97,7 +97,7 @@ export async function addMarketSignalToDealImpl(args: {
     .select('organization_id')
     .eq('id', user.id)
     .single()
-  const orgId = (profile as { organization_id?: string | null } | null)?.organization_id
+  const orgId = profile?.organization_id
   if (!orgId) return { success: false, error: 'Keine Organisation gefunden' }
 
   const { count: dealCount, error: dealErr } = await supabase

--- a/app/dashboard/market-signals/signal-ingest-impl.ts
+++ b/app/dashboard/market-signals/signal-ingest-impl.ts
@@ -33,7 +33,7 @@ export async function triggerMarketSignalsIngestForMyOrgImpl(args?: {
     .eq('id', user.id)
     .maybeSingle()
 
-  const orgId = (profile as { organization_id?: string | null } | null)?.organization_id
+  const orgId = profile?.organization_id
   if (!orgId) return { success: false, error: 'Keine Organisation gefunden.' }
   const ingestMode: 'all_accounts' | 'focus_only' = args?.ingestMode ?? 'focus_only'
   const refreshFeeds = args?.refreshFeeds === true
@@ -147,7 +147,7 @@ export async function backfillMarketSignalEnrichmentForMyOrgImpl(args?: {
     .eq('id', user.id)
     .maybeSingle()
 
-  const orgId = (profile as { organization_id?: string | null } | null)?.organization_id
+  const orgId = profile?.organization_id
   if (!orgId) return { success: false, error: 'Keine Organisation gefunden.' }
 
   // Service-Role weil: LLM-Backfill liest/schreibt Signale org-weit.
@@ -205,7 +205,7 @@ export async function backfillCompanyNewsroomsForMyOrgImpl(args?: {
     .eq('id', user.id)
     .maybeSingle()
 
-  const orgId = (profile as { organization_id?: string | null } | null)?.organization_id
+  const orgId = profile?.organization_id
   if (!orgId) return { success: false, error: 'Keine Organisation gefunden.' }
 
   const force = Boolean(args?.force)
@@ -296,7 +296,7 @@ export async function updateCompanyNewsroomUrlsImpl(
     .select('organization_id')
     .eq('id', user.id)
     .maybeSingle()
-  const orgId = (profile as { organization_id?: string | null } | null)?.organization_id
+  const orgId = profile?.organization_id
   if (!orgId) return { success: false, error: 'Keine Organisation gefunden.' }
 
   const cleaned: string[] = []

--- a/app/dashboard/market-signals/signal-match-impl.ts
+++ b/app/dashboard/market-signals/signal-match-impl.ts
@@ -211,7 +211,7 @@ export async function getDecisionMakerCandidatesImpl(args: {
     .select('organization_id')
     .eq('id', user.id)
     .single()
-  const orgId = (profile as { organization_id?: string | null } | null)?.organization_id
+  const orgId = profile?.organization_id
   if (!orgId) return { success: false, error: 'Keine Organisation gefunden' }
 
   const { data: company } = await supabase
@@ -222,7 +222,7 @@ export async function getDecisionMakerCandidatesImpl(args: {
     .maybeSingle()
   if (!company) return { success: false, error: 'Account nicht gefunden' }
 
-  const companyName = String((company as { name?: string | null }).name ?? '').trim()
+  const companyName = String(company?.name ?? '').trim()
   if (!companyName) return { success: true, candidates: [] }
 
   const allRaw = await Promise.all(
@@ -303,7 +303,7 @@ export async function requestReferenceApprovalForSignalImpl(args: {
     .select('organization_id')
     .eq('id', user.id)
     .maybeSingle()
-  const orgId = (profile as { organization_id?: string | null } | null)?.organization_id
+  const orgId = profile?.organization_id
   if (!orgId) return { success: false, error: 'Keine Organisation gefunden.' }
 
   void writeAuditLog({

--- a/app/dashboard/market-signals/watchlist-impl.ts
+++ b/app/dashboard/market-signals/watchlist-impl.ts
@@ -22,7 +22,7 @@ export async function setCompanyWatchlistStateImpl(
     .select('organization_id')
     .eq('id', user.id)
     .maybeSingle()
-  const orgId = (profile as { organization_id?: string | null } | null)?.organization_id
+  const orgId = profile?.organization_id
   if (!orgId) return { success: false as const, error: 'Keine Organisation gefunden' }
 
   const { error } = await supabase
@@ -55,7 +55,7 @@ export async function setCompaniesWatchlistStateImpl(
     .select('organization_id')
     .eq('id', user.id)
     .maybeSingle()
-  const orgId = (profile as { organization_id?: string | null } | null)?.organization_id
+  const orgId = profile?.organization_id
   if (!orgId) return { success: false as const, error: 'Keine Organisation gefunden' }
 
   const { error } = await supabase
@@ -88,7 +88,7 @@ export async function watchCompanyFromSuggestionImpl(input: {
     .select('organization_id')
     .eq('id', user.id)
     .maybeSingle()
-  const orgId = (profile as { organization_id?: string | null } | null)?.organization_id
+  const orgId = profile?.organization_id
   if (!orgId) return { success: false, error: 'Keine Organisation gefunden' }
 
   const suggestionId = input.id.trim()
@@ -202,7 +202,7 @@ export async function setChampionWatchlistStateImpl(
       .select('organization_id')
       .eq('id', user.id)
       .maybeSingle()
-    const orgId = (profile as { organization_id?: string | null } | null)?.organization_id
+    const orgId = profile?.organization_id
 
     let personTitle: string | null = null
     if (orgId) {

--- a/docs/tech-debt-offen-backlog.md
+++ b/docs/tech-debt-offen-backlog.md
@@ -10,8 +10,8 @@
 
 | Status | Themen |
 |--------|--------|
-| **Erledigt** | Inventar-Hygiene (#0); E4 Hotspot-Audit (#1); E7 Schema-Sync (#2); **P1-6** Accounts Naming App/Lib (#4); Welle-5 Rollen (Invite/`AppRole`/Mapping); Typed-Supabase **Accounts** + **Deals** + References **1–5** + Settings **1** + Shared Portfolio **1** + Deal-Desk/Notifications Quick Wins |
-| **In Arbeit** | Typed-Supabase Cast-Abbau (#3) — Rest-Domänen (Market Signals / Command Center / Cron) + **T4** |
+| **Erledigt** | Inventar-Hygiene (#0); E4 Hotspot-Audit (#1); E7 Schema-Sync (#2); **P1-6** Accounts Naming App/Lib (#4); Welle-5 Rollen (Invite/`AppRole`/Mapping); Typed-Supabase Kern-Domänen + Shared Portfolio + **Market Signals Slice 1** (Instant Alerts/Digest/Champion/Newsroom/MS-Actions) |
+| **In Arbeit** | Typed-Supabase Cast-Abbau (#3) — Rest (MS Ingest/Data-Detail, Command Center, Cron) + **T4** |
 | **Offen (Queue)** | #3 Rest · #5 God-Files (Boy-Scout) · #6 `{ ok }` → `{ success }` (Boy-Scout) · #7 DE/EN-Dateinamen (Boy-Scout) · #8 `references`/`evidence` Rename · #9 Invite-SQL-Kosmetik (optional) |
 | **Geparkt** | Pilot (H3/E1/G2); Massen-Renames; produktweite `evidence`↔`references`-Entscheidung |
 
@@ -26,7 +26,7 @@
 | **0** | Inventar-Hygiene | ✅ | — | — | — |
 | **1** | E4 Service-Role | ✅ Audit + Hotspots | Boy-Scout: Kommentar an neuen Service-Role-Callern | XS ongoing | bei Touch |
 | **2** | E7 Schema-Sync | ✅ T1–T4 | Types bei Migrationen regenerieren (`db:types`) | XS ongoing | bei Schema-Change |
-| **3** | Typed-Supabase Cast-Abbau | **🟡 aktiv** | Market Signals / Command Center / Cron / Register-RPC; zuletzt **T4** CI-Gate | M | Market-Signals Instant Alerts oder T4-Check |
+| **3** | Typed-Supabase Cast-Abbau | **🟡 aktiv** | MS Ingest/Executive Rest · Command Center · ggf. T4 | M | Market Signals Slice 2 (ingest) **oder** T4 CI-Gate |
 | **4** | P1-6 Accounts Naming | ✅ App/Lib | DB-Tabelle `companies` / `company_id` / Firmennamen-Helfer **bewusst offen** | — | nicht anfassen ohne Produktentscheid |
 | **5** | God-File-Nacharbeit | offen (Boy-Scout) | Overview / Share-Link / MS-Feed weiter slicen **nur bei Feature-Touch** | M ongoing | kein eigener Big-Bang-PR |
 | **6** | `{ ok }` → `{ success }` | offen (Boy-Scout) | ~130 Matches in Libs/Cron | S–M | bei Lib-Berührung mitziehen |
@@ -51,14 +51,15 @@
 | Shared Portfolio | ✅ Slice 1 | `app/p/actions` RPC-Json-Guards |
 | Deal-Desk | ✅ Quick | workspace-persistence typed; page redirect |
 | Notifications | ✅ Quick | Inbox org/champion rows |
-| Andere | offen | Market Signals, Command Center, Cron Digests, Onboarding/Register RPC |
+| Market Signals | ✅ Slice 1 | Instant Alerts, Digest, Champion, Newsroom, Action orgIds; data joins |
+| Andere | offen | MS Ingest/Executive Rest, Command Center, Register/Onboarding RPC |
 | **T4 CI** | offen | `typecheck` in CI **scharf**, wenn Domänen-Casts weitgehend weg / typecheck stabil 0 |
 
 **Empfohlene nächsten PRs (klein halten):**
 
-1. Market Signals Instant Alerts / Champion-Display Casts  
-2. Typed-Supabase **T4** — CI-`typecheck`-Gate (wenn Rest ruhig)  
-3. Optional: Command Center / Cron Boy-Scout
+1. Market Signals Slice 2 — Ingest/Executive-Intel Rest-Casts **oder**  
+2. Typed-Supabase **T4** — CI-`typecheck`-Gate  
+3. Optional: Command Center Boy-Scout
 
 ---
 
@@ -101,7 +102,7 @@ Bei Feature-PRs mitnehmen, **kein** Massen-PR:
 | P1-6 | ✅ App/Lib; DB `companies` bleibt |
 | E4 / E7 | ✅ |
 | E6 Logger | ✅ App/Lib; Sink/Scripts bewusst |
-| Typed-Supabase T3 | 🟡 aktiv (Kern-Domänen weitgehend ✅; Market Signals/CC/Cron Rest) |
+| Typed-Supabase T3 | 🟡 aktiv (Kern + MS Slice 1 ✅; Ingest/CC Rest) |
 | Typed-Supabase T4 | offen (nach T3-Ruhe) |
 | Welle 5 T3 Paths | → Queue #8 |
 | Welle 5 T4 `workspace_state` | vor Start erneut `grep`en |

--- a/lib/market-signals/champion-display.ts
+++ b/lib/market-signals/champion-display.ts
@@ -1,4 +1,5 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '@/lib/database.types'
 
 function normalizeKey(raw: string): string {
   return raw.trim().toLowerCase().replace(/\s+/g, ' ')
@@ -6,7 +7,7 @@ function normalizeKey(raw: string): string {
 
 /** Resolves a person title from org stakeholders and executive signal events. */
 export async function resolveChampionPersonTitle(
-  supabase: SupabaseClient,
+  supabase: SupabaseClient<Database>,
   orgId: string,
   personName: string,
   companyName?: string | null,
@@ -22,18 +23,15 @@ export async function resolveChampionPersonTitle(
     .select('id, name')
     .eq('organization_id', orgId)
     .limit(2000)
-  const companyIds = (companies ?? [])
-    .map((c) => String((c as { id?: string }).id ?? ''))
-    .filter(Boolean)
+  const companyIds = (companies ?? []).map((c) => c.id).filter(Boolean)
   if (companyIds.length === 0) return null
 
   const nameToCompanyId = new Map<string, string>()
   for (const c of companies ?? []) {
-    const id = String((c as { id?: string }).id ?? '')
-    const name = String((c as { name?: string | null }).name ?? '')
+    const name = String(c.name ?? '')
       .trim()
       .toLowerCase()
-    if (id && name) nameToCompanyId.set(name, id)
+    if (c.id && name) nameToCompanyId.set(name, c.id)
   }
 
   let preferredCompanyId: string | null = null
@@ -57,11 +55,9 @@ export async function resolveChampionPersonTitle(
     .limit(2000)
 
   const stakeholderMatches = (stakeholders ?? []).filter((row) => {
-    const nameKey = normalizeKey(String((row as { name?: string }).name ?? ''))
-    return (
-      nameKey === key && String((row as { title?: string | null }).title ?? '').trim()
-    )
-  }) as Array<{ name: string; title: string | null; company_id: string | null }>
+    const nameKey = normalizeKey(String(row.name ?? ''))
+    return nameKey === key && Boolean(String(row.title ?? '').trim())
+  })
 
   if (preferredCompanyId) {
     const atCompany = stakeholderMatches.find(
@@ -81,12 +77,7 @@ export async function resolveChampionPersonTitle(
     .order('detected_at', { ascending: false })
     .limit(20)
 
-  const eventRows = (events ?? []) as Array<{
-    person_name: string
-    person_title_after: string | null
-    person_title_before: string | null
-    company_id: string
-  }>
+  const eventRows = events ?? []
 
   const preferredEvent = preferredCompanyId
     ? eventRows.find((row) => row.company_id === preferredCompanyId)

--- a/lib/market-signals/discover-company-newsroom.ts
+++ b/lib/market-signals/discover-company-newsroom.ts
@@ -1,4 +1,5 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '@/lib/database.types'
 import { log } from '@/lib/observability/logger'
 
 const PROBE_TIMEOUT_MS = 2_500
@@ -122,7 +123,7 @@ export async function discoverCompanyNewsroomUrls(
 }
 
 export async function discoverAndSaveCompanyNewsrooms(
-  supabase: SupabaseClient,
+  supabase: SupabaseClient<Database>,
   companyId: string,
   opts?: { websiteUrl?: string | null; force?: boolean },
 ): Promise<{ urls: string[]; error?: string }> {
@@ -137,16 +138,9 @@ export async function discoverAndSaveCompanyNewsrooms(
       .eq('id', id)
       .maybeSingle()
     if (error) return { urls: [], error: error.message }
-    websiteUrl =
-      websiteUrl ?? (data as { website_url?: string | null } | null)?.website_url ?? null
-    if (
-      !opts?.force &&
-      data &&
-      (data as { newsroom_discovered_at?: string | null }).newsroom_discovered_at
-    ) {
-      const existing = (
-        (data as { newsroom_urls?: string[] | null }).newsroom_urls ?? []
-      ).filter(Boolean)
+    websiteUrl = websiteUrl ?? data?.website_url ?? null
+    if (!opts?.force && data?.newsroom_discovered_at) {
+      const existing = (data.newsroom_urls ?? []).filter(Boolean)
       return { urls: existing }
     }
   }
@@ -234,7 +228,7 @@ export function isStoredNewsroomHost(
 
 /** Fire-and-forget wrapper for create/import hooks. */
 export function scheduleCompanyNewsroomDiscovery(
-  supabase: SupabaseClient,
+  supabase: SupabaseClient<Database>,
   companyId: string,
   websiteUrl?: string | null,
 ): void {

--- a/lib/market-signals/market-signals-digest.ts
+++ b/lib/market-signals/market-signals-digest.ts
@@ -1,9 +1,13 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '@/lib/database.types'
+import { accountFromJoin } from '@/lib/accounts/account-from-join'
 import { ROUTES } from '@/lib/routes'
 import { buildRefstackEmailHtml } from '@/lib/email/refstack-email-layout'
 import { isActiveDealStatus } from '@/lib/market-signals/ingest-company-news'
 import { isSystemAdmin } from '@/lib/roles/capability-access'
 import { parseProfileRoles } from '@/lib/roles/profile-roles'
+
+type DbClient = SupabaseClient<Database>
 
 export type MarketSignalsDigestRole = 'admin' | 'sales' | 'account_manager'
 
@@ -29,11 +33,8 @@ export type MarketSignalsDigestExecutive = {
   detectedAt: string
 }
 
-function companyNameFromRow(row: unknown): string {
-  const r = row as { companies?: { name?: string } | { name?: string }[] | null }
-  const c = r.companies
-  const one = Array.isArray(c) ? c[0] : c
-  return String(one?.name ?? 'Account')
+function companyNameFromRow(companies: unknown): string {
+  return accountFromJoin(companies)?.name ?? 'Account'
 }
 
 export function parseMarketSignalsDigestRole(raw: unknown): MarketSignalsDigestRole {
@@ -59,7 +60,7 @@ export function marketSignalsDigestRoleFromProfile(
 
 /** Favoriten (+ bei Admin/AM Accounts mit aktivem Deal) – gleiche Logik wie Digest/Inbox-Priorität. */
 export async function resolveAllowedCompanyIdsForMarketSignals(
-  supabase: SupabaseClient,
+  supabase: DbClient,
   organizationId: string,
   role: MarketSignalsDigestRole,
 ): Promise<Set<string>> {
@@ -72,8 +73,8 @@ export async function resolveAllowedCompanyIdsForMarketSignals(
   const dealCompanyIds = new Set<string>()
   if (!dealErr) {
     for (const row of dealRows ?? []) {
-      if (isActiveDealStatus((row as { status?: unknown }).status)) {
-        const id = String((row as { company_id?: string | null }).company_id ?? '')
+      if (isActiveDealStatus(row.status)) {
+        const id = row.company_id ?? ''
         if (id) dealCompanyIds.add(id)
       }
     }
@@ -90,9 +91,8 @@ export async function resolveAllowedCompanyIdsForMarketSignals(
 
   const favoriteIds = new Set<string>()
   for (const row of companyRows ?? []) {
-    if (Boolean((row as { is_favorite?: boolean | null }).is_favorite)) {
-      const id = String((row as { id?: string }).id ?? '')
-      if (id) favoriteIds.add(id)
+    if (Boolean(row.is_favorite)) {
+      favoriteIds.add(row.id)
     }
   }
 
@@ -112,7 +112,7 @@ export async function resolveAllowedCompanyIdsForMarketSignals(
  * Entspricht grob der Priorisierung in der Inbox (Sales nur Favoriten).
  */
 export async function loadMarketSignalsDigestForUser(
-  supabase: SupabaseClient,
+  supabase: DbClient,
   input: {
     organizationId: string
     role: MarketSignalsDigestRole
@@ -158,23 +158,21 @@ export async function loadMarketSignalsDigestForUser(
     .limit(40)
 
   const news: MarketSignalsDigestNews[] = (newsRows ?? []).map((row) => ({
-    id: String((row as { id?: string }).id ?? ''),
-    body: String((row as { body?: string }).body ?? '').trim(),
-    companyId: String((row as { company_id?: string }).company_id ?? ''),
-    companyName: companyNameFromRow(row),
-    publishedOn: String((row as { published_on?: string }).published_on ?? ''),
-    sourceLabel: ((row as { source_label?: string | null }).source_label ?? null) as
-      | string
-      | null,
+    id: row.id,
+    body: String(row.body ?? '').trim(),
+    companyId: row.company_id,
+    companyName: companyNameFromRow(row.companies),
+    publishedOn: row.published_on ?? '',
+    sourceLabel: row.source_label ?? null,
   }))
 
   const executives: MarketSignalsDigestExecutive[] = (execRows ?? []).map((row) => ({
-    id: String((row as { id?: string }).id ?? ''),
-    personName: String((row as { person_name?: string }).person_name ?? '').trim(),
-    summary: String((row as { change_summary?: string }).change_summary ?? '').trim(),
-    companyId: String((row as { company_id?: string }).company_id ?? ''),
-    companyName: companyNameFromRow(row),
-    detectedAt: String((row as { detected_at?: string }).detected_at ?? ''),
+    id: row.id,
+    personName: String(row.person_name ?? '').trim(),
+    summary: String(row.change_summary ?? '').trim(),
+    companyId: row.company_id,
+    companyName: companyNameFromRow(row.companies),
+    detectedAt: row.detected_at ?? '',
   }))
 
   return { news, executives }

--- a/lib/market-signals/market-signals-instant-alerts.ts
+++ b/lib/market-signals/market-signals-instant-alerts.ts
@@ -1,6 +1,8 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database, Json } from '@/lib/database.types'
 import { Resend } from 'resend'
 import webpush from 'web-push'
+import { accountFromJoin } from '@/lib/accounts/account-from-join'
 import { ROUTES } from '@/lib/routes'
 import {
   buildRefstackEmailHtml,
@@ -13,6 +15,8 @@ import {
   type MarketSignalsDigestExecutive,
   type MarketSignalsDigestNews,
 } from '@/lib/market-signals/market-signals-digest'
+
+type AdminClient = SupabaseClient<Database>
 
 function getResend(): Resend | null {
   const key = process.env.RESEND_API_KEY?.trim()
@@ -36,31 +40,29 @@ function ensureWebPushConfigured(): boolean {
   return true
 }
 
-function companyNameFromRow(row: unknown): string {
-  const r = row as { companies?: { name?: string } | { name?: string }[] | null }
-  const c = r.companies
-  const one = Array.isArray(c) ? c[0] : c
-  return String(one?.name ?? 'Account')
+function orgIdFromCompaniesJoin(companies: unknown): string {
+  const c = Array.isArray(companies) ? companies[0] : companies
+  if (!c || typeof c !== 'object') return ''
+  const oid = (c as { organization_id?: string | null }).organization_id
+  return typeof oid === 'string' ? oid : ''
 }
 
-function orgIdFromRow(row: unknown): string {
-  const r = row as {
-    companies?: { organization_id?: string } | { organization_id?: string }[] | null
-  }
-  const c = r.companies
-  const one = Array.isArray(c) ? c[0] : c
-  return String(one?.organization_id ?? '')
+function notificationSettingsRecord(
+  ns: Json | null | undefined,
+): Record<string, unknown> {
+  if (!ns || typeof ns !== 'object' || Array.isArray(ns)) return {}
+  return ns as Record<string, unknown>
 }
 
 async function companyIdsForOrganization(
-  admin: SupabaseClient,
+  admin: AdminClient,
   organizationId: string,
 ): Promise<string[]> {
   const { data } = await admin
     .from('companies')
     .select('id')
     .eq('organization_id', organizationId)
-  return (data ?? []).map((c) => String((c as { id?: string }).id ?? '')).filter(Boolean)
+  return (data ?? []).map((c) => c.id).filter(Boolean)
 }
 
 type OrgBucket = {
@@ -123,7 +125,7 @@ function buildInstantEmailHtml(input: {
  * Nach Ingest: gebündelte Sofort-E-Mail und/oder Web Push pro Nutzer (nur priorisierte Companies).
  */
 export async function notifyInstantMarketSignalsAfterIngest(
-  admin: SupabaseClient,
+  admin: AdminClient,
   opts: { sinceIso: string; organizationId?: string | null },
 ): Promise<{ emailed: number; pushed: number; skipped: boolean; errors: string[] }> {
   const { sinceIso, organizationId } = opts
@@ -168,30 +170,28 @@ export async function notifyInstantMarketSignalsAfterIngest(
   }
 
   for (const row of newsRows ?? []) {
-    const oid = orgIdFromRow(row)
+    const oid = orgIdFromCompaniesJoin(row.companies)
     if (!oid) continue
     bucket(oid).news.push({
-      id: String((row as { id?: string }).id ?? ''),
-      body: String((row as { body?: string }).body ?? '').trim(),
-      companyId: String((row as { company_id?: string }).company_id ?? ''),
-      companyName: companyNameFromRow(row),
-      publishedOn: String((row as { published_on?: string }).published_on ?? ''),
-      sourceLabel: ((row as { source_label?: string | null }).source_label ?? null) as
-        | string
-        | null,
+      id: row.id,
+      body: String(row.body ?? '').trim(),
+      companyId: row.company_id,
+      companyName: accountFromJoin(row.companies)?.name ?? 'Account',
+      publishedOn: row.published_on ?? '',
+      sourceLabel: row.source_label ?? null,
     })
   }
 
   for (const row of execRows ?? []) {
-    const oid = orgIdFromRow(row)
+    const oid = orgIdFromCompaniesJoin(row.companies)
     if (!oid) continue
     bucket(oid).executives.push({
-      id: String((row as { id?: string }).id ?? ''),
-      personName: String((row as { person_name?: string }).person_name ?? '').trim(),
-      summary: String((row as { change_summary?: string }).change_summary ?? '').trim(),
-      companyId: String((row as { company_id?: string }).company_id ?? ''),
-      companyName: companyNameFromRow(row),
-      detectedAt: String((row as { detected_at?: string }).detected_at ?? ''),
+      id: row.id,
+      personName: String(row.person_name ?? '').trim(),
+      summary: String(row.change_summary ?? '').trim(),
+      companyId: row.company_id,
+      companyName: accountFromJoin(row.companies)?.name ?? 'Account',
+      detectedAt: row.detected_at ?? '',
     })
   }
 
@@ -212,9 +212,7 @@ export async function notifyInstantMarketSignalsAfterIngest(
       .select('id, system_role, function_role, notification_settings, full_name')
       .eq('organization_id', orgIdKey)
 
-    const userIds = (profiles ?? [])
-      .map((p) => String((p as { id?: string }).id ?? ''))
-      .filter(Boolean)
+    const userIds = (profiles ?? []).map((p) => p.id).filter(Boolean)
     if (!userIds.length) continue
 
     const { data: subs } = await admin
@@ -227,21 +225,19 @@ export async function notifyInstantMarketSignalsAfterIngest(
       { endpoint: string; p256dh: string; auth: string }[]
     >()
     for (const s of subs ?? []) {
-      const uid = String((s as { user_id?: string }).user_id ?? '')
-      if (!uid) continue
-      if (!subsByUser.has(uid)) subsByUser.set(uid, [])
-      subsByUser.get(uid)!.push({
-        endpoint: String((s as { endpoint?: string }).endpoint ?? ''),
-        p256dh: String((s as { p256dh?: string }).p256dh ?? ''),
-        auth: String((s as { auth?: string }).auth ?? ''),
+      if (!s.user_id) continue
+      if (!subsByUser.has(s.user_id)) subsByUser.set(s.user_id, [])
+      subsByUser.get(s.user_id)!.push({
+        endpoint: s.endpoint,
+        p256dh: s.p256dh,
+        auth: s.auth,
       })
     }
 
     for (const prof of profiles ?? []) {
-      const userId = String((prof as { id?: string }).id ?? '')
+      const userId = prof.id
       if (!userId) continue
-      const ns = (prof as { notification_settings?: unknown }).notification_settings
-      const settings = ns && typeof ns === 'object' ? (ns as Record<string, unknown>) : {}
+      const settings = notificationSettingsRecord(prof.notification_settings)
 
       const wantEmail = settings.email_instant_market_signals === true
       const wantPushPref = settings.browser_push_market_signals === true
@@ -260,9 +256,7 @@ export async function notifyInstantMarketSignalsAfterIngest(
       if (!newsF.length && !execF.length) continue
 
       const total = newsF.length + execF.length
-      const recipientName = String(
-        (prof as { full_name?: string | null }).full_name ?? '',
-      ).trim()
+      const recipientName = String(prof.full_name ?? '').trim()
 
       if (wantEmail && resend) {
         const { data: userData } = await admin.auth.admin.getUserById(userId)
@@ -300,7 +294,10 @@ export async function notifyInstantMarketSignalsAfterIngest(
             pushed += 1
           } catch (e) {
             const msg = e instanceof Error ? e.message : String(e)
-            const status = (e as { statusCode?: number }).statusCode
+            const status =
+              e && typeof e === 'object' && 'statusCode' in e
+                ? Number((e as { statusCode?: unknown }).statusCode)
+                : NaN
             if (status === 404 || status === 410) {
               await admin
                 .from('push_subscriptions')


### PR DESCRIPTION
## Summary
- Type Market Signals instant alerts, digest helpers, champion display, newsroom discovery
- Drop profile orgId casts in MS action impls; use `accountFromJoin` on feed company joins
- Digest cron uses typed profile rows
- Backlog: Market Signals Slice 1 ✅

## Test plan
- [x] `npm run typecheck`
- [ ] Spot-check Market Signals feed / manage watchlist if convenient

Made with [Cursor](https://cursor.com)