### PR TITLE
refactor(#6): ok→success for auth/CRM slice

### DIFF
--- a/app/api/integrations/hubspot/callback/route.ts
+++ b/app/api/integrations/hubspot/callback/route.ts
@@ -33,7 +33,7 @@ export async function GET(request: Request) {
 
   try {
     const guard = await requireCrmAdmin()
-    if (!guard.ok) {
+    if (!guard.success) {
       return redirectWithStatus('error', returnTo)
     }
 

--- a/app/api/integrations/hubspot/connect/route.ts
+++ b/app/api/integrations/hubspot/connect/route.ts
@@ -28,7 +28,7 @@ export async function GET(request: Request) {
 
   try {
     const guard = await requireCrmAdmin()
-    if (!guard.ok) {
+    if (!guard.success) {
       return redirectWithError(returnTo)
     }
 

--- a/app/api/integrations/hubspot/disconnect/route.ts
+++ b/app/api/integrations/hubspot/disconnect/route.ts
@@ -7,7 +7,7 @@ import { log } from '@/lib/observability/logger'
 export async function POST() {
   try {
     const guard = await requireCrmAdmin()
-    if (!guard.ok) {
+    if (!guard.success) {
       return NextResponse.json({ error: guard.error }, { status: guard.status })
     }
 

--- a/app/api/integrations/hubspot/discover/route.ts
+++ b/app/api/integrations/hubspot/discover/route.ts
@@ -10,7 +10,7 @@ export const maxDuration = 60
 export async function GET() {
   try {
     const guard = await requireCrmAdmin()
-    if (!guard.ok) {
+    if (!guard.success) {
       return NextResponse.json({ error: guard.error }, { status: guard.status })
     }
 

--- a/app/api/integrations/hubspot/import/route.ts
+++ b/app/api/integrations/hubspot/import/route.ts
@@ -16,7 +16,7 @@ type ImportBody = {
 export async function POST(request: Request) {
   try {
     const guard = await requireCrmAdmin()
-    if (!guard.ok) {
+    if (!guard.success) {
       return NextResponse.json({ error: guard.error }, { status: guard.status })
     }
 

--- a/app/api/integrations/hubspot/status/route.ts
+++ b/app/api/integrations/hubspot/status/route.ts
@@ -8,7 +8,7 @@ import { log } from '@/lib/observability/logger'
 export async function GET() {
   try {
     const guard = await requireCrmAdmin()
-    if (!guard.ok) {
+    if (!guard.success) {
       return NextResponse.json({ error: guard.error }, { status: guard.status })
     }
 

--- a/app/auth/update-password/actions.ts
+++ b/app/auth/update-password/actions.ts
@@ -15,7 +15,7 @@ export async function updatePasswordAfterReset(
 
   if (!password) return { error: 'Bitte neues Passwort eingeben.' }
   const policy = validatePasswordPolicy(password)
-  if (!policy.ok) return { error: policy.error }
+  if (!policy.success) return { error: policy.error }
   if (password !== confirm) {
     return { error: 'Die Passwörter stimmen nicht überein.' }
   }

--- a/app/dashboard/settings/actions.ts
+++ b/app/dashboard/settings/actions.ts
@@ -202,7 +202,7 @@ export async function changeOwnPassword(
     return { error: 'Die neuen Passwörter stimmen nicht überein.' }
   }
   const policy = validatePasswordPolicy(newPassword)
-  if (!policy.ok) return { error: policy.error }
+  if (!policy.success) return { error: policy.error }
 
   const { error: signInError } = await supabase.auth.signInWithPassword({
     email: user.email,

--- a/app/login/actions.ts
+++ b/app/login/actions.ts
@@ -71,7 +71,7 @@ export async function sendMagicLinkSignIn(formData: FormData): Promise<AltSignIn
     inviteToken,
   })
 
-  if (resendResult.ok) {
+  if (resendResult.success) {
     return { success: successMessage }
   }
 

--- a/app/register/actions.ts
+++ b/app/register/actions.ts
@@ -100,7 +100,7 @@ export async function signUp(formData: FormData): Promise<SignUpResult> {
   if (!email) return { error: 'Bitte E-Mail-Adresse eingeben.' }
   if (!password) return { error: 'Bitte Passwort eingeben.' }
   const policy = validatePasswordPolicy(password)
-  if (!policy.ok) return { error: policy.error }
+  if (!policy.success) return { error: policy.error }
 
   const supabase = await createServerSupabaseClient()
 

--- a/docs/tech-debt-offen-backlog.md
+++ b/docs/tech-debt-offen-backlog.md
@@ -11,8 +11,8 @@
 | Status | Themen |
 |--------|--------|
 | **Erledigt** | Inventar-Hygiene (#0); E4 (#1); E7 (#2); **P1-6** (#4); Welle-5 Rollen; Typed-Supabase **T1–T4** (#3); **#8** `references`-Pfade; **#9** Invite-SQL skip; **#7** DE/EN-Dateinamen (ki-entwurf/sperrlink) |
-| **In Arbeit** | — |
-| **Offen (Queue)** | #5 God-Files (Boy-Scout) · #6 `{ ok }` → `{ success }` (Boy-Scout) |
+| **In Arbeit** | #6 `{ ok }` → `{ success }` (Slice 1 Auth/CRM) |
+| **Offen (Queue)** | #5 God-Files (Boy-Scout) · #6 Rest (Extract/Approvals/Cron) |
 | **Geparkt** | Pilot (H3/E1/G2); Massen-Renames |
 
 **Hebel jetzt:** Boy-Scout #5–6 bei Feature-Touch. Big-Bang-Queue leer.
@@ -29,7 +29,7 @@
 | **3** | Typed-Supabase Cast-Abbau | ✅ T1–T4 | Rest-Casts nur Boundaries (HTTP/RPC/Json); Boy-Scout bei Touch | — | CI: `typecheck` vor Build |
 | **4** | P1-6 Accounts Naming | ✅ App/Lib | DB-Tabelle `companies` / `company_id` / Firmennamen-Helfer **bewusst offen** | — | nicht anfassen ohne Produktentscheid |
 | **5** | God-File-Nacharbeit | offen (Boy-Scout) | Overview / Share-Link / MS-Feed weiter slicen **nur bei Feature-Touch** | M ongoing | kein eigener Big-Bang-PR |
-| **6** | `{ ok }` → `{ success }` | offen (Boy-Scout) | ~130 Matches in Libs/Cron | S–M | bei Lib-Berührung mitziehen |
+| **6** | `{ ok }` → `{ success }` | Slice 1 ✅ | Auth/CRM: password-policy, magic-link, requireCrmAdmin, hubSpotApiFetch | S remaining | nächster: Extract / Internal-Approval; Cron-JSON bewusst später |
 | **7** | P3-3 DE/EN-Dateinamen | ✅ Slice | `ai-draft-*`, `customer-control-link-email`; API `/api/ai-draft` + Redirect; UI-Copy „Sperrlink“/Event `ki_entwurf_generated` bleiben | — | Rest nur bei Touch |
 | **8** | `references`/`evidence` Pfade | ✅ | App = `references` (Routen/Ordner/`ROUTES`); Redirects `/dashboard/evidence` bleiben; `evidence_events` bleibt | — | Rest-`evidence` nur Domänenbegriff (RFP-Belege) |
 | **9** | DB-Legacy Invite-Helfer | ✅ skip | App-`.rpc`-Caller = 0, aber **SQL-intern** weiter von Invite-RPCs genutzt → nicht droppen | — | behalten |
@@ -76,6 +76,17 @@ Welle-5 T3 („Module nach `evidence`“) ist **obsolet** — gegenläufig und n
 
 **Check 2026-08-06:** Keine App-Aufrufe von `resolve_invite_roles` / `legacy_role_from_dimensions` via `.rpc`.
 Die Funktionen bleiben **DB-intern** (Invite create/accept/list RPCs in Migrationen) — Drop wäre kein Kosmetik-PR.
+
+## Queue #6 — `{ ok }` → `{ success }`
+
+| Slice | Stand |
+|-------|-------|
+| 1 Auth/CRM | ✅ password-policy (`Result`), magic-link, `requireCrmAdmin`, `hubSpotApiFetch` + HubSpot-Caller |
+| Rest | offen: Document-Extract, Internal-Approval, Bulk-Import, Cron/Push-JSON (`ok` als HTTP-Body) |
+
+Cron-/Push-Responses mit `{ ok: true }` sind **HTTP-Vertrags**-ähnlich — separat entscheiden, nicht blind umbiegen.
+
+---
 
 ## Boy-Scout (kein eigener Sprint)
 

--- a/lib/auth/send-magic-link-email.ts
+++ b/lib/auth/send-magic-link-email.ts
@@ -14,9 +14,9 @@ import { log } from '@/lib/observability/logger'
 import { createServiceRoleSupabaseClient } from '@/lib/supabase/service-role'
 
 export type SendMagicLinkEmailResult =
-  | { ok: true; delivery: 'resend' }
+  | { success: true; delivery: 'resend' }
   | {
-      ok: false
+      success: false
       reason: 'not_configured' | 'user_not_found' | 'generate_failed' | 'send_failed'
       message?: string
     }
@@ -31,7 +31,7 @@ export async function sendMagicLinkEmailViaResend(params: {
   // Grenze: nur Auth-Operation für die angegebene E-Mail-Adresse.
   const admin = createServiceRoleSupabaseClient()
   if (!admin || !resendKey) {
-    return { ok: false, reason: 'not_configured' }
+    return { success: false, reason: 'not_configured' }
   }
 
   const { data, error } = await admin.auth.admin.generateLink({
@@ -46,19 +46,19 @@ export async function sendMagicLinkEmailViaResend(params: {
   if (error || !actionLink) {
     const message = error?.message ?? ''
     if (/user not found/i.test(message) || /not found/i.test(message)) {
-      return { ok: false, reason: 'user_not_found', message }
+      return { success: false, reason: 'user_not_found', message }
     }
     log.error(
       'generateLink failed',
       { action: 'sendMagicLinkEmailViaResend.generateLink' },
       error,
     )
-    return { ok: false, reason: 'generate_failed', message }
+    return { success: false, reason: 'generate_failed', message }
   }
 
   if (shouldMockResendSend()) {
     log.info('RESEND_MOCK_SUCCESS', { action: 'sendMagicLinkEmailViaResend.mock' })
-    return { ok: true, delivery: 'resend' }
+    return { success: true, delivery: 'resend' }
   }
 
   const recipient = resolveResendRecipient(params.email)
@@ -92,7 +92,7 @@ export async function sendMagicLinkEmailViaResend(params: {
     if (sendError) {
       if (isResendSandboxRecipientError(sendError.message)) {
         return {
-          ok: false,
+          success: false,
           reason: 'send_failed',
           message:
             'E-Mail konnte nicht gesendet werden. In Resend sind nur verifizierte Test-Empfänger erlaubt – RESEND_DEV_OVERRIDE_TO setzen oder Domain verifizieren.',
@@ -103,12 +103,12 @@ export async function sendMagicLinkEmailViaResend(params: {
         { action: 'sendMagicLinkEmailViaResend.send' },
         sendError,
       )
-      return { ok: false, reason: 'send_failed', message: sendError.message }
+      return { success: false, reason: 'send_failed', message: sendError.message }
     }
 
-    return { ok: true, delivery: 'resend' }
+    return { success: true, delivery: 'resend' }
   } catch (e) {
     log.error('Resend exception', { action: 'sendMagicLinkEmailViaResend.send' }, e)
-    return { ok: false, reason: 'send_failed' }
+    return { success: false, reason: 'send_failed' }
   }
 }

--- a/lib/crm/hubspot/client.ts
+++ b/lib/crm/hubspot/client.ts
@@ -77,10 +77,10 @@ export async function hubSpotApiFetch<T>(
   organizationId: string,
   path: string,
   init?: RequestInit,
-): Promise<{ ok: true; data: T } | { ok: false; error: string; status: number }> {
+): Promise<{ success: true; data: T } | { success: false; error: string; status: number }> {
   const accessToken = await getHubSpotAccessTokenForOrg(supabase, organizationId)
   if (!accessToken) {
-    return { ok: false, error: 'HubSpot ist nicht verbunden.', status: 401 }
+    return { success: false, error: 'HubSpot ist nicht verbunden.', status: 401 }
   }
 
   const res = await fetch(`https://api.hubapi.com${path}`, {
@@ -95,14 +95,14 @@ export async function hubSpotApiFetch<T>(
   if (!res.ok) {
     const err = (await res.json().catch(() => ({}))) as HubSpotApiError
     return {
-      ok: false,
+      success: false,
       error: err.message ?? `HubSpot API Fehler (${res.status})`,
       status: res.status,
     }
   }
 
   const data = (await res.json()) as T
-  return { ok: true, data }
+  return { success: true, data }
 }
 
 export function buildHubSpotDealUrl(params: {

--- a/lib/crm/hubspot/list-accounts-with-opportunities.ts
+++ b/lib/crm/hubspot/list-accounts-with-opportunities.ts
@@ -67,7 +67,7 @@ async function fetchAllOpenDeals(
       { method: 'POST', body: JSON.stringify(body) },
     )
 
-    if (!res.ok) break
+    if (!res.success) break
 
     const batch = res.data.results ?? []
     deals.push(...batch)
@@ -101,7 +101,7 @@ async function fetchCompaniesByIds(
       },
     )
 
-    if (!res.ok) continue
+    if (!res.success) continue
 
     for (const row of res.data.results ?? []) {
       const name = String(row.properties?.name ?? '').trim()
@@ -153,7 +153,7 @@ export async function listHubSpotAccountsWithOpenOpportunities(
     },
   )
 
-  if (!associations.ok) {
+  if (!associations.success) {
     return { success: false, error: associations.error }
   }
 

--- a/lib/crm/require-crm-admin.ts
+++ b/lib/crm/require-crm-admin.ts
@@ -10,8 +10,8 @@ export type CrmAdminContext = {
 }
 
 export type CrmAdminGuardResult =
-  | { ok: true; ctx: CrmAdminContext }
-  | { ok: false; error: string; status: number }
+  | { success: true; ctx: CrmAdminContext }
+  | { success: false; error: string; status: number }
 
 /** Nur Workspace-Admins dürfen CRM-Verbindungen verwalten und importieren. */
 export async function requireCrmAdmin(): Promise<CrmAdminGuardResult> {
@@ -21,7 +21,7 @@ export async function requireCrmAdmin(): Promise<CrmAdminGuardResult> {
   } = await supabase.auth.getUser()
 
   if (!user) {
-    return { ok: false, error: 'Nicht angemeldet.', status: 401 }
+    return { success: false, error: 'Nicht angemeldet.', status: 401 }
   }
 
   const { data: profile } = await supabase
@@ -31,20 +31,20 @@ export async function requireCrmAdmin(): Promise<CrmAdminGuardResult> {
     .single()
 
   if (!profile?.organization_id) {
-    return { ok: false, error: 'Onboarding unvollständig.', status: 403 }
+    return { success: false, error: 'Onboarding unvollständig.', status: 403 }
   }
 
   const { systemRole } = parseProfileRoles(profile)
   if (!isSystemAdmin(systemRole)) {
     return {
-      ok: false,
+      success: false,
       error: 'Nur Administratoren können CRM-Verbindungen verwalten.',
       status: 403,
     }
   }
 
   return {
-    ok: true,
+    success: true,
     ctx: {
       supabase,
       user,

--- a/lib/crm/sync-hubspot-won-deals.ts
+++ b/lib/crm/sync-hubspot-won-deals.ts
@@ -77,7 +77,7 @@ async function fetchClosedWonDeals(
       { method: 'POST', body: JSON.stringify(body) },
     )
 
-    if (!res.ok) break
+    if (!res.success) break
 
     const batch = (res.data.results ?? []).filter((deal) => {
       const stage = deal.properties?.dealstage ?? ''
@@ -125,7 +125,7 @@ export async function syncHubSpotWonDealsForOrganization(
     },
   )
 
-  if (!associations.ok) return { upserted: 0, skipped: dealIds.length }
+  if (!associations.success) return { upserted: 0, skipped: dealIds.length }
 
   const companyIdByDealId = new Map<string, string>()
   for (const row of associations.data.results ?? []) {

--- a/lib/security/password-policy.ts
+++ b/lib/security/password-policy.ts
@@ -1,4 +1,6 @@
-export type PasswordPolicyResult = { ok: true } | { ok: false; error: string }
+import { err, ok, type Result } from '@/lib/observability/result'
+
+export type PasswordPolicyResult = Result<void>
 
 const COMMON_PASSWORDS = new Set([
   'password',
@@ -16,34 +18,22 @@ const COMMON_PASSWORDS = new Set([
 export function validatePasswordPolicy(password: string): PasswordPolicyResult {
   const value = String(password ?? '')
   if (value.length < 12) {
-    return { ok: false, error: 'Das Passwort muss mindestens 12 Zeichen lang sein.' }
+    return err('Das Passwort muss mindestens 12 Zeichen lang sein.')
   }
   if (!/[A-Z]/.test(value)) {
-    return {
-      ok: false,
-      error: 'Das Passwort muss mindestens einen Großbuchstaben enthalten.',
-    }
+    return err('Das Passwort muss mindestens einen Großbuchstaben enthalten.')
   }
   if (!/[a-z]/.test(value)) {
-    return {
-      ok: false,
-      error: 'Das Passwort muss mindestens einen Kleinbuchstaben enthalten.',
-    }
+    return err('Das Passwort muss mindestens einen Kleinbuchstaben enthalten.')
   }
   if (!/[0-9]/.test(value)) {
-    return { ok: false, error: 'Das Passwort muss mindestens eine Zahl enthalten.' }
+    return err('Das Passwort muss mindestens eine Zahl enthalten.')
   }
   if (!/[^A-Za-z0-9]/.test(value)) {
-    return {
-      ok: false,
-      error: 'Das Passwort muss mindestens ein Sonderzeichen enthalten.',
-    }
+    return err('Das Passwort muss mindestens ein Sonderzeichen enthalten.')
   }
   if (COMMON_PASSWORDS.has(value.toLowerCase())) {
-    return {
-      ok: false,
-      error: 'Dieses Passwort ist zu häufig. Bitte wähle ein stärkeres Passwort.',
-    }
+    return err('Dieses Passwort ist zu häufig. Bitte wähle ein stärkeres Passwort.')
   }
-  return { ok: true }
+  return ok()
 }


### PR DESCRIPTION
## Summary
- Queue **#6** Slice 1: `password-policy` → `Result`/`success`; magic-link, `requireCrmAdmin`, `hubSpotApiFetch` + Caller.
- Cron/Push-JSON `{ ok }` bewusst **nicht** angefasst (HTTP-Vertrag).
- Backlog: Rest ~105 Matches (Extract/Approvals/…).

## Test plan
- [x] `npm run typecheck`
- [ ] Login Magic-Link (Resend-Pfad)
- [ ] Passwort ändern / Register Policy-Fehler
- [ ] HubSpot Status/Connect als Admin


Made with [Cursor](https://cursor.com)