### PR TITLE
chore(#8): close references/evidence path rename

### DIFF
--- a/app/dashboard/dashboard-overview.tsx
+++ b/app/dashboard/dashboard-overview.tsx
@@ -40,6 +40,7 @@ import {
   STATUS_LABELS,
   loadColumnOrderFromStorage,
   loadReferenceColumnWidthsFromStorage,
+  loadShowExpiredCertificatesFromStorage,
   loadVisibleColumnsFromStorage,
 } from './overview/reference-overview-columns'
 import {
@@ -204,13 +205,7 @@ export function DashboardOverview({
 
   useLayoutEffect(() => {
     syncReferenceLibraryModeFromStorage()
-    try {
-      setShowExpiredCertificates(
-        localStorage.getItem(REFERENCE_SHOW_EXPIRED_CERTS_KEY) === '1',
-      )
-    } catch {
-      /* ignore */
-    }
+    setShowExpiredCertificates(loadShowExpiredCertificatesFromStorage())
   }, [])
 
   const handleLibraryModeChange = useCallback((mode: ReferenceLibraryMode) => {

--- a/app/dashboard/overview/reference-overview-columns.ts
+++ b/app/dashboard/overview/reference-overview-columns.ts
@@ -87,7 +87,21 @@ export const COLUMN_LABELS: Record<(typeof COLUMN_KEYS)[number], string> = {
 export const COLUMN_ORDER_STORAGE_KEY = 'dashboard-overview-column-order-v1'
 export const COLUMN_VISIBLE_STORAGE_KEY = 'dashboard-overview-column-visible-v1'
 export const COLUMN_SIZING_STORAGE_KEY = 'dashboard-overview-column-sizing-v1'
-export const REFERENCE_SHOW_EXPIRED_CERTS_KEY = 'evidence-compliance-show-expired-v1'
+export const REFERENCE_SHOW_EXPIRED_CERTS_KEY = 'reference-compliance-show-expired-v1'
+/** Prefixed legacy key from pre-rename localStorage (Queue #8). */
+const LEGACY_SHOW_EXPIRED_CERTS_KEY = 'evidence-compliance-show-expired-v1'
+
+export function loadShowExpiredCertificatesFromStorage(): boolean {
+  if (typeof window === 'undefined') return false
+  try {
+    const raw =
+      localStorage.getItem(REFERENCE_SHOW_EXPIRED_CERTS_KEY) ??
+      localStorage.getItem(LEGACY_SHOW_EXPIRED_CERTS_KEY)
+    return raw === '1'
+  } catch {
+    return false
+  }
+}
 
 export function loadVisibleColumnsFromStorage(): Record<
   (typeof COLUMN_KEYS)[number],

--- a/docs/arbeitspaket-legacy-abbau-welle-5.md
+++ b/docs/arbeitspaket-legacy-abbau-welle-5.md
@@ -54,10 +54,13 @@
 
 ## T3 (Block B) — `references`/`evidence`-Namen konsolidieren
 
-**Soll:** Die Modul-Ordner-Bezeichnung `references` (Server-Actions/Helfer, **keine** Route) an die UI-Route `evidence` angleichen — ein Name für das Domänenobjekt. Variante: Module nach `app/dashboard/evidence/_actions/` (oder `lib/evidence/`) verschieben und die **42 Importe** aktualisieren.
-**Charakter:** mechanischer Rename/Move — ein gebündelter PR, am besten per IDE-Refactor; danach Voll-Build.
-**Akzeptanz:** Keine `@/app/dashboard/references/`-Importe mehr; Funktion unverändert; Tests grün.
-**Hinweis:** Öffentliche Routen/Slug-Pfade (`/p/[slug]`) und Storage-Bucket-Namen **nicht** umbenennen — nur interne Modulpfade.
+**Status (2026-08-06): erledigt unter Produktentscheid `references`** — nicht wie unten historisch skizziert Richtung `evidence`.  
+Aktuell: Routen/Ordner/`ROUTES`/`lib` = `references`; Redirects von `/dashboard/evidence`; siehe [`arbeitspaket-rename-smart-match-references.md`](./arbeitspaket-rename-smart-match-references.md) und Queue #8.
+
+**Historischer Soll (obsolet):** Die Modul-Ordner-Bezeichnung `references` an die UI-Route `evidence` angleichen. Gegenläufige Produktentscheidung: App an DB-Namen **`references`**.
+
+**Akzeptanz (aktuell):** Domäne heißt `references`; Legacy-URLs redirecten; `evidence_events` unberührt.  
+**Hinweis:** Öffentliche Routen/Slug-Pfade (`/p/[slug]`) und Storage-Bucket-Namen **nicht** umbenennen; Feld `evidence` in RFP/Deal-Desk (= Beleg) bleibt.
 
 ---
 

--- a/docs/arbeitspaket-rename-smart-match-references.md
+++ b/docs/arbeitspaket-rename-smart-match-references.md
@@ -10,12 +10,17 @@
 - `docs/ai-coding-agent-guide.md`
 - `lib/copy.ts` (zentrale UI-Labels), `lib/routes.ts` (zentrale Routen), `middleware.ts`
 
-## Ist-Stand (verifiziert)
+## Status (2026-08-06)
 
-- **Display-Labels** liegen zentral in `lib/copy.ts`:
+**T1 + T2 weitgehend erledigt** (Routen/Ordner/`ROUTES.references`/`lib/references`, Redirects, COPY-Keys).  
+Rest: `evidence_events` bleibt; RFP-Feld `evidence` (= Beleg) ist bewusst anderer Begriff. Siehe Queue **#8** in `tech-debt-offen-backlog.md`.
+
+## Ist-Stand (historisch, vor Rename)
+
+- **Display-Labels** lagen zentral in `lib/copy.ts`:
   - `nav.match = 'Finden'`, `pages.match = 'Finden'` → Ziel **„Smart Match"**.
   - `nav.evidence = 'Referenzen'`, `pages.evidence = 'Referenzen'` → **bereits korrekt** (kein Display-Change nötig).
-- **Routen/Code** liegen zentral in `lib/routes.ts`:
+- **Routen/Code** lagen zentral in `lib/routes.ts`:
   - `ROUTES.match = '/dashboard/match'`, `ROUTES.matchWithDeal(dealId)`.
   - `ROUTES.evidence.{root,new,newBulk,detail,edit} = '/dashboard/evidence/…'`.
 - **Ordner:** `app/dashboard/match/*`, `app/dashboard/evidence/*` (inkl. `new/`, `[id]/`, `[id]/edit/`).

--- a/docs/tech-debt-offen-backlog.md
+++ b/docs/tech-debt-offen-backlog.md
@@ -10,12 +10,12 @@
 
 | Status | Themen |
 |--------|--------|
-| **Erledigt** | Inventar-Hygiene (#0); E4 (#1); E7 (#2); **P1-6** (#4); Welle-5 Rollen; Typed-Supabase **T1–T4** (#3 Domänen + CI-`typecheck`-Gate) |
+| **Erledigt** | Inventar-Hygiene (#0); E4 (#1); E7 (#2); **P1-6** (#4); Welle-5 Rollen; Typed-Supabase **T1–T4** (#3); **#8** `references`-Pfade (Produktname = DB) |
 | **In Arbeit** | — |
-| **Offen (Queue)** | #5 God-Files (Boy-Scout) · #6 `{ ok }` → `{ success }` (Boy-Scout) · #7 DE/EN-Dateinamen (Boy-Scout) · #8 `references`/`evidence` Rename · #9 Invite-SQL-Kosmetik (optional) |
-| **Geparkt** | Pilot (H3/E1/G2); Massen-Renames; produktweite `evidence`↔`references`-Entscheidung |
+| **Offen (Queue)** | #5 God-Files (Boy-Scout) · #6 `{ ok }` → `{ success }` (Boy-Scout) · #7 DE/EN-Dateinamen (Boy-Scout) · #9 Invite-SQL-Kosmetik (optional) |
+| **Geparkt** | Pilot (H3/E1/G2); Massen-Renames |
 
-**Hebel jetzt:** Nach #3-Ruhe erst Big-Bang **#8** (`references`/`evidence` Pfade); sonst Boy-Scout #5–7 bei Feature-Touch.
+**Hebel jetzt:** Boy-Scout #5–7 bei Feature-Touch; optional #9 Invite-SQL wenn Caller = 0.
 
 ---
 
@@ -31,7 +31,7 @@
 | **5** | God-File-Nacharbeit | offen (Boy-Scout) | Overview / Share-Link / MS-Feed weiter slicen **nur bei Feature-Touch** | M ongoing | kein eigener Big-Bang-PR |
 | **6** | `{ ok }` → `{ success }` | offen (Boy-Scout) | ~130 Matches in Libs/Cron | S–M | bei Lib-Berührung mitziehen |
 | **7** | P3-3 DE/EN-Dateinamen | offen (Boy-Scout) | z. B. `ki-entwurf-sheet`, `customer-sperrlink-email` | XS | nur bei Datei-Touch |
-| **8** | Welle-5 T3 `references`/`evidence` | offen | Modulpfade an einen Domänennamen | L | **nächster Big-Bang** nach #3 |
+| **8** | `references`/`evidence` Pfade | ✅ | App = `references` (Routen/Ordner/`ROUTES`); Redirects `/dashboard/evidence` bleiben; `evidence_events` bleibt | — | Rest-`evidence` nur Domänenbegriff (RFP-Belege) |
 | **9** | DB-Legacy Invite-Helfer | optional | `legacy_role_from_dimensions` / `resolve_invite_roles` wenn App-Caller = 0 | S | `grep` vor Start |
 | **10** | Rest-`console.*` | erledigt (App/Lib) | Logger-Sink + Scripts behalten; später Sentry/Logflare | — | kein Ticket |
 
@@ -54,6 +54,24 @@
 
 ---
 
+## Queue #8 — `references`/`evidence` (abgeschlossen)
+
+**Produktentscheid:** Domänenname = DB = **`references`** ([`arbeitspaket-rename-smart-match-references.md`](./arbeitspaket-rename-smart-match-references.md)).  
+Welle-5 T3 („Module nach `evidence`“) ist **obsolet** — gegenläufig und nicht mehr umsetzen.
+
+| Teil | Stand |
+|------|-------|
+| Routen `/dashboard/references`, `ROUTES.references`, Ordner `app/…/references`, `lib/references` | ✅ |
+| Smart Match Pfade | ✅ |
+| Legacy-Redirects `/dashboard/evidence` → `/dashboard/references` | ✅ behalten |
+| COPY/`ROUTES.evidence`-Keys | ✅ entfernt |
+| localStorage-Keys (`reference-*-v1`, Legacy-Fallback) | ✅ |
+| DB `evidence_events` | bewusst **nicht** umbenannt |
+
+**Nicht umbenennen:** Feld `evidence` in RFP/Deal-Desk (Beleg/Zitat aus Ausschreibungstext) — anderer Begriff.
+
+---
+
 ## Boy-Scout (kein eigener Sprint)
 
 Bei Feature-PRs mitnehmen, **kein** Massen-PR:
@@ -69,7 +87,6 @@ Bei Feature-PRs mitnehmen, **kein** Massen-PR:
 
 | Thema | Warum |
 |-------|--------|
-| Repo-weites `evidence`↔`references` (Produktname) | Überlappt #8; Produktentscheidung nötig |
 | Massen-Migration Results / Dateinamen | Boy-Scout reicht |
 | H3 Background-Jobs, E1 Pre-Pilot, G2 Pilotstart | Erst wenn Pilot terminiert |
 | Blindes Knip-Export-Löschen | False Positives bei Server Actions |
@@ -78,10 +95,9 @@ Bei Feature-PRs mitnehmen, **kein** Massen-PR:
 
 ## Session-Start (kurz)
 
-1. Dieses Dokument lesen — Default: **#8** planen oder Boy-Scout #5–7.  
+1. Dieses Dokument lesen — Default: Boy-Scout #5–7 oder optional #9.  
 2. Feature-Arbeit: #5–7 mitnehmen.  
-3. **#8** nur als eigener Branch, CI grün, kein Verhaltens-Diff.  
-4. Nach Abschluss: Status hier + Inventar anpassen.
+3. Nach Abschluss: Status hier + Inventar anpassen.
 
 ---
 
@@ -95,5 +111,5 @@ Bei Feature-PRs mitnehmen, **kein** Massen-PR:
 | E6 Logger | ✅ App/Lib; Sink/Scripts bewusst |
 | Typed-Supabase T3 | ✅ Domänen weitgehend |
 | Typed-Supabase T4 | ✅ CI-`typecheck`-Gate scharf |
-| Welle 5 T3 Paths | → Queue #8 |
-| Welle 5 T4 `workspace_state` | vor Start erneut `grep`en |
+| Welle 5 T3 Paths | ✅ als `references` (nicht evidence); siehe Queue #8 |
+| Welle 5 T4 `workspace_state` | Spalte gedroppt (Migration); App-Code ohne Treffer |

--- a/lib/references/library/reference-library-mode.ts
+++ b/lib/references/library/reference-library-mode.ts
@@ -1,6 +1,8 @@
 export type ReferenceLibraryMode = 'references' | 'certificates'
 
-export const REFERENCE_LIBRARY_MODE_STORAGE_KEY = 'evidence-library-mode-v1'
+export const REFERENCE_LIBRARY_MODE_STORAGE_KEY = 'reference-library-mode-v1'
+/** Prefixed legacy key from pre-rename localStorage (Queue #8). */
+const LEGACY_LIBRARY_MODE_STORAGE_KEY = 'evidence-library-mode-v1'
 
 /** Kurzlabels für Top-Bar, Segment-Switch und CTAs. */
 export const REFERENCE_PROOF_SEGMENT_LABELS: Record<ReferenceLibraryMode, string> = {
@@ -21,7 +23,9 @@ export function referenceLibraryTitle(mode: ReferenceLibraryMode): string {
 export function loadReferenceLibraryModeFromStorage(): ReferenceLibraryMode {
   if (typeof window === 'undefined') return 'references'
   try {
-    const raw = localStorage.getItem(REFERENCE_LIBRARY_MODE_STORAGE_KEY)
+    const raw =
+      localStorage.getItem(REFERENCE_LIBRARY_MODE_STORAGE_KEY) ??
+      localStorage.getItem(LEGACY_LIBRARY_MODE_STORAGE_KEY)
     return raw === 'certificates' ? 'certificates' : 'references'
   } catch {
     return 'references'

--- a/lib/routes.ts
+++ b/lib/routes.ts
@@ -97,7 +97,7 @@ export const LEGACY_REDIRECTS = [
     destination: '/dashboard/references/:id/edit',
     permanent: true,
   },
-  // Alte Concept-URL (W3); Lesezeichen weiter auf Evidence leiten
+  // Alte Concept-URL (W3); Lesezeichen weiter auf Referenzen leiten
   {
     source: '/dashboard/concepts/inbox-references',
     destination: ROUTES.references.root,


### PR DESCRIPTION
## Summary
- Queue **#8** schließen: Domäne ist bereits `references` (Routen/Ordner/`ROUTES`); Welle-5 T3 Richtung `evidence` als obsolet dokumentiert.
- localStorage-Keys auf `reference-*-v1` umgestellt, Legacy-`evidence-*`-Keys weiter lesbar.
- Backlog/Arbeitspakete an Produktentscheid und Ist-Stand angeglichen.

## Test plan
- [ ] `npm run typecheck` grün
- [ ] Dashboard: Library-Mode / „abgelaufene Zertifikate“-Toggle behalten Preferences nach Reload (auch mit altem Key in localStorage)
- [ ] `/dashboard/evidence` redirectet weiter nach `/dashboard/references`


Made with [Cursor](https://cursor.com)