### PR TITLE
chore(#7): rename DE module filenames (ai-draft, control-link)

### DIFF
--- a/app/api/ai-draft/stream/route.ts
+++ b/app/api/ai-draft/stream/route.ts
@@ -4,10 +4,10 @@ import { z } from 'zod'
 
 import { createServerSupabaseClient } from '@/lib/supabase/server'
 import {
-  buildKiEntwurfUserPrompt,
-  type KiEntwurfOutputFormat,
-  type KiEntwurfTone,
-} from '@/lib/ki-entwurf-prompt'
+  buildAiDraftUserPrompt,
+  type AiDraftOutputFormat,
+  type AiDraftTone,
+} from '@/lib/ai-draft-prompt'
 
 export const runtime = 'nodejs'
 
@@ -108,7 +108,7 @@ export async function POST(req: NextRequest) {
     )
   }
 
-  const userPrompt = buildKiEntwurfUserPrompt({
+  const userPrompt = buildAiDraftUserPrompt({
     reference: {
       title: (ref.title as string) ?? '',
       summary: (ref.summary as string | null) ?? null,
@@ -118,8 +118,8 @@ export async function POST(req: NextRequest) {
       companyName: company?.name?.trim() ? (company.name as string) : null,
     },
     matchScore,
-    outputFormat: outputFormat as KiEntwurfOutputFormat,
-    tone: tone as KiEntwurfTone,
+    outputFormat: outputFormat as AiDraftOutputFormat,
+    tone: tone as AiDraftTone,
     additionalContext: additionalContext ?? undefined,
     dealContext: dealContext ?? undefined,
   })

--- a/app/dashboard/actions.ts
+++ b/app/dashboard/actions.ts
@@ -66,7 +66,7 @@ import { updateReferenceImpl } from '@/lib/references/library/update'
 import { updateReferenceDetailFieldsImpl } from '@/lib/references/library/detail-fields'
 import { bulkCreateReferencesFromFilesImpl } from '@/lib/references/library/bulk-import'
 import { generateSummaryFromStoryImpl } from '@/lib/references/library/summary'
-import { recordKiEntwurfGenerated as recordKiEntwurfGeneratedImpl } from '@/lib/references/library/ki-entwurf-log'
+import { recordAiDraftGenerated as recordAiDraftGeneratedImpl } from '@/lib/references/library/ai-draft-log'
 
 export type ReferenceRow = {
   id: string
@@ -414,10 +414,10 @@ export async function generateSummaryFromStory(
 }
 
 /** Epic 5: Telemetrie nach KI-Entwurf (Sheet). */
-export async function recordKiEntwurfGenerated(
-  args: Parameters<typeof recordKiEntwurfGeneratedImpl>[0],
+export async function recordAiDraftGenerated(
+  args: Parameters<typeof recordAiDraftGeneratedImpl>[0],
 ): Promise<void> {
-  return recordKiEntwurfGeneratedImpl(args)
+  return recordAiDraftGeneratedImpl(args)
 }
 
 export type {

--- a/app/dashboard/deals/cockpit/deal-rfp-drafts-section.tsx
+++ b/app/dashboard/deals/cockpit/deal-rfp-drafts-section.tsx
@@ -18,13 +18,13 @@ import {
   CollapsibleTrigger,
 } from '@/components/ui/collapsible'
 import { Textarea } from '@/components/ui/textarea'
-import { KiEntwurfSheet } from '@/app/dashboard/deals/components/ki-entwurf-sheet'
+import { AiDraftSheet } from '@/app/dashboard/deals/components/ai-draft-sheet'
 import type { DealWithReferences } from '@/app/dashboard/deals/types'
 import { AppIcon } from '@/lib/icons'
 import { COPY } from '@/lib/copy'
 import type { DealRfpCockpitData } from '@/lib/deals/load-deal-rfp-cockpit-data'
 import type { DealDeskDraftRow } from '@/lib/deal-desk/mock-analysis'
-import { buildDealContextForKiEntwurf } from '@/lib/deals/build-deal-context-for-ki-entwurf'
+import { buildDealContextForAiDraft } from '@/lib/deals/build-deal-context-for-ai-draft'
 import {
   draftRowStatus,
   sortDraftRowsByCriticality,
@@ -95,7 +95,7 @@ export function DealRfpDraftsSection({
 
   if (!showSection) return null
 
-  const dealContext = buildDealContextForKiEntwurf(deal)
+  const dealContext = buildDealContextForAiDraft(deal)
   const covered = rows.filter((d) => Boolean(d.reference)).length
   const gaps = rows.length - covered
 
@@ -144,7 +144,7 @@ export function DealRfpDraftsSection({
     }
   }
 
-  function openKiEntwurf(row: DealDeskDraftRow) {
+  function openAiDraft(row: DealDeskDraftRow) {
     const ref = row.reference
     if (!ref?.id) return
     setActiveKi({
@@ -298,7 +298,7 @@ export function DealRfpDraftsSection({
                                   size="sm"
                                   variant="outline"
                                   className="h-8"
-                                  onClick={() => openKiEntwurf(row)}
+                                  onClick={() => openAiDraft(row)}
                                 >
                                   {COPY.deals.cockpit.draftsGenerateCta}
                                 </Button>
@@ -384,7 +384,7 @@ export function DealRfpDraftsSection({
       </Card>
 
       {activeKi ? (
-        <KiEntwurfSheet
+        <AiDraftSheet
           open={kiOpen}
           onOpenChange={setKiOpen}
           referenceId={activeKi.referenceId}

--- a/app/dashboard/deals/components/ai-draft-sheet.tsx
+++ b/app/dashboard/deals/components/ai-draft-sheet.tsx
@@ -22,16 +22,16 @@ import {
 } from '@/components/ui/sheet'
 import { Textarea } from '@/components/ui/textarea'
 import { AppIcon } from '@/lib/icons'
-import type { KiEntwurfOutputFormat, KiEntwurfTone } from '@/lib/ki-entwurf-prompt'
-import { recordKiEntwurfGenerated } from '@/app/dashboard/actions'
+import type { AiDraftOutputFormat, AiDraftTone } from '@/lib/ai-draft-prompt'
+import { recordAiDraftGenerated } from '@/app/dashboard/actions'
 
-const FORMAT_OPTIONS: Array<{ value: KiEntwurfOutputFormat; label: string }> = [
+const FORMAT_OPTIONS: Array<{ value: AiDraftOutputFormat; label: string }> = [
   { value: 'email_snippet', label: 'E-Mail-Snippet' },
   { value: 'proposal_passage', label: 'Angebots-Passage' },
   { value: 'elevator_pitch', label: 'Elevator Pitch (3 Sätze)' },
 ]
 
-const TONE_OPTIONS: Array<{ value: KiEntwurfTone; label: string }> = [
+const TONE_OPTIONS: Array<{ value: AiDraftTone; label: string }> = [
   { value: 'professional', label: 'Professionell' },
   { value: 'casual', label: 'Locker' },
   { value: 'formal', label: 'Formell' },
@@ -51,7 +51,7 @@ type Props = {
 /**
  * Epic 5 / Wireframe §15: Sheet mit Format, Tonalität, Kontext, Streaming (GPT-4o), Editor, Kopieren, Neu generieren.
  */
-export function KiEntwurfSheet({
+export function AiDraftSheet({
   open,
   onOpenChange,
   referenceId,
@@ -60,8 +60,8 @@ export function KiEntwurfSheet({
   dealId,
   dealContext,
 }: Props) {
-  const [outputFormat, setOutputFormat] = useState<KiEntwurfOutputFormat>('email_snippet')
-  const [tone, setTone] = useState<KiEntwurfTone>('professional')
+  const [outputFormat, setOutputFormat] = useState<AiDraftOutputFormat>('email_snippet')
+  const [tone, setTone] = useState<AiDraftTone>('professional')
   const [additionalContext, setAdditionalContext] = useState('')
   const [output, setOutput] = useState('')
   const [streaming, setStreaming] = useState(false)
@@ -81,7 +81,7 @@ export function KiEntwurfSheet({
     setStreaming(true)
     setOutput('')
     try {
-      const res = await fetch('/api/ki-entwurf/stream', {
+      const res = await fetch('/api/ai-draft/stream', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         signal: ac.signal,
@@ -117,7 +117,7 @@ export function KiEntwurfSheet({
       }
 
       if (!acc.includes('[Fehler:')) {
-        void recordKiEntwurfGenerated({
+        void recordAiDraftGenerated({
           referenceId,
           dealId: dealId ?? null,
           outputFormat,
@@ -182,7 +182,7 @@ export function KiEntwurfSheet({
                 >
                   <input
                     type="radio"
-                    name="ki-entwurf-format"
+                    name="ai-draft-format"
                     value={opt.value}
                     checked={outputFormat === opt.value}
                     onChange={() => setOutputFormat(opt.value)}
@@ -195,9 +195,9 @@ export function KiEntwurfSheet({
           </fieldset>
 
           <div className="space-y-2">
-            <Label htmlFor="ki-entwurf-tone">Tonalität</Label>
-            <Select value={tone} onValueChange={(v) => setTone(v as KiEntwurfTone)}>
-              <SelectTrigger id="ki-entwurf-tone" className="max-w-xs">
+            <Label htmlFor="ai-draft-tone">Tonalität</Label>
+            <Select value={tone} onValueChange={(v) => setTone(v as AiDraftTone)}>
+              <SelectTrigger id="ai-draft-tone" className="max-w-xs">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -211,9 +211,9 @@ export function KiEntwurfSheet({
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="ki-entwurf-context">Zusätzlicher Kontext (optional)</Label>
+            <Label htmlFor="ai-draft-context">Zusätzlicher Kontext (optional)</Label>
             <Textarea
-              id="ki-entwurf-context"
+              id="ai-draft-context"
               value={additionalContext}
               onChange={(e) => setAdditionalContext(e.target.value)}
               rows={3}
@@ -242,10 +242,10 @@ export function KiEntwurfSheet({
           </Button>
 
           <div className="space-y-2">
-            <Label htmlFor="ki-entwurf-result">Ergebnis</Label>
+            <Label htmlFor="ai-draft-result">Ergebnis</Label>
             <div className="rounded-lg border border-border bg-card p-3 shadow-sm">
               <Textarea
-                id="ki-entwurf-result"
+                id="ai-draft-result"
                 value={output}
                 onChange={(e) => setOutput(e.target.value)}
                 readOnly={streaming}

--- a/app/dashboard/deals/components/match-result-card.tsx
+++ b/app/dashboard/deals/components/match-result-card.tsx
@@ -24,7 +24,7 @@ import type { MatchReferenceHit } from '@/lib/match/match-types'
 import { createSharedPortfolio } from '@/app/dashboard/actions'
 import { addReferenceToDealWithScore, removeReferenceFromDeal } from '../actions'
 import { PdfExportDialog } from '@/app/dashboard/references/[id]/pdf-export-dialog'
-import { KiEntwurfSheet } from './ki-entwurf-sheet'
+import { AiDraftSheet } from './ai-draft-sheet'
 
 export function MatchResultCard({
   hit,
@@ -299,7 +299,7 @@ export function MatchResultCard({
         showTriggerButton={false}
       />
 
-      <KiEntwurfSheet
+      <AiDraftSheet
         open={kiOpen}
         onOpenChange={setKiOpen}
         referenceId={hit.id}

--- a/docs/tech-debt-inventar.md
+++ b/docs/tech-debt-inventar.md
@@ -119,7 +119,7 @@ Teilweise Call-Sites auf die Facade umgestellt (`reference-extract`, `rfp/analyz
 | ---- | ------------------------ | -------------------------------------------- | -------------------- | -------------------------------------------------------------------------------------------------------- |
 | P3-1 | `components/dashboard/*` | 4× PascalCase (`DashboardMfaGate`, …)        | kebab-case           | S — ✅ `dashboard-mfa-gate`, `settings-totp-mfa-card`, `support-ticket-modal`, `support-channels-dialog` |
 | P3-2 | Quote-Mix                | `components/ui/` oft `"`, Rest `'`           | Prettier/`format`    | S — ✅ Format-Welle 2026-08-04                                                                           |
-| P3-3 | DE/EN Dateinamen         | `ki-entwurf`, `sperrlink` vs engl. Domains   | Bei Touch angleichen | —                                                                                                        |
+| P3-3 | DE/EN Dateinamen         | `ki-entwurf`, `sperrlink` vs engl. Domains   | Bei Touch angleichen | ✅ 2026-08-06 Slice: `ai-draft-*`, `customer-control-link-email` (UI-Copy/DB-Enum bewusst DE)            |
 | P3-4 | Hardcoded Farben         | Accounts/Deals Status (`red-*`, `emerald-*`) | Design-Tokens        | M — ✅ `--status-*` + `lib/ui/status-tone.ts` (Accounts/Deals/Approval-Badges)                           |
 | P3-5 | EN-Copy Reste            | Strategy-Tab Buying-Center, „Company Update“ | `COPY` / DE          | S — ✅ Account-UI auf `COPY` verdrahtet                                                                  |
 

--- a/docs/tech-debt-offen-backlog.md
+++ b/docs/tech-debt-offen-backlog.md
@@ -10,12 +10,12 @@
 
 | Status | Themen |
 |--------|--------|
-| **Erledigt** | Inventar-Hygiene (#0); E4 (#1); E7 (#2); **P1-6** (#4); Welle-5 Rollen; Typed-Supabase **T1–T4** (#3); **#8** `references`-Pfade; **#9** Invite-SQL skip (SQL-intern behalten) |
+| **Erledigt** | Inventar-Hygiene (#0); E4 (#1); E7 (#2); **P1-6** (#4); Welle-5 Rollen; Typed-Supabase **T1–T4** (#3); **#8** `references`-Pfade; **#9** Invite-SQL skip; **#7** DE/EN-Dateinamen (ki-entwurf/sperrlink) |
 | **In Arbeit** | — |
-| **Offen (Queue)** | #5 God-Files (Boy-Scout) · #6 `{ ok }` → `{ success }` (Boy-Scout) · #7 DE/EN-Dateinamen (Boy-Scout) |
+| **Offen (Queue)** | #5 God-Files (Boy-Scout) · #6 `{ ok }` → `{ success }` (Boy-Scout) |
 | **Geparkt** | Pilot (H3/E1/G2); Massen-Renames |
 
-**Hebel jetzt:** Boy-Scout #5–7 bei Feature-Touch. Big-Bang-Queue leer.
+**Hebel jetzt:** Boy-Scout #5–6 bei Feature-Touch. Big-Bang-Queue leer.
 
 ---
 
@@ -30,7 +30,7 @@
 | **4** | P1-6 Accounts Naming | ✅ App/Lib | DB-Tabelle `companies` / `company_id` / Firmennamen-Helfer **bewusst offen** | — | nicht anfassen ohne Produktentscheid |
 | **5** | God-File-Nacharbeit | offen (Boy-Scout) | Overview / Share-Link / MS-Feed weiter slicen **nur bei Feature-Touch** | M ongoing | kein eigener Big-Bang-PR |
 | **6** | `{ ok }` → `{ success }` | offen (Boy-Scout) | ~130 Matches in Libs/Cron | S–M | bei Lib-Berührung mitziehen |
-| **7** | P3-3 DE/EN-Dateinamen | offen (Boy-Scout) | z. B. `ki-entwurf-sheet`, `customer-sperrlink-email` | XS | nur bei Datei-Touch |
+| **7** | P3-3 DE/EN-Dateinamen | ✅ Slice | `ai-draft-*`, `customer-control-link-email`; API `/api/ai-draft` + Redirect; UI-Copy „Sperrlink“/Event `ki_entwurf_generated` bleiben | — | Rest nur bei Touch |
 | **8** | `references`/`evidence` Pfade | ✅ | App = `references` (Routen/Ordner/`ROUTES`); Redirects `/dashboard/evidence` bleiben; `evidence_events` bleibt | — | Rest-`evidence` nur Domänenbegriff (RFP-Belege) |
 | **9** | DB-Legacy Invite-Helfer | ✅ skip | App-`.rpc`-Caller = 0, aber **SQL-intern** weiter von Invite-RPCs genutzt → nicht droppen | — | behalten |
 | **10** | Rest-`console.*` | erledigt (App/Lib) | Logger-Sink + Scripts behalten; später Sentry/Logflare | — | kein Ticket |
@@ -83,7 +83,6 @@ Bei Feature-PRs mitnehmen, **kein** Massen-PR:
 
 - God-Files weiter splitten (#5)  
 - `{ ok }` → `{ success }` (#6)  
-- DE/EN-Dateinamen (#7)  
 - Service-Role-Caller mit Org/Token-Kommentar (#1 Rest)
 
 ---
@@ -100,7 +99,7 @@ Bei Feature-PRs mitnehmen, **kein** Massen-PR:
 
 ## Session-Start (kurz)
 
-1. Dieses Dokument lesen — Default: Boy-Scout #5–7 bei Feature-Touch.  
+1. Dieses Dokument lesen — Default: Boy-Scout #5–6 bei Feature-Touch.  
 2. Kein weiterer Big-Bang in der offenen Queue.  
 3. Nach Abschluss: Status hier + Inventar anpassen.
 

--- a/lib/ai-draft-prompt.ts
+++ b/lib/ai-draft-prompt.ts
@@ -1,14 +1,14 @@
 import { formatIndustryDisplay } from '@/lib/constants/industries'
 
 /** Epic 5: Ausgabeformate für KI-Entwurf (Wireframe §15). */
-export type KiEntwurfOutputFormat =
+export type AiDraftOutputFormat =
   | 'email_snippet'
   | 'proposal_passage'
   | 'elevator_pitch'
 
-export type KiEntwurfTone = 'professional' | 'casual' | 'formal'
+export type AiDraftTone = 'professional' | 'casual' | 'formal'
 
-export type KiEntwurfReferencePayload = {
+export type AiDraftReferencePayload = {
   title: string
   summary: string | null
   customerChallenge: string | null
@@ -17,7 +17,7 @@ export type KiEntwurfReferencePayload = {
   companyName: string | null
 }
 
-const FORMAT_INSTRUCTIONS: Record<KiEntwurfOutputFormat, string> = {
+const FORMAT_INSTRUCTIONS: Record<AiDraftOutputFormat, string> = {
   email_snippet:
     'Format: **E-Mail-Snippet** (Anschreiben-Charakter). Anrede optional, 1 kurzer Absatz Fließtext, professioneller Abschluss. Keine Bullet-Listen, keine Betreff-Zeile erzwingen.',
   proposal_passage:
@@ -26,7 +26,7 @@ const FORMAT_INSTRUCTIONS: Record<KiEntwurfOutputFormat, string> = {
     'Format: **Elevator Pitch** – **genau drei Sätze**, nacheinander nummeriert implizit nur durch Zeilenumbruch (keine „1.“-Liste), maximal prägnant.',
 }
 
-const TONE_INSTRUCTIONS: Record<KiEntwurfTone, string> = {
+const TONE_INSTRUCTIONS: Record<AiDraftTone, string> = {
   professional:
     'Tonalität: **Professionell** – Siezen, sachlich, vertrauenswürdig, typisch B2B-Vertrieb.',
   casual:
@@ -38,11 +38,11 @@ const TONE_INSTRUCTIONS: Record<KiEntwurfTone, string> = {
 /**
  * Baut den Nutzer-Prompt für GPT-4o (Deutsch, nur Fließtext-Ausgabe).
  */
-export function buildKiEntwurfUserPrompt(params: {
-  reference: KiEntwurfReferencePayload
+export function buildAiDraftUserPrompt(params: {
+  reference: AiDraftReferencePayload
   matchScore: number
-  outputFormat: KiEntwurfOutputFormat
-  tone: KiEntwurfTone
+  outputFormat: AiDraftOutputFormat
+  tone: AiDraftTone
   additionalContext?: string | null
   dealContext?: string | null
 }): string {

--- a/lib/deals/build-deal-context-for-ai-draft.ts
+++ b/lib/deals/build-deal-context-for-ai-draft.ts
@@ -2,7 +2,7 @@ import { formatIndustryDisplay } from '@/lib/constants/industries'
 import type { DealWithReferences } from '@/app/dashboard/deals/types'
 
 /** Kontextzeilen für KI-Entwurf (Epic 5 / KAN-128). */
-export function buildDealContextForKiEntwurf(deal: DealWithReferences): string {
+export function buildDealContextForAiDraft(deal: DealWithReferences): string {
   const parts = [
     deal.title ? `Deal: ${deal.title}` : null,
     deal.company_name ? `Account: ${deal.company_name}` : null,

--- a/lib/references/client-approval-confirmation-email.ts
+++ b/lib/references/client-approval-confirmation-email.ts
@@ -6,7 +6,7 @@ import {
   resolveCustomerApprovalRecipient,
   type CustomerApprovalRecipientRow,
 } from '@/lib/references/customer-approval-recipient'
-import { sendCustomerSperrlinkEmail } from '@/lib/references/customer-sperrlink-email'
+import { sendCustomerControlLinkEmail } from '@/lib/references/customer-control-link-email'
 import { log } from '@/lib/observability/logger'
 
 export async function sendClientApprovalConfirmationEmail(args: {
@@ -42,7 +42,7 @@ export async function sendClientApprovalConfirmationEmail(args: {
     return false
   }
 
-  return sendCustomerSperrlinkEmail({
+  return sendCustomerControlLinkEmail({
     admin: args.admin,
     organizationId: args.organizationId,
     refTitle: args.refTitle,

--- a/lib/references/customer-control-link-email.test.ts
+++ b/lib/references/customer-control-link-email.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildCustomerControlLoopEmailHtml } from './customer-sperrlink-email'
+import { buildCustomerControlLoopEmailHtml } from './customer-control-link-email'
 
 describe('buildCustomerControlLoopEmailHtml', () => {
   it('includes vendor org and control copy with CTA', () => {

--- a/lib/references/customer-control-link-email.ts
+++ b/lib/references/customer-control-link-email.ts
@@ -43,7 +43,7 @@ export function buildCustomerControlLoopEmailHtml(args: {
   })
 }
 
-export async function sendCustomerSperrlinkEmail(args: {
+export async function sendCustomerControlLinkEmail(args: {
   admin: SupabaseClient
   organizationId: string | null | undefined
   refTitle: string
@@ -80,7 +80,7 @@ export async function sendCustomerSperrlinkEmail(args: {
     })
     return true
   } catch (e) {
-    log.error('send failed', { action: 'sendCustomerSperrlinkEmail.send' }, e)
+    log.error('send failed', { action: 'sendCustomerControlLinkEmail.send' }, e)
     return false
   }
 }

--- a/lib/references/library/ai-draft-log.ts
+++ b/lib/references/library/ai-draft-log.ts
@@ -2,14 +2,14 @@
 
 import { logEventForCurrentOrg } from '@/lib/events/log-event'
 
-import type { KiEntwurfOutputFormat, KiEntwurfTone } from '@/lib/ki-entwurf-prompt'
+import type { AiDraftOutputFormat, AiDraftTone } from '@/lib/ai-draft-prompt'
 
 /** Nach erfolgreicher Stream-Generierung (Client ruft nach Abschluss auf). */
-export async function recordKiEntwurfGenerated(args: {
+export async function recordAiDraftGenerated(args: {
   referenceId: string
   dealId?: string | null
-  outputFormat: KiEntwurfOutputFormat
-  tone: KiEntwurfTone
+  outputFormat: AiDraftOutputFormat
+  tone: AiDraftTone
 }): Promise<void> {
   await logEventForCurrentOrg({
     eventType: 'ki_entwurf_generated',
@@ -18,7 +18,7 @@ export async function recordKiEntwurfGenerated(args: {
     payload: {
       output_format: args.outputFormat,
       tone: args.tone,
-      source: 'ki_entwurf_sheet',
+      source: 'ai_draft_sheet',
     },
   })
 }

--- a/lib/references/library/sharing.ts
+++ b/lib/references/library/sharing.ts
@@ -11,7 +11,7 @@ import { logEvent } from '@/lib/events/log-event'
 import { parseOrgPublicLinkPolicy } from '@/lib/organization-link-policy'
 import { writeAuditLog } from '@/lib/audit/log-audit'
 import { getAppOrigin } from '@/lib/env/app-origin'
-import { sendCustomerSperrlinkEmail } from '@/lib/references/customer-sperrlink-email'
+import { sendCustomerControlLinkEmail } from '@/lib/references/customer-control-link-email'
 import { log } from '@/lib/observability/logger'
 import {
   buildCustomerManageUrl,
@@ -292,7 +292,7 @@ export async function createSharedPortfolioImpl(
   return { success: false, error: 'Slug-Kollision. Bitte erneut versuchen.' }
 }
 
-async function notifyCustomerOfSperrlink(
+async function notifyCustomerOfControlLink(
   supabase: SupabaseClient,
   referenceId: string,
   manageUrl: string,
@@ -324,7 +324,7 @@ async function notifyCustomerOfSperrlink(
 
   const companyName = accountFromJoin(ref.companies)?.name?.trim() || 'Referenz'
 
-  return sendCustomerSperrlinkEmail({
+  return sendCustomerControlLinkEmail({
     admin: supabase,
     organizationId: ref.organization_id,
     refTitle: String(ref.title ?? 'Referenz'),
@@ -478,7 +478,7 @@ export async function resetSharedPortfolioManageTokenImpl(
     const previewUrl = await getPublicPreviewUrlForReference(supabase, referenceId)
     if (previewUrl) {
       const manageUrl = buildCustomerManageUrl(previewUrl, payload.token)
-      customerEmailSent = await notifyCustomerOfSperrlink(
+      customerEmailSent = await notifyCustomerOfControlLink(
         supabase,
         referenceId,
         manageUrl,

--- a/lib/routes.ts
+++ b/lib/routes.ts
@@ -110,4 +110,10 @@ export const LEGACY_REDIRECTS = [
     destination: ROUTES.marketSignalsManage,
     permanent: true,
   },
+  // P3-3: alte KI-Entwurf-API → ai-draft
+  {
+    source: '/api/ki-entwurf/stream',
+    destination: '/api/ai-draft/stream',
+    permanent: false,
+  },
 ] as const


### PR DESCRIPTION
## Summary
- Queue **#7** / P3-3: `ki-entwurf-*` → `ai-draft-*`, `customer-sperrlink-email` → `customer-control-link-email` (Dateien + Exports).
- API `/api/ai-draft/stream` mit Redirect von `/api/ki-entwurf/stream`.
- Bewusst unverändert: UI-Copy „Sperrlink“/„KI-Entwurf“, DB-Enum `ki_entwurf_generated`.

## Test plan
- [x] `npm run typecheck`
- [x] `vitest` customer-control-link-email
- [ ] KI-Entwurf Sheet öffnen (Match/RFP-Drafts) und Stream erzeugen
- [ ] Freigabe/Sperrlink-Mail-Pfad (Control-Link) unverändert


Made with [Cursor](https://cursor.com)