### PR TITLE
refactor(market-signals): typed Supabase cast abbau slice 2

### DIFF
--- a/app/api/cron/company-news/route.ts
+++ b/app/api/cron/company-news/route.ts
@@ -79,9 +79,7 @@ export async function GET(request: Request) {
   const orgIds = Array.from(
     new Set(
       (favoriteOrgs ?? [])
-        .map((row) =>
-          String((row as { organization_id?: string | null }).organization_id ?? ''),
-        )
+        .map((row) => row.organization_id ?? '')
         .filter(Boolean),
     ),
   )

--- a/app/dashboard/market-signals/data.ts
+++ b/app/dashboard/market-signals/data.ts
@@ -226,9 +226,7 @@ export async function loadMarketSignalsPageData(): Promise<MarketSignalsPageMode
   const championWatchlist = Array.from(
     new Set(
       (championRows ?? [])
-        .map((row) =>
-          normalizeChampionKey((row as { person_key?: string | null }).person_key ?? ''),
-        )
+        .map((row) => normalizeChampionKey(row.person_key ?? ''))
         .filter(Boolean),
     ),
   )
@@ -242,8 +240,8 @@ export async function loadMarketSignalsPageData(): Promise<MarketSignalsPageMode
   const activeDealCompanyIds = Array.from(
     new Set(
       (dealRows ?? [])
-        .filter((row) => isActiveDealStatus((row as { status?: unknown }).status))
-        .map((row) => String((row as { company_id?: string | null }).company_id ?? ''))
+        .filter((row) => isActiveDealStatus(row.status))
+        .map((row) => row.company_id ?? '')
         .filter(Boolean),
     ),
   )
@@ -255,11 +253,11 @@ export async function loadMarketSignalsPageData(): Promise<MarketSignalsPageMode
     .not('company_id', 'is', null)
     .limit(500)
   const activeDeals = (activeDealRows ?? [])
-    .filter((row) => isActiveDealStatus((row as { status?: unknown }).status))
+    .filter((row) => isActiveDealStatus(row.status))
     .map((row) => ({
-      id: String((row as { id?: string | null }).id ?? ''),
-      title: String((row as { title?: string | null }).title ?? 'Deal'),
-      companyId: String((row as { company_id?: string | null }).company_id ?? ''),
+      id: row.id,
+      title: row.title ?? 'Deal',
+      companyId: row.company_id ?? '',
     }))
     .filter((d) => d.id && d.companyId)
 
@@ -315,7 +313,7 @@ export async function loadMarketSignalsPageData(): Promise<MarketSignalsPageMode
     const bootstrapCompanyIds = Array.from(
       new Set(
         [...(execRows ?? []), ...(newsRows ?? [])]
-          .map((row) => String((row as { company_id?: string | null }).company_id ?? ''))
+          .map((row) => String(row.company_id ?? ''))
           .filter((companyId) => companyId && companyMetaById.has(companyId)),
       ),
     ).slice(0, 8)

--- a/app/dashboard/market-signals/signal-inbox-impl.ts
+++ b/app/dashboard/market-signals/signal-inbox-impl.ts
@@ -20,9 +20,7 @@ async function upsertNotificationKeys(keys: string[]) {
   if (existingError) return { success: false as const, error: existingError.message }
 
   const existingKeys = new Set(
-    (existingRows ?? []).map((row) =>
-      String((row as { notification_key?: string | null }).notification_key ?? ''),
-    ),
+    (existingRows ?? []).map((row) => String(row.notification_key ?? '')),
   )
   const toInsert = uniqueKeys
     .filter((key) => !existingKeys.has(key))
@@ -122,10 +120,7 @@ export async function addMarketSignalToDealImpl(args: {
       .order('updated_at', { ascending: false })
       .limit(2)
     if (refErr) return { success: false, error: refErr.message }
-    referenceIds = (refRows ?? [])
-      .map((r) => String((r as { id?: string | null }).id ?? ''))
-      .filter(Boolean)
-      .slice(0, 2)
+    referenceIds = (refRows ?? []).map((r) => r.id).filter(Boolean).slice(0, 2)
   }
 
   if (!referenceIds.length) {
@@ -141,11 +136,7 @@ export async function addMarketSignalToDealImpl(args: {
     .in('id', referenceIds)
     .eq('company_id', companyId)
   if (validErr) return { success: false, error: validErr.message }
-  const validRefIds = new Set(
-    (validRefs ?? [])
-      .map((r) => String((r as { id?: string | null }).id ?? ''))
-      .filter(Boolean),
-  )
+  const validRefIds = new Set((validRefs ?? []).map((r) => r.id).filter(Boolean))
   const safeRefIds = referenceIds.filter((id) => validRefIds.has(id))
 
   let added = 0

--- a/docs/tech-debt-offen-backlog.md
+++ b/docs/tech-debt-offen-backlog.md
@@ -10,8 +10,8 @@
 
 | Status | Themen |
 |--------|--------|
-| **Erledigt** | Inventar-Hygiene (#0); E4 Hotspot-Audit (#1); E7 Schema-Sync (#2); **P1-6** Accounts Naming App/Lib (#4); Welle-5 Rollen (Invite/`AppRole`/Mapping); Typed-Supabase Kern-Domänen + Shared Portfolio + **Market Signals Slice 1** (Instant Alerts/Digest/Champion/Newsroom/MS-Actions) |
-| **In Arbeit** | Typed-Supabase Cast-Abbau (#3) — Rest (MS Ingest/Data-Detail, Command Center, Cron) + **T4** |
+| **Erledigt** | Inventar-Hygiene (#0); E4 Hotspot-Audit (#1); E7 Schema-Sync (#2); **P1-6** Accounts Naming App/Lib (#4); Welle-5 Rollen (Invite/`AppRole`/Mapping); Typed-Supabase Kern-Domänen + Shared Portfolio + Market Signals **Slices 1–2** |
+| **In Arbeit** | Typed-Supabase Cast-Abbau (#3) — Rest (Command Center / Register) + **T4** |
 | **Offen (Queue)** | #3 Rest · #5 God-Files (Boy-Scout) · #6 `{ ok }` → `{ success }` (Boy-Scout) · #7 DE/EN-Dateinamen (Boy-Scout) · #8 `references`/`evidence` Rename · #9 Invite-SQL-Kosmetik (optional) |
 | **Geparkt** | Pilot (H3/E1/G2); Massen-Renames; produktweite `evidence`↔`references`-Entscheidung |
 
@@ -26,7 +26,7 @@
 | **0** | Inventar-Hygiene | ✅ | — | — | — |
 | **1** | E4 Service-Role | ✅ Audit + Hotspots | Boy-Scout: Kommentar an neuen Service-Role-Callern | XS ongoing | bei Touch |
 | **2** | E7 Schema-Sync | ✅ T1–T4 | Types bei Migrationen regenerieren (`db:types`) | XS ongoing | bei Schema-Change |
-| **3** | Typed-Supabase Cast-Abbau | **🟡 aktiv** | MS Ingest/Executive Rest · Command Center · ggf. T4 | M | Market Signals Slice 2 (ingest) **oder** T4 CI-Gate |
+| **3** | Typed-Supabase Cast-Abbau | **🟡 aktiv** | Command Center / Onboarding-RPC Rest; dann **T4** CI-Gate | S–M | **T4** CI-`typecheck`-Gate prüfen |
 | **4** | P1-6 Accounts Naming | ✅ App/Lib | DB-Tabelle `companies` / `company_id` / Firmennamen-Helfer **bewusst offen** | — | nicht anfassen ohne Produktentscheid |
 | **5** | God-File-Nacharbeit | offen (Boy-Scout) | Overview / Share-Link / MS-Feed weiter slicen **nur bei Feature-Touch** | M ongoing | kein eigener Big-Bang-PR |
 | **6** | `{ ok }` → `{ success }` | offen (Boy-Scout) | ~130 Matches in Libs/Cron | S–M | bei Lib-Berührung mitziehen |
@@ -51,15 +51,14 @@
 | Shared Portfolio | ✅ Slice 1 | `app/p/actions` RPC-Json-Guards |
 | Deal-Desk | ✅ Quick | workspace-persistence typed; page redirect |
 | Notifications | ✅ Quick | Inbox org/champion rows |
-| Market Signals | ✅ Slice 1 | Instant Alerts, Digest, Champion, Newsroom, Action orgIds; data joins |
-| Andere | offen | MS Ingest/Executive Rest, Command Center, Register/Onboarding RPC |
+| Market Signals | ✅ Slices 1–2 | Instant/Digest/Champion + Ingest/Purge/Backfill/Data deals |
+| Andere | offen | Command Center, Register/Onboarding RPC (vereinzelt) |
 | **T4 CI** | offen | `typecheck` in CI **scharf**, wenn Domänen-Casts weitgehend weg / typecheck stabil 0 |
 
 **Empfohlene nächsten PRs (klein halten):**
 
-1. Market Signals Slice 2 — Ingest/Executive-Intel Rest-Casts **oder**  
-2. Typed-Supabase **T4** — CI-`typecheck`-Gate  
-3. Optional: Command Center Boy-Scout
+1. Typed-Supabase **T4** — CI-`typecheck`-Gate  
+2. Optional: Command Center / Register Boy-Scout
 
 ---
 
@@ -102,7 +101,7 @@ Bei Feature-PRs mitnehmen, **kein** Massen-PR:
 | P1-6 | ✅ App/Lib; DB `companies` bleibt |
 | E4 / E7 | ✅ |
 | E6 Logger | ✅ App/Lib; Sink/Scripts bewusst |
-| Typed-Supabase T3 | 🟡 aktiv (Kern + MS Slice 1 ✅; Ingest/CC Rest) |
+| Typed-Supabase T3 | 🟡 aktiv (Kern + MS ✅; CC/Onboarding Rest) → T4 als Nächstes |
 | Typed-Supabase T4 | offen (nach T3-Ruhe) |
 | Welle 5 T3 Paths | → Queue #8 |
 | Welle 5 T4 `workspace_state` | vor Start erneut `grep`en |

--- a/lib/market-signals/backfill-signal-enrichment.ts
+++ b/lib/market-signals/backfill-signal-enrichment.ts
@@ -1,4 +1,5 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '@/lib/database.types'
 
 import { isMissingEnrichmentColumnsError } from './enrichment-db'
 import { enrichSignal } from './enrich-signal-with-llm'
@@ -29,12 +30,15 @@ type CompanyJoin = { name?: string | null; organization_id?: string | null }
 
 function companyFromRow(row: Record<string, unknown>): CompanyJoin | null {
   const raw = row.companies
-  if (Array.isArray(raw)) return (raw[0] as CompanyJoin) ?? null
-  return (raw as CompanyJoin | null) ?? null
+  if (Array.isArray(raw)) {
+    const first = raw[0]
+    return first && typeof first === 'object' ? (first as CompanyJoin) : null
+  }
+  return raw && typeof raw === 'object' ? (raw as CompanyJoin) : null
 }
 
 async function resolveCompanyIds(
-  supabase: SupabaseClient,
+  supabase: SupabaseClient<Database>,
   organizationId?: string,
 ): Promise<string[] | null> {
   if (!organizationId) return null
@@ -44,9 +48,7 @@ async function resolveCompanyIds(
     .eq('organization_id', organizationId)
     .limit(10_000)
   if (error) throw new Error(`companies: ${error.message}`)
-  return (data ?? [])
-    .map((row) => String((row as { id?: string }).id ?? ''))
-    .filter(Boolean)
+  return (data ?? []).map((row) => row.id).filter(Boolean)
 }
 
 function needsEnrichment(row: Record<string, unknown>): boolean {
@@ -60,7 +62,7 @@ async function pause(ms: number) {
 }
 
 export async function runMarketSignalEnrichmentBackfill(
-  supabase: SupabaseClient,
+  supabase: SupabaseClient<Database>,
   options?: BackfillSignalEnrichmentOptions,
 ): Promise<BackfillSignalEnrichmentResult> {
   const maxNews = Math.min(500, Math.max(1, options?.maxNews ?? 80))

--- a/lib/market-signals/ingest-company-news.ts
+++ b/lib/market-signals/ingest-company-news.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'crypto'
 import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '@/lib/database.types'
 import {
   isMissingEnrichmentColumnsError,
   stripEnrichmentFields,
@@ -170,7 +171,7 @@ async function fetchMergedCompanyArticles(
  * zuletzt breites Google News. Leadership-Titel → executive_events.
  */
 export async function runCompanyNewsIngest(
-  supabase: SupabaseClient,
+  supabase: SupabaseClient<Database>,
   options?: {
     organizationId?: string
     ingestMode?: 'all_accounts' | 'focus_only'
@@ -205,8 +206,8 @@ export async function runCompanyNewsIngest(
     errors.push(`deals: ${dealErr.message}`)
   } else {
     for (const row of dealRows ?? []) {
-      if (isActiveDealStatus((row as { status?: unknown }).status)) {
-        const id = String((row as { company_id?: string | null }).company_id ?? '')
+      if (isActiveDealStatus(row.status)) {
+        const id = row.company_id ?? ''
         if (id) dealCompanyIds.add(id)
       }
     }
@@ -235,27 +236,23 @@ export async function runCompanyNewsIngest(
 
   const candidates =
     ingestMode === 'all_accounts'
-      ? ((allCompanies ?? []) as CompanyNewsIngestCompanyRow[] &
-          { is_favorite?: boolean }[])
-      : ((allCompanies ?? []).filter((row) =>
-          Boolean((row as { is_favorite?: boolean | null }).is_favorite),
-        ) as CompanyNewsIngestCompanyRow[] & { is_favorite?: boolean }[])
+      ? (allCompanies ?? [])
+      : (allCompanies ?? []).filter((row) => Boolean(row.is_favorite))
 
   const seen = new Set<string>()
   const uniqueList: CompanyNewsIngestCompanyRow[] = []
   for (const row of candidates) {
-    const id = String(row.id)
-    if (!id || seen.has(id)) continue
+    const id = row.id
+    if (!id || seen.has(id) || !row.organization_id) continue
     seen.add(id)
     uniqueList.push({
       id,
-      organization_id: String(row.organization_id),
+      organization_id: row.organization_id,
       name: String(row.name ?? ''),
-      website_url: (row.website_url as string | null) ?? null,
-      account_status: (row.account_status as string | null) ?? null,
-      industry: (row as { industry?: string | null }).industry ?? null,
-      newsroom_urls: ((row as { newsroom_urls?: string[] | null }).newsroom_urls ??
-        null) as string[] | null,
+      website_url: row.website_url ?? null,
+      account_status: row.account_status ?? null,
+      industry: row.industry ?? null,
+      newsroom_urls: row.newsroom_urls ?? null,
     })
     if (uniqueList.length >= maxCompanies) break
   }
@@ -358,7 +355,7 @@ export async function runCompanyNewsIngest(
               ).error
             }
             if (insErr) {
-              const code = (insErr as { code?: string }).code
+              const code = insErr.code
               if (
                 code !== '23505' &&
                 !/duplicate key|unique constraint/i.test(insErr.message)
@@ -399,7 +396,7 @@ export async function runCompanyNewsIngest(
             ).error
           }
           if (insErr) {
-            const code = (insErr as { code?: string }).code
+            const code = insErr.code
             if (
               code !== '23505' &&
               !/duplicate key|unique constraint/i.test(insErr.message)

--- a/lib/market-signals/ingest-executive-intel.ts
+++ b/lib/market-signals/ingest-executive-intel.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'crypto'
 import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '@/lib/database.types'
 import {
   isMissingEnrichmentColumnsError,
   stripEnrichmentFields,
@@ -124,7 +125,7 @@ export type RunExecutiveIntelIngestResult = {
  * Zuordnung zu company_id über Stakeholder-Name oder frühere Executive-Events.
  */
 export async function runExecutiveIntelIngest(
-  supabase: SupabaseClient,
+  supabase: SupabaseClient<Database>,
   options?: {
     organizationId?: string
     maxPeople?: number
@@ -154,9 +155,7 @@ export async function runExecutiveIntelIngest(
   }
 
   const userIds = [
-    ...new Set(
-      (watchRaw ?? []).map((w) => String((w as { user_id?: string }).user_id ?? '')),
-    ),
+    ...new Set((watchRaw ?? []).map((w) => w.user_id).filter(Boolean)),
   ]
   const { data: profs, error: profErr } = await supabase
     .from('profiles')
@@ -174,9 +173,7 @@ export async function runExecutiveIntelIngest(
 
   const orgByUser = new Map<string, string>()
   for (const p of profs ?? []) {
-    const id = String((p as { id?: string }).id ?? '')
-    const oid = String((p as { organization_id?: string | null }).organization_id ?? '')
-    if (id && oid) orgByUser.set(id, oid)
+    if (p.id && p.organization_id) orgByUser.set(p.id, p.organization_id)
   }
 
   type Watched = {
@@ -188,13 +185,10 @@ export async function runExecutiveIntelIngest(
   const watchedByOrg = new Map<string, Map<string, Watched>>()
 
   for (const row of watchRaw ?? []) {
-    const uid = String((row as { user_id?: string }).user_id ?? '')
-    const personKey = normalizeChampionKey(
-      (row as { person_key?: string }).person_key ?? '',
-    )
-    const personName = String((row as { person_name?: string }).person_name ?? '').trim()
-    const watchlistCompanyName =
-      String((row as { company_name?: string | null }).company_name ?? '').trim() || null
+    const uid = row.user_id
+    const personKey = normalizeChampionKey(row.person_key ?? '')
+    const personName = String(row.person_name ?? '').trim()
+    const watchlistCompanyName = String(row.company_name ?? '').trim() || null
     if (!personKey || !personName) continue
     const orgId = orgByUser.get(uid)
     if (!orgId) continue
@@ -223,8 +217,8 @@ export async function runExecutiveIntelIngest(
         .select('id, name')
         .eq('organization_id', orgId)
       const orgCompanyList = (orgCompanies ?? []).map((c) => ({
-        id: String((c as { id?: string }).id ?? ''),
-        name: String((c as { name?: string | null }).name ?? '').trim(),
+        id: c.id,
+        name: String(c.name ?? '').trim(),
       }))
       const allowedCompanyIds = new Set(orgCompanyList.map((c) => c.id).filter(Boolean))
       const companyIdByNormalizedName = new Map<string, string>()
@@ -258,8 +252,8 @@ export async function runExecutiveIntelIngest(
           .in('company_id', Array.from(allowedCompanyIds))
           .limit(3000)
         for (const s of stakeholders ?? []) {
-          const name = String((s as { name?: string | null }).name ?? '')
-          const cid = String((s as { company_id?: string }).company_id ?? '')
+          const name = String(s.name ?? '')
+          const cid = s.company_id ?? ''
           const k = normalizeChampionKey(name)
           if (!k || !cid || stakeholderCompanyByKey.has(k)) continue
           stakeholderCompanyByKey.set(k, cid)
@@ -275,10 +269,8 @@ export async function runExecutiveIntelIngest(
           .order('detected_at', { ascending: false })
           .limit(800)
         for (const e of evs ?? []) {
-          const k = normalizeChampionKey(
-            String((e as { person_name?: string }).person_name ?? ''),
-          )
-          const cid = String((e as { company_id?: string }).company_id ?? '')
+          const k = normalizeChampionKey(String(e.person_name ?? ''))
+          const cid = e.company_id
           if (!k || !cid || eventCompanyByKey.has(k)) continue
           eventCompanyByKey.set(k, cid)
         }
@@ -363,7 +355,7 @@ export async function runExecutiveIntelIngest(
               ).error
             }
             if (insErr) {
-              const code = (insErr as { code?: string }).code
+              const code = insErr.code
               if (
                 code !== '23505' &&
                 !/duplicate key|unique constraint/i.test(insErr.message)

--- a/lib/market-signals/purge-market-signals.ts
+++ b/lib/market-signals/purge-market-signals.ts
@@ -1,8 +1,11 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '@/lib/database.types'
 import { isLowValueRssTitle } from '@/lib/market-signals/sales-signal-relevance'
 
+type DbClient = SupabaseClient<Database>
+
 export async function getFocusCompanyIdsForOrg(
-  supabase: SupabaseClient,
+  supabase: DbClient,
   organizationId: string,
   maxCompanies = 40,
 ): Promise<string[]> {
@@ -13,11 +16,11 @@ export async function getFocusCompanyIdsForOrg(
     .eq('is_favorite', true)
     .limit(maxCompanies)
   if (error) throw new Error(error.message)
-  return (data ?? []).map((r) => String(r.id)).filter(Boolean)
+  return (data ?? []).map((r) => r.id).filter(Boolean)
 }
 
 export async function getOrgCompanyIds(
-  supabase: SupabaseClient,
+  supabase: DbClient,
   organizationId: string,
 ): Promise<string[]> {
   const { data, error } = await supabase
@@ -26,7 +29,7 @@ export async function getOrgCompanyIds(
     .eq('organization_id', organizationId)
     .limit(8000)
   if (error) throw new Error(error.message)
-  return (data ?? []).map((r) => String(r.id)).filter(Boolean)
+  return (data ?? []).map((r) => r.id).filter(Boolean)
 }
 
 export type PurgeLowValueResult = {
@@ -36,7 +39,7 @@ export type PurgeLowValueResult = {
 
 /** Entfernt Stellenanzeigen und anderes RSS-Rauschen anhand der Titel-Heuristik. */
 export async function purgeLowValueMarketSignals(
-  supabase: SupabaseClient,
+  supabase: DbClient,
   companyIds: string[],
 ): Promise<PurgeLowValueResult> {
   if (!companyIds.length) return { accountNewsDeleted: 0, executiveDeleted: 0 }
@@ -54,8 +57,8 @@ export async function purgeLowValueMarketSignals(
     if (newsFetchErr) throw new Error(newsFetchErr.message)
 
     const lowValueNewsIds = (newsRows ?? [])
-      .filter((r) => isLowValueRssTitle(String((r as { body?: string }).body ?? '')))
-      .map((r) => String((r as { id?: string }).id ?? ''))
+      .filter((r) => isLowValueRssTitle(String(r.body ?? '')))
+      .map((r) => r.id)
       .filter(Boolean)
 
     if (lowValueNewsIds.length) {
@@ -75,12 +78,8 @@ export async function purgeLowValueMarketSignals(
     if (execFetchErr) throw new Error(execFetchErr.message)
 
     const lowValueExecIds = (execRows ?? [])
-      .filter((r) =>
-        isLowValueRssTitle(
-          String((r as { change_summary?: string }).change_summary ?? ''),
-        ),
-      )
-      .map((r) => String((r as { id?: string }).id ?? ''))
+      .filter((r) => isLowValueRssTitle(String(r.change_summary ?? '')))
+      .map((r) => r.id)
       .filter(Boolean)
 
     if (lowValueExecIds.length) {
@@ -106,7 +105,7 @@ export type PurgeRssIngestResult = {
  * Manuelle Einträge (ohne content_hash / ingest_source != RSS) bleiben erhalten.
  */
 export async function purgeRssIngestedSignalsForCompanies(
-  supabase: SupabaseClient,
+  supabase: DbClient,
   companyIds: string[],
 ): Promise<PurgeRssIngestResult> {
   if (!companyIds.length) return { accountNewsDeleted: 0, executiveDeleted: 0 }
@@ -142,7 +141,7 @@ export type RefreshMarketSignalsPurgeResult = PurgeLowValueResult & PurgeRssInge
 
 /** Vor manuellem Feed-Refresh: Rauschen entfernen und RSS-Zeilen für Favoriten zurücksetzen. */
 export async function prepareMarketSignalsFeedRefresh(
-  supabase: SupabaseClient,
+  supabase: DbClient,
   organizationId: string,
 ): Promise<RefreshMarketSignalsPurgeResult> {
   const [orgCompanyIds, focusCompanyIds] = await Promise.all([


### PR DESCRIPTION
## Summary
- Type executive + company-news ingest loaders with `SupabaseClient<Database>`
- Clean purge/backfill, feed deal mapping, inbox reference IDs, company-news cron org IDs
- Backlog: Market Signals Slices 1–2 ✅; next = T4 CI gate

## Test plan
- [x] `npm run typecheck`
- [ ] Spot-check Market Signals ingest/refresh if convenient

Made with [Cursor](https://cursor.com)