### PR TITLE
chore(typed-supabase): close T4 CI typecheck gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,11 +88,11 @@ jobs:
       - name: Lint
         run: npm run lint
 
-      - name: Test
-        run: npm test
-
       - name: Typecheck
         run: npm run typecheck
+
+      - name: Test
+        run: npm test
 
       - name: Build
         run: npm run build

--- a/app/dashboard/settings/invite-actions.ts
+++ b/app/dashboard/settings/invite-actions.ts
@@ -14,7 +14,10 @@ import {
   type InviteRoleDimensions,
 } from '@/lib/roles/invite-roles'
 import { parseProfileRoles } from '@/lib/roles/profile-roles'
-import type { Json } from '@/lib/database.types'
+import {
+  parseInviteRpcJson,
+  parseInviteRpcRows,
+} from '@/lib/invites/parse-invite-rpc'
 import { log } from '@/lib/observability/logger'
 
 const INVITE_VALID_DAYS = 7
@@ -25,44 +28,6 @@ function formatInviteExpiresAt(expiresAt: Date): string {
     month: '2-digit',
     year: 'numeric',
   })
-}
-
-type InviteRpcFields = {
-  id?: string
-  email?: string | null
-  token?: string | null
-  system_role?: string | null
-  function_role?: string | null
-}
-
-/** RPC `get_organization_invite_for_resend` / pending-invite rows sind `Json`. */
-function parseInviteRpcObject(data: Json | null | undefined): InviteRpcFields | null {
-  if (!data || typeof data !== 'object' || Array.isArray(data)) return null
-  const obj = data as Record<string, unknown>
-  return {
-    id: typeof obj.id === 'string' ? obj.id : undefined,
-    email: typeof obj.email === 'string' ? obj.email : obj.email === null ? null : undefined,
-    token: typeof obj.token === 'string' ? obj.token : obj.token === null ? null : undefined,
-    system_role:
-      typeof obj.system_role === 'string'
-        ? obj.system_role
-        : obj.system_role === null
-          ? null
-          : undefined,
-    function_role:
-      typeof obj.function_role === 'string'
-        ? obj.function_role
-        : obj.function_role === null
-          ? null
-          : undefined,
-  }
-}
-
-function parsePendingInviteRows(data: Json | null | undefined): InviteRpcFields[] {
-  if (!Array.isArray(data)) return []
-  return data
-    .map((row) => parseInviteRpcObject(row))
-    .filter((row): row is InviteRpcFields => Boolean(row?.id))
 }
 
 export type CreateInviteResult =
@@ -300,7 +265,7 @@ export async function resendInviteEmail(params: {
 
   if (inviteErr) return { success: false, error: inviteErr.message }
 
-  const invite = parseInviteRpcObject(inviteDataRaw)
+  const invite = parseInviteRpcJson(inviteDataRaw)
 
   const email = invite?.email?.trim().toLowerCase() || ''
   const token = invite?.token?.trim() || ''
@@ -408,7 +373,7 @@ export async function getTeamMembers(): Promise<TeamMemberRow[]> {
     )
   }
 
-  const pending: TeamMemberRow[] = parsePendingInviteRows(invitesRpc.data).flatMap(
+  const pending: TeamMemberRow[] = parseInviteRpcRows(invitesRpc.data).flatMap(
     (i) => {
       if (!i.id) return []
       const roles = parseInviteRoleDimensions(i)

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -5,6 +5,7 @@ import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 import { OnboardingWizard } from './onboarding-wizard'
 import { isHubSpotConfigured } from '@/lib/crm/hubspot/config'
+import { parseInviteRpcJson } from '@/lib/invites/parse-invite-rpc'
 
 type Props = {
   searchParams: Promise<{
@@ -32,7 +33,7 @@ export default async function OnboardingPage({ searchParams }: Props) {
     const { data } = await supabase.rpc('get_invite_by_token', {
       invite_token: inviteToken,
     })
-    const parsed = data as { organization_name?: string } | null
+    const parsed = parseInviteRpcJson(data)
     if (parsed?.organization_name) {
       inviteOrganizationName = parsed.organization_name
     }
@@ -44,8 +45,11 @@ export default async function OnboardingPage({ searchParams }: Props) {
     .eq('id', user.id)
     .maybeSingle()
 
-  const meta = (user.user_metadata ?? {}) as { full_name?: string }
-  const initialFullName = typeof meta.full_name === 'string' ? meta.full_name.trim() : ''
+  const meta = user.user_metadata
+  const initialFullName =
+    meta && typeof meta === 'object' && typeof meta.full_name === 'string'
+      ? meta.full_name.trim()
+      : ''
 
   return (
     <Suspense fallback={<div className="min-h-screen animate-pulse bg-zinc-100/50" />}>

--- a/app/onboarding/wizard-actions.ts
+++ b/app/onboarding/wizard-actions.ts
@@ -20,6 +20,7 @@ import {
 import type { FunctionRole, SystemRole } from '@/lib/roles/capabilities'
 import { parseInviteRoleDimensions } from '@/lib/roles/invite-roles'
 import { profileIsSalesRestricted } from '@/lib/roles/profile-guards'
+import { parseInviteRpcJson } from '@/lib/invites/parse-invite-rpc'
 
 export type FinalizeWorkspaceResult =
   | { success: true }
@@ -52,11 +53,7 @@ export async function finalizeWorkspaceAndProfile(params: {
     const { data } = await supabase.rpc('get_invite_by_token', {
       invite_token: inviteToken,
     })
-    const parsed = data as {
-      organization_id?: string
-      system_role?: string | null
-      function_role?: string | null
-    } | null
+    const parsed = parseInviteRpcJson(data)
     if (parsed?.organization_id) {
       organizationId = parsed.organization_id
       joinedViaInvite = true

--- a/app/register/actions.ts
+++ b/app/register/actions.ts
@@ -9,6 +9,7 @@ import { ROUTES } from '@/lib/routes'
 import { validatePasswordPolicy } from '@/lib/security/password-policy'
 import { getAppOrigin } from '@/lib/env/app-origin'
 import { parseInviteRoleDimensions } from '@/lib/roles/invite-roles'
+import { parseInviteRpcJson } from '@/lib/invites/parse-invite-rpc'
 import {
   buildRefstackEmailHtml,
   escapeRefstackEmailHtml,
@@ -136,11 +137,7 @@ export async function signUp(formData: FormData): Promise<SignUpResult> {
         },
       )
 
-      const parsed = inviteData as {
-        organization_id?: string
-        system_role?: string
-        function_role?: string
-      } | null
+      const parsed = parseInviteRpcJson(inviteData)
       const organizationId = parsed?.organization_id ?? null
       if (!inviteError && organizationId && data.user?.id) {
         const inviteRoles = parseInviteRoleDimensions(parsed ?? {})

--- a/docs/arbeitspaket-typed-supabase.md
+++ b/docs/arbeitspaket-typed-supabase.md
@@ -9,7 +9,7 @@
 ## Vorab lesen (für die Coding-Session)
 
 - **Konventionen:** `docs/ai-coding-agent-guide.md`.
-- Aktueller Stand `[verifiziert]`: `tsconfig` `strict: true`; **0** `any`/`@ts-ignore`; aber **273** `as { … }`-Casts auf DB-Rows; **kein** `database.types.ts`, **kein** gen-Script, **kein** `typecheck`-Script; CI = lint/test/build. Die drei Clients (`lib/supabase/{client,server,service-role}.ts`) nutzen **keinen** `Database`-Generic.
+- Aktueller Stand `[verifiziert 2026-08-06]`: `tsconfig` `strict: true`; `lib/database.types.ts` + `db:types`/`typecheck`; Clients mit `Database`-Generic; Domänen-Casts weitgehend abgebaut (T3); **T4** CI-Gate scharf (`npm run typecheck` vor Test/Build in `.github/workflows/ci.yml`).
 - **Code vor Edit lesen**; **Vault nicht** heranziehen.
 
 ---
@@ -69,10 +69,12 @@ createClient<Database>(url, serviceKey, { … })
 
 ---
 
-## T4 — CI-Gate aktivieren
+## T4 — CI-Gate aktivieren ✅
 
 **Soll:** In `.github/workflows/ci.yml` einen `typecheck`-Schritt **vor** dem Build ergänzen — erst **scharf schalten**, wenn T3 org-weit 0 Fehler erreicht hat (sonst rot). Optional: separater CI-Job, der Migrationen gegen eine Wegwerf-/lokale DB anwendet (fängt SQL-/Schema-Fehler vor Prod).
-**Akzeptanz:** CI bricht künftig bei Spalten-/Schema-Drift ab (`tsc --noEmit`); grüner Lauf auf `main`.
+
+**Erledigt (2026-08-06):** `lint-and-build` führt `npm run typecheck` **scharf** (kein `continue-on-error`) **vor** Test/Build aus; Migrations-Job existiert separat (`db-migrations`, E7).  
+**Akzeptanz:** CI bricht bei Spalten-/Schema-Drift ab (`tsc --noEmit`); grüner Lauf auf `main`.
 
 ---
 

--- a/docs/tech-debt-inventar.md
+++ b/docs/tech-debt-inventar.md
@@ -52,7 +52,8 @@ Verweis: [arbeitspaket-logging-error-e6.md](./arbeitspaket-logging-error-e6.md),
 | Legacy-`role` / Naming      | Welle 5           | Rollen-Mapping ✅; P1-6 App/Lib-Naming ✅ (DB `companies` bleibt)     |
 | God-Files / Modularisierung | E5, QC-Struktur   | Welle ✅; Rest Boy-Scout bei Feature-Touch                           |
 | Rollen/Capabilities         | Welle 1–2 Cleanup | Accounts/Deals Auth meist `system_role`/`function_role`              |
-| Service-Role / Schema       | E4, E7            | ✅ Hotspots/Sync — Rest siehe [`tech-debt-offen-backlog.md`](./tech-debt-offen-backlog.md) #1–3 |
+| Service-Role / Schema       | E4, E7            | ✅ — Rest Boy-Scout siehe [`tech-debt-offen-backlog.md`](./tech-debt-offen-backlog.md) |
+| Typed Supabase              | E1/E2 Arbeitspaket | ✅ T1–T4 (Domänen + CI-`typecheck`-Gate) |
 
 ---
 

--- a/docs/tech-debt-offen-backlog.md
+++ b/docs/tech-debt-offen-backlog.md
@@ -10,12 +10,12 @@
 
 | Status | Themen |
 |--------|--------|
-| **Erledigt** | Inventar-Hygiene (#0); E4 Hotspot-Audit (#1); E7 Schema-Sync (#2); **P1-6** Accounts Naming App/Lib (#4); Welle-5 Rollen (Invite/`AppRole`/Mapping); Typed-Supabase Kern-Domänen + Shared Portfolio + Market Signals **Slices 1–2** |
-| **In Arbeit** | Typed-Supabase Cast-Abbau (#3) — Rest (Command Center / Register) + **T4** |
-| **Offen (Queue)** | #3 Rest · #5 God-Files (Boy-Scout) · #6 `{ ok }` → `{ success }` (Boy-Scout) · #7 DE/EN-Dateinamen (Boy-Scout) · #8 `references`/`evidence` Rename · #9 Invite-SQL-Kosmetik (optional) |
+| **Erledigt** | Inventar-Hygiene (#0); E4 (#1); E7 (#2); **P1-6** (#4); Welle-5 Rollen; Typed-Supabase **T1–T4** (#3 Domänen + CI-`typecheck`-Gate) |
+| **In Arbeit** | — |
+| **Offen (Queue)** | #5 God-Files (Boy-Scout) · #6 `{ ok }` → `{ success }` (Boy-Scout) · #7 DE/EN-Dateinamen (Boy-Scout) · #8 `references`/`evidence` Rename · #9 Invite-SQL-Kosmetik (optional) |
 | **Geparkt** | Pilot (H3/E1/G2); Massen-Renames; produktweite `evidence`↔`references`-Entscheidung |
 
-**Hebel jetzt:** Queue **#3** zu Ende führen (References-Rest → andere Domänen → Typed-Supabase **T4** CI-`typecheck`-Gate), danach erst Big-Bang **#8**.
+**Hebel jetzt:** Nach #3-Ruhe erst Big-Bang **#8** (`references`/`evidence` Pfade); sonst Boy-Scout #5–7 bei Feature-Touch.
 
 ---
 
@@ -26,39 +26,31 @@
 | **0** | Inventar-Hygiene | ✅ | — | — | — |
 | **1** | E4 Service-Role | ✅ Audit + Hotspots | Boy-Scout: Kommentar an neuen Service-Role-Callern | XS ongoing | bei Touch |
 | **2** | E7 Schema-Sync | ✅ T1–T4 | Types bei Migrationen regenerieren (`db:types`) | XS ongoing | bei Schema-Change |
-| **3** | Typed-Supabase Cast-Abbau | **🟡 aktiv** | Command Center / Onboarding-RPC Rest; dann **T4** CI-Gate | S–M | **T4** CI-`typecheck`-Gate prüfen |
+| **3** | Typed-Supabase Cast-Abbau | ✅ T1–T4 | Rest-Casts nur Boundaries (HTTP/RPC/Json); Boy-Scout bei Touch | — | CI: `typecheck` vor Build |
 | **4** | P1-6 Accounts Naming | ✅ App/Lib | DB-Tabelle `companies` / `company_id` / Firmennamen-Helfer **bewusst offen** | — | nicht anfassen ohne Produktentscheid |
 | **5** | God-File-Nacharbeit | offen (Boy-Scout) | Overview / Share-Link / MS-Feed weiter slicen **nur bei Feature-Touch** | M ongoing | kein eigener Big-Bang-PR |
 | **6** | `{ ok }` → `{ success }` | offen (Boy-Scout) | ~130 Matches in Libs/Cron | S–M | bei Lib-Berührung mitziehen |
 | **7** | P3-3 DE/EN-Dateinamen | offen (Boy-Scout) | z. B. `ki-entwurf-sheet`, `customer-sperrlink-email` | XS | nur bei Datei-Touch |
-| **8** | Welle-5 T3 `references`/`evidence` | offen | Modulpfade an einen Domänennamen | L | **nach** #3-Ruhe; eigener Branch |
+| **8** | Welle-5 T3 `references`/`evidence` | offen | Modulpfade an einen Domänennamen | L | **nächster Big-Bang** nach #3 |
 | **9** | DB-Legacy Invite-Helfer | optional | `legacy_role_from_dimensions` / `resolve_invite_roles` wenn App-Caller = 0 | S | `grep` vor Start |
 | **10** | Rest-`console.*` | erledigt (App/Lib) | Logger-Sink + Scripts behalten; später Sentry/Logflare | — | kein Ticket |
 
 ---
 
-## Queue #3 — Typed-Supabase (Detail Rest)
+## Queue #3 — Typed-Supabase (abgeschlossen)
 
-**Ziel:** Row-Casts nur noch an echten Boundaries (RPC-JSON, externe APIs, Schema-Fallbacks).  
+**Ziel erreicht:** Domänen-Casts weitgehend abgebaut; Row-Casts nur noch an echten Boundaries.  
 **Arbeitspaket:** [`arbeitspaket-typed-supabase.md`](./arbeitspaket-typed-supabase.md)
 
-| Domäne | Stand | Noch typische Hotspots |
-|--------|-------|------------------------|
-| Accounts | ✅ Slices 1–4 | wenig: CRM-JSON, External-Contacts-Fallback, Error-Shapes |
-| Deals | ✅ Slices 1–2 | wenig: Eligibility/JSON-API-Responses (bewusst) |
-| References | ✅ Slice 1–5 | Rest vereinzelt (trash/Quote/JSON); Page date_format ✅ |
-| Settings | ✅ Slice 1 | Stripe/HubSpot/Push-JSON bewusst |
-| Shared Portfolio | ✅ Slice 1 | `app/p/actions` RPC-Json-Guards |
-| Deal-Desk | ✅ Quick | workspace-persistence typed; page redirect |
-| Notifications | ✅ Quick | Inbox org/champion rows |
-| Market Signals | ✅ Slices 1–2 | Instant/Digest/Champion + Ingest/Purge/Backfill/Data deals |
-| Andere | offen | Command Center, Register/Onboarding RPC (vereinzelt) |
-| **T4 CI** | offen | `typecheck` in CI **scharf**, wenn Domänen-Casts weitgehend weg / typecheck stabil 0 |
+| Domäne | Stand |
+|--------|-------|
+| Accounts / Deals / References / Settings | ✅ |
+| Shared Portfolio / Deal-Desk / Notifications | ✅ |
+| Market Signals | ✅ Slices 1–2 |
+| Command Center / Register / Onboarding Invite-RPC | ✅ Quick (mit T4) |
+| **T4 CI** | ✅ `npm run typecheck` in CI **vor** Test/Build (scharf, kein `continue-on-error`) |
 
-**Empfohlene nächsten PRs (klein halten):**
-
-1. Typed-Supabase **T4** — CI-`typecheck`-Gate  
-2. Optional: Command Center / Register Boy-Scout
+**Rest (Boy-Scout, kein eigener Sprint):** vereinzelte HTTP-JSON / LLM-Responses / Schema-Fallbacks.
 
 ---
 
@@ -86,8 +78,8 @@ Bei Feature-PRs mitnehmen, **kein** Massen-PR:
 
 ## Session-Start (kurz)
 
-1. Dieses Dokument lesen — Default: **#3** weiter.  
-2. Feature-Arbeit: #5–7 Boy-Scout.  
+1. Dieses Dokument lesen — Default: **#8** planen oder Boy-Scout #5–7.  
+2. Feature-Arbeit: #5–7 mitnehmen.  
 3. **#8** nur als eigener Branch, CI grün, kein Verhaltens-Diff.  
 4. Nach Abschluss: Status hier + Inventar anpassen.
 
@@ -101,7 +93,7 @@ Bei Feature-PRs mitnehmen, **kein** Massen-PR:
 | P1-6 | ✅ App/Lib; DB `companies` bleibt |
 | E4 / E7 | ✅ |
 | E6 Logger | ✅ App/Lib; Sink/Scripts bewusst |
-| Typed-Supabase T3 | 🟡 aktiv (Kern + MS ✅; CC/Onboarding Rest) → T4 als Nächstes |
-| Typed-Supabase T4 | offen (nach T3-Ruhe) |
+| Typed-Supabase T3 | ✅ Domänen weitgehend |
+| Typed-Supabase T4 | ✅ CI-`typecheck`-Gate scharf |
 | Welle 5 T3 Paths | → Queue #8 |
 | Welle 5 T4 `workspace_state` | vor Start erneut `grep`en |

--- a/lib/command-center/global-search.ts
+++ b/lib/command-center/global-search.ts
@@ -308,11 +308,14 @@ export async function searchCommandCenter(
   const accountCandidates: Extract<CommandSearchResult, { kind: 'account' }>[] = []
   const partnerCandidates: Extract<CommandSearchResult, { kind: 'partner' }>[] = []
   for (const row of accountsRes.data ?? []) {
-    const entityKind = String((row as { entity_kind?: string }).entity_kind ?? 'account')
+    const entityKind =
+      'entity_kind' in row && typeof row.entity_kind === 'string'
+        ? row.entity_kind
+        : 'account'
     const base = {
-      id: String(row.id),
+      id: row.id,
       title: String(row.name ?? ''),
-      logoUrl: (row.logo_url as string | null) ?? null,
+      logoUrl: row.logo_url ?? null,
     }
     if (entityKind === 'partner') {
       partnerCandidates.push({ kind: 'partner', ...base })

--- a/lib/command-center/search-homepage-buckets.ts
+++ b/lib/command-center/search-homepage-buckets.ts
@@ -32,9 +32,10 @@ function referenceFromJoin(
 ): { title: string; companyName: string | null } | null {
   const ref = Array.isArray(raw) ? raw[0] : raw
   if (!ref || typeof ref !== 'object') return null
-  const title = String((ref as { title?: string }).title ?? '').trim()
+  const row = ref as { title?: unknown; companies?: unknown }
+  const title = String(row.title ?? '').trim()
   if (!title) return null
-  const co = accountFromJoin((ref as { companies?: unknown }).companies)
+  const co = accountFromJoin(row.companies)
   return { title, companyName: co?.name ?? null }
 }
 

--- a/lib/invites/parse-invite-rpc.ts
+++ b/lib/invites/parse-invite-rpc.ts
@@ -1,0 +1,43 @@
+import type { Json } from '@/lib/database.types'
+
+/** Fields returned by invite RPCs (`get_invite_by_token`, resend/pending helpers). */
+export type InviteRpcFields = {
+  id?: string
+  email?: string | null
+  token?: string | null
+  organization_id?: string
+  organization_name?: string
+  system_role?: string | null
+  function_role?: string | null
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined
+}
+
+function optionalNullableString(value: unknown): string | null | undefined {
+  if (value === null) return null
+  return typeof value === 'string' ? value : undefined
+}
+
+/** Narrow invite RPC `Json` without row-shaped casts. */
+export function parseInviteRpcJson(data: Json | null | undefined): InviteRpcFields | null {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return null
+  const obj = data as Record<string, unknown>
+  return {
+    id: optionalString(obj.id),
+    email: optionalNullableString(obj.email),
+    token: optionalNullableString(obj.token),
+    organization_id: optionalString(obj.organization_id),
+    organization_name: optionalString(obj.organization_name),
+    system_role: optionalNullableString(obj.system_role),
+    function_role: optionalNullableString(obj.function_role),
+  }
+}
+
+export function parseInviteRpcRows(data: Json | null | undefined): InviteRpcFields[] {
+  if (!Array.isArray(data)) return []
+  return data
+    .map((row) => parseInviteRpcJson(row))
+    .filter((row): row is InviteRpcFields => Boolean(row?.id))
+}


### PR DESCRIPTION
## Summary
- Confirm/harden Typed-Supabase **T4**: CI runs `npm run typecheck` scharf **before** Test/Build
- Shared `parseInviteRpcJson` for register/onboarding/settings invite RPCs
- Drop leftover Command Center / invite row casts
- Backlog + Arbeitspaket: Typed-Supabase T1–T4 ✅; next queue item #8

## Test plan
- [x] `npm run typecheck`
- [ ] CI green on PR

Made with [Cursor](https://cursor.com)