### PR TITLE
refactor(#6): ok→success for document extract slice

### DIFF
--- a/app/api/bulk-import/preview/route.ts
+++ b/app/api/bulk-import/preview/route.ts
@@ -33,7 +33,7 @@ export async function POST(request: Request) {
 
     const buffer = Buffer.from(await file.arrayBuffer())
     const plain = await extractPlainTextFromBuffer(buffer, file.name, file.type)
-    if (!plain.ok) {
+    if (!plain.success) {
       return NextResponse.json({ success: false, error: plain.error }, { status: 400 })
     }
 

--- a/app/api/rfp/analyze/route.ts
+++ b/app/api/rfp/analyze/route.ts
@@ -216,12 +216,12 @@ export async function POST(req: NextRequest) {
   }
 
   const loaded = await loadDealDocumentAsFile(supabase, dealDoc)
-  if (!loaded.ok) {
+  if (!loaded.success) {
     return fail(loaded.error, 400)
   }
 
   const plain = await extractRfpPlainTextFromFile(loaded.file, { maxChars: 120_000 })
-  if (!plain.ok) {
+  if (!plain.success) {
     return fail(plain.error, 400)
   }
 

--- a/app/dashboard/deals/cockpit/deal-documents-section.tsx
+++ b/app/dashboard/deals/cockpit/deal-documents-section.tsx
@@ -138,7 +138,7 @@ function DocumentDropzone({
   function acceptFile(next: File | undefined) {
     if (!next) return
     const validation = validateDealDocumentUpload(next, kind)
-    if (!validation.ok) {
+    if (!validation.success) {
       toast.error(validation.error)
       return
     }
@@ -284,7 +284,7 @@ export function DealDocumentsSection({
     setAnalyzingId(doc.id)
     try {
       const result = await runDealRfpAnalyze(dealId, doc)
-      if (!result.ok) {
+      if (!result.success) {
         toast.error(result.error ?? COPY.deals.cockpit.documentsAnalyzeFailed)
         return
       }
@@ -558,7 +558,7 @@ export function DealDocumentsSection({
                   setUploadKind(kind)
                   if (uploadFile) {
                     const validation = validateDealDocumentUpload(uploadFile, kind)
-                    if (!validation.ok) {
+                    if (!validation.success) {
                       toast.error(validation.error)
                       setUploadFile(null)
                     }

--- a/app/dashboard/deals/cockpit/deal-rfp-analyze-button.tsx
+++ b/app/dashboard/deals/cockpit/deal-rfp-analyze-button.tsx
@@ -29,9 +29,9 @@ async function ensureAusschreibungKind(doc: DealDocumentRow): Promise<boolean> {
 export async function runDealRfpAnalyze(
   dealId: string,
   doc: DealDocumentRow,
-): Promise<{ ok: boolean; error?: string }> {
+): Promise<{ success: boolean; error?: string }> {
   const kindOk = await ensureAusschreibungKind(doc)
-  if (!kindOk) return { ok: false }
+  if (!kindOk) return { success: false }
 
   const res = await fetch('/api/rfp/analyze', {
     method: 'POST',
@@ -40,9 +40,9 @@ export async function runDealRfpAnalyze(
   })
   const json = (await res.json()) as { success?: boolean; error?: string }
   if (!res.ok || !json.success) {
-    return { ok: false, error: json.error ?? COPY.deals.cockpit.documentsAnalyzeFailed }
+    return { success: false, error: json.error ?? COPY.deals.cockpit.documentsAnalyzeFailed }
   }
-  return { ok: true }
+  return { success: true }
 }
 
 export function DealRfpAnalyzeButton({
@@ -80,7 +80,7 @@ export function DealRfpAnalyzeButton({
     setPending(true)
     try {
       const result = await runDealRfpAnalyze(dealId, targetDoc)
-      if (!result.ok) {
+      if (!result.success) {
         toast.error(result.error ?? COPY.deals.cockpit.documentsAnalyzeFailed)
         return
       }

--- a/app/dashboard/deals/document-actions.ts
+++ b/app/dashboard/deals/document-actions.ts
@@ -138,11 +138,11 @@ async function attachUploaderNames(
 function assertCanManageDeal(
   auth: Extract<DocumentAuth, { userId: string }>,
   deal: DealAccessRow,
-): { ok: true } | { error: string } {
+): { success: true } | { error: string } {
   if (!canManageDealDocuments(deal, auth.userId, auth.systemRole, auth.functionRole)) {
     return { error: 'Keine Berechtigung, Dokumente an diesem Deal zu verwalten.' }
   }
-  return { ok: true }
+  return { success: true }
 }
 
 function revalidateDealPage(dealId: string) {
@@ -201,7 +201,7 @@ export async function uploadDealDocument(
   }
 
   const validation = validateDealDocumentUpload(file, kind)
-  if (!validation.ok) {
+  if (!validation.success) {
     return { success: false, error: validation.error }
   }
 
@@ -304,7 +304,7 @@ export async function setDealDocumentKind(
       size: Number(docRes.row.size_bytes),
     }
     const validation = validateDealDocumentUpload(pseudoFile, kind)
-    if (!validation.ok) {
+    if (!validation.success) {
       return { success: false, error: validation.error }
     }
   }

--- a/docs/tech-debt-offen-backlog.md
+++ b/docs/tech-debt-offen-backlog.md
@@ -11,8 +11,8 @@
 | Status | Themen |
 |--------|--------|
 | **Erledigt** | Inventar-Hygiene (#0); E4 (#1); E7 (#2); **P1-6** (#4); Welle-5 Rollen; Typed-Supabase **T1–T4** (#3); **#8** `references`-Pfade; **#9** Invite-SQL skip; **#7** DE/EN-Dateinamen (ki-entwurf/sperrlink) |
-| **In Arbeit** | #6 `{ ok }` → `{ success }` (Slice 1 Auth/CRM) |
-| **Offen (Queue)** | #5 God-Files (Boy-Scout) · #6 Rest (Extract/Approvals/Cron) |
+| **In Arbeit** | #6 `{ ok }` → `{ success }` (Slice 2 Extract) |
+| **Offen (Queue)** | #5 God-Files (Boy-Scout) · #6 Rest (Approvals/Cron) |
 | **Geparkt** | Pilot (H3/E1/G2); Massen-Renames |
 
 **Hebel jetzt:** Boy-Scout #5–6 bei Feature-Touch. Big-Bang-Queue leer.
@@ -29,7 +29,7 @@
 | **3** | Typed-Supabase Cast-Abbau | ✅ T1–T4 | Rest-Casts nur Boundaries (HTTP/RPC/Json); Boy-Scout bei Touch | — | CI: `typecheck` vor Build |
 | **4** | P1-6 Accounts Naming | ✅ App/Lib | DB-Tabelle `companies` / `company_id` / Firmennamen-Helfer **bewusst offen** | — | nicht anfassen ohne Produktentscheid |
 | **5** | God-File-Nacharbeit | offen (Boy-Scout) | Overview / Share-Link / MS-Feed weiter slicen **nur bei Feature-Touch** | M ongoing | kein eigener Big-Bang-PR |
-| **6** | `{ ok }` → `{ success }` | Slice 1 ✅ | Auth/CRM: password-policy, magic-link, requireCrmAdmin, hubSpotApiFetch | S remaining | nächster: Extract / Internal-Approval; Cron-JSON bewusst später |
+| **6** | `{ ok }` → `{ success }` | Slice 1–2 ✅ | Auth/CRM + Document-Extract/Deal-Docs | S remaining | nächster: Internal-Approval; Cron-JSON bewusst später |
 | **7** | P3-3 DE/EN-Dateinamen | ✅ Slice | `ai-draft-*`, `customer-control-link-email`; API `/api/ai-draft` + Redirect; UI-Copy „Sperrlink“/Event `ki_entwurf_generated` bleiben | — | Rest nur bei Touch |
 | **8** | `references`/`evidence` Pfade | ✅ | App = `references` (Routen/Ordner/`ROUTES`); Redirects `/dashboard/evidence` bleiben; `evidence_events` bleibt | — | Rest-`evidence` nur Domänenbegriff (RFP-Belege) |
 | **9** | DB-Legacy Invite-Helfer | ✅ skip | App-`.rpc`-Caller = 0, aber **SQL-intern** weiter von Invite-RPCs genutzt → nicht droppen | — | behalten |
@@ -82,7 +82,8 @@ Die Funktionen bleiben **DB-intern** (Invite create/accept/list RPCs in Migratio
 | Slice | Stand |
 |-------|-------|
 | 1 Auth/CRM | ✅ password-policy (`Result`), magic-link, `requireCrmAdmin`, `hubSpotApiFetch` + HubSpot-Caller |
-| Rest | offen: Document-Extract, Internal-Approval, Bulk-Import, Cron/Push-JSON (`ok` als HTTP-Body) |
+| 2 Document-Extract | ✅ `extractPlainText*`, RFP-Extract, `extractPlainTextFromBuffer`, Deal-Upload-Validate, `loadDealDocumentAsFile`, `runDealRfpAnalyze` |
+| Rest | offen: Internal-Approval, Bulk-Import-UI, Cron/Push-JSON (`ok` als HTTP-Body) |
 
 Cron-/Push-Responses mit `{ ok: true }` sind **HTTP-Vertrags**-ähnlich — separat entscheiden, nicht blind umbiegen.
 

--- a/lib/deals/deal-document-upload.test.ts
+++ b/lib/deals/deal-document-upload.test.ts
@@ -55,7 +55,7 @@ describe('deal-document-upload', () => {
       type: 'application/pdf',
       size: DEAL_DOCUMENT_STORAGE_MAX_BYTES,
     }
-    expect(validateDealDocumentUpload(file, 'sonstiges').ok).toBe(true)
+    expect(validateDealDocumentUpload(file, 'sonstiges').success).toBe(true)
   })
 
   it('rejects oversized ablage file', () => {
@@ -64,7 +64,7 @@ describe('deal-document-upload', () => {
       type: 'application/pdf',
       size: DEAL_DOCUMENT_STORAGE_MAX_BYTES + 1,
     }
-    expect(validateDealDocumentUpload(file, 'vertrag').ok).toBe(false)
+    expect(validateDealDocumentUpload(file, 'vertrag').success).toBe(false)
   })
 
   it('enforces analyzable limit for ausschreibung', () => {
@@ -73,7 +73,7 @@ describe('deal-document-upload', () => {
       type: 'application/pdf',
       size: DEAL_DOCUMENT_ANALYZABLE_MAX_BYTES + 1,
     }
-    expect(validateDealDocumentUpload(file, 'ausschreibung').ok).toBe(false)
+    expect(validateDealDocumentUpload(file, 'ausschreibung').success).toBe(false)
   })
 
   it('requires analyzable mime for ausschreibung', () => {
@@ -82,6 +82,6 @@ describe('deal-document-upload', () => {
       type: 'image/png',
       size: 1024,
     }
-    expect(validateDealDocumentUpload(file, 'ausschreibung').ok).toBe(false)
+    expect(validateDealDocumentUpload(file, 'ausschreibung').success).toBe(false)
   })
 })

--- a/lib/deals/deal-document-upload.ts
+++ b/lib/deals/deal-document-upload.ts
@@ -66,18 +66,18 @@ function isAnalyzableUpload(file: Pick<File, 'name' | 'type'>): boolean {
   return ANALYZABLE_EXTENSIONS.test(file.name)
 }
 
-export type ValidateDealDocumentUploadResult = { ok: true } | { ok: false; error: string }
+export type ValidateDealDocumentUploadResult = { success: true } | { success: false; error: string }
 
 export function validateDealDocumentUpload(
   file: Pick<File, 'name' | 'type' | 'size'>,
   kind: DealDocumentKind,
 ): ValidateDealDocumentUploadResult {
   if (!file.size) {
-    return { ok: false, error: 'Keine gültige Datei.' }
+    return { success: false, error: 'Keine gültige Datei.' }
   }
 
   if (!fileMatchesAllowedMime(file)) {
-    return { ok: false, error: 'Dateityp wird nicht unterstützt.' }
+    return { success: false, error: 'Dateityp wird nicht unterstützt.' }
   }
 
   const maxBytes =
@@ -89,17 +89,17 @@ export function validateDealDocumentUpload(
     const maxMb = (maxBytes / 1024 / 1024).toFixed(1)
     const actualMb = (file.size / 1024 / 1024).toFixed(1)
     return {
-      ok: false,
+      success: false,
       error: `Datei zu groß (max. ${maxMb} MB). Aktuell: ${actualMb} MB.`,
     }
   }
 
   if (kind === 'ausschreibung' && !isAnalyzableUpload(file)) {
     return {
-      ok: false,
+      success: false,
       error: 'Ausschreibungen müssen PDF, DOCX oder PPTX sein (für Analyse).',
     }
   }
 
-  return { ok: true }
+  return { success: true }
 }

--- a/lib/deals/load-deal-document-file.ts
+++ b/lib/deals/load-deal-document-file.ts
@@ -18,14 +18,14 @@ export type DealDocumentStorageRow = {
 export async function loadDealDocumentAsFile(
   supabase: SupabaseClient,
   doc: Pick<DealDocumentStorageRow, 'storage_path' | 'file_name' | 'mime_type'>,
-): Promise<{ ok: true; file: File } | { ok: false; error: string }> {
+): Promise<{ success: true; file: File } | { success: false; error: string }> {
   const { data, error } = await supabase.storage
     .from(DEAL_DOCUMENTS_BUCKET)
     .download(doc.storage_path)
 
   if (error || !data) {
     return {
-      ok: false,
+      success: false,
       error: error?.message ?? 'Datei konnte nicht aus dem Speicher geladen werden.',
     }
   }
@@ -35,5 +35,5 @@ export async function loadDealDocumentAsFile(
     type: doc.mime_type?.trim() || 'application/octet-stream',
   })
 
-  return { ok: true, file }
+  return { success: true, file }
 }

--- a/lib/document-extraction.ts
+++ b/lib/document-extraction.ts
@@ -268,12 +268,12 @@ export async function extractPlainTextFromBuffer(
   buffer: Buffer,
   fileName: string,
   mimeType?: string | null,
-): Promise<{ ok: true; text: string } | { ok: false; error: string }> {
+): Promise<{ success: true; text: string } | { success: false; error: string }> {
   const name = fileName || 'unbenannt'
   const size = buffer.length
   if (size > MAX_FILE_BYTES) {
     return {
-      ok: false,
+      success: false,
       error: `Datei zu groß (max. 4,5 MB). Aktuell: ${(size / 1024 / 1024).toFixed(1)} MB.`,
     }
   }
@@ -291,7 +291,7 @@ export async function extractPlainTextFromBuffer(
 
   if (!isPdf && !isPptx && !isDocx && !isDoc && !isImage) {
     return {
-      ok: false,
+      success: false,
       error:
         'Nur Word-, PowerPoint-, PDF- oder Bild-Dateien (PNG/JPEG/WebP) werden unterstützt.',
     }
@@ -320,15 +320,15 @@ export async function extractPlainTextFromBuffer(
     } else throw new Error('DOC_FORMAT_UNSUPPORTED')
     if (!documentText?.trim() || documentText.trim().length < 50) {
       return {
-        ok: false,
+        success: false,
         error:
           'Zu wenig erkennbarer Text (evtl. Scan/Bildqualität). Bitte Felder manuell ausfüllen.',
       }
     }
-    return { ok: true, text: documentText }
+    return { success: true, text: documentText }
   } catch (e) {
     const err = e instanceof Error ? e : new Error(String(e))
-    return { ok: false, error: mapDocumentExtractError(err, format) }
+    return { success: false, error: mapDocumentExtractError(err, format) }
   }
 }
 
@@ -342,7 +342,7 @@ export async function extractDataFromBuffer(
   options?: ExtractFromBufferOptions,
 ): Promise<ExtractDataFromDocumentResult> {
   const plain = await extractPlainTextFromBuffer(buffer, fileName, mimeType)
-  if (!plain.ok) return { success: false, error: plain.error }
+  if (!plain.success) return { success: false, error: plain.error }
 
   const documentText = plain.text
   const heuristicData = parseReferenceHeuristicsFromText(documentText, {

--- a/lib/extract-document-plain-text.ts
+++ b/lib/extract-document-plain-text.ts
@@ -22,13 +22,13 @@ async function extractTextFromDocx(buffer: Buffer): Promise<string> {
 
 export type ExtractPlainTextResult =
   | {
-      ok: true
+      success: true
       text: string
       extractionMethod?: 'native' | 'ocr'
       ocrTruncated?: boolean
       ocrPagesProcessed?: number
     }
-  | { ok: false; error: string; isScanLikely?: boolean; isQuotaError?: boolean }
+  | { success: false; error: string; isScanLikely?: boolean; isQuotaError?: boolean }
 
 /**
  * PDF oder DOCX → Klartext (Ausschnitt für RFP reicht oft mit Limit).
@@ -39,11 +39,11 @@ export async function extractPlainTextFromFile(
 ): Promise<ExtractPlainTextResult> {
   const maxChars = options?.maxChars ?? 120_000
   if (!file?.size) {
-    return { ok: false, error: 'Keine Datei übergeben.' }
+    return { success: false, error: 'Keine Datei übergeben.' }
   }
   if (file.size > MAX_BYTES) {
     return {
-      ok: false,
+      success: false,
       error: `Datei zu groß (max. 4,5 MB). Aktuell: ${(file.size / 1024 / 1024).toFixed(1)} MB.`,
     }
   }
@@ -57,7 +57,7 @@ export async function extractPlainTextFromFile(
     /\.docx$/i.test(fileName)
 
   if (!isPdf && !isDocx) {
-    return { ok: false, error: 'Nur PDF oder DOCX werden unterstützt.' }
+    return { success: false, error: 'Nur PDF oder DOCX werden unterstützt.' }
   }
 
   try {
@@ -67,10 +67,10 @@ export async function extractPlainTextFromFile(
       const pdf = await extractPdfPlainTextWithOcrFallback(buffer, { maxOcrPages: 40 })
       const t = pdf.text.trim()
       if (t.length < 40) {
-        return { ok: false, error: RFP_LOW_TEXT_ERROR, isScanLikely: true }
+        return { success: false, error: RFP_LOW_TEXT_ERROR, isScanLikely: true }
       }
       return {
-        ok: true,
+        success: true,
         text: t.slice(0, maxChars),
         extractionMethod: pdf.method,
         ocrTruncated: pdf.ocrTruncated,
@@ -81,16 +81,16 @@ export async function extractPlainTextFromFile(
     const text = await extractTextFromDocx(buffer)
     const t = text.trim()
     if (t.length < 40) {
-      return { ok: false, error: RFP_LOW_TEXT_ERROR, isScanLikely: true }
+      return { success: false, error: RFP_LOW_TEXT_ERROR, isScanLikely: true }
     }
-    return { ok: true, text: t.slice(0, maxChars), extractionMethod: 'native' }
+    return { success: true, text: t.slice(0, maxChars), extractionMethod: 'native' }
   } catch (e) {
     const msg = e instanceof Error ? e.message : ''
     if (isOpenAiQuotaErrorMessage(msg)) {
-      return { ok: false, error: msg, isQuotaError: true }
+      return { success: false, error: msg, isQuotaError: true }
     }
     return {
-      ok: false,
+      success: false,
       error: 'Text konnte aus der Datei nicht gelesen werden.',
     }
   }

--- a/lib/extract-rfp-plain-text.ts
+++ b/lib/extract-rfp-plain-text.ts
@@ -46,11 +46,11 @@ export async function extractRfpPlainTextFromFile(
   const mimeType = file.type ?? ''
 
   if (!file?.size) {
-    return { ok: false, error: 'Keine Datei übergeben.' }
+    return { success: false, error: 'Keine Datei übergeben.' }
   }
   if (file.size > MAX_BYTES) {
     return {
-      ok: false,
+      success: false,
       error: `Datei zu groß (max. 4,5 MB). Aktuell: ${(file.size / 1024 / 1024).toFixed(1)} MB.`,
     }
   }
@@ -61,16 +61,16 @@ export async function extractRfpPlainTextFromFile(
       const text = extractExcelPlainText(buffer).trim()
       if (text.length < 40) {
         return {
-          ok: false,
+          success: false,
           error:
             'In der Excel-Datei wurde zu wenig lesbarer Inhalt gefunden (leere oder rein formatierte Tabellen).',
           isScanLikely: false,
         }
       }
-      return { ok: true, text: text.slice(0, maxChars) }
+      return { success: true, text: text.slice(0, maxChars) }
     } catch {
       return {
-        ok: false,
+        success: false,
         error:
           'Excel konnte nicht gelesen werden. Bitte als XLSX speichern oder PDF/Word verwenden.',
       }

--- a/lib/references/library/bulk-import.ts
+++ b/lib/references/library/bulk-import.ts
@@ -27,7 +27,7 @@ async function extractMetadataFromFile(file: File) {
   if (!(file instanceof File) || file.size === 0) return null
   const buffer = Buffer.from(await file.arrayBuffer())
   const plain = await extractPlainTextFromBuffer(buffer, file.name, file.type)
-  if (!plain.ok) return null
+  if (!plain.success) return null
   return parseReferenceHeuristicsFromText(plain.text, { fileName: file.name })
 }
 


### PR DESCRIPTION
## Summary
- Queue **#6** Slice 2: Plain-Text/RFP-Extract, Buffer-Extract, Deal-Upload-Validate, `loadDealDocumentAsFile`, `runDealRfpAnalyze` (+ Caller).
- `Response.ok` unverändert; Cron/Push weiter offen.
- Rest ~69 `{ ok }`-Literale (Approvals, Bulk-UI, Cron, …).

## Test plan
- [x] `npm run typecheck`
- [x] `vitest` deal-document-upload
- [ ] Deal-Dokumente hochladen + Ausschreibung analysieren
- [ ] Bulk-Import-Preview mit PDF/DOCX


Made with [Cursor](https://cursor.com)