### PR TITLE
refactor(#6): ok→success for internal approval slice

### DIFF
--- a/app/internal-approval/[token]/actions.ts
+++ b/app/internal-approval/[token]/actions.ts
@@ -21,7 +21,7 @@ export async function confirmInternalApprovalAction(
   if (!admin) return { success: false, error: 'server_config' }
 
   const result = await confirmInternalApprovalFromToken(admin, token)
-  if (!result.ok) {
+  if (!result.success) {
     return {
       success: false,
       error:
@@ -48,7 +48,7 @@ export async function delegateInternalApprovalAction(
   if (!admin) return { success: false, error: 'server_config' }
 
   const result = await delegateInternalApprovalFromToken(admin, token, delegateEmail)
-  if (!result.ok) {
+  if (!result.success) {
     if (result.reason === 'invalid_email') {
       return { success: false, error: 'Bitte eine gültige E-Mail-Adresse eingeben.' }
     }

--- a/app/internal-approval/[token]/page.tsx
+++ b/app/internal-approval/[token]/page.tsx
@@ -35,7 +35,7 @@ export default async function InternalApprovalPage({
 
   const context = await getInternalApprovalPageContext(admin, token)
 
-  if (!context.ok) {
+  if (!context.success) {
     return (
       <InvalidCard
         title="Link ungültig"

--- a/docs/tech-debt-offen-backlog.md
+++ b/docs/tech-debt-offen-backlog.md
@@ -11,8 +11,8 @@
 | Status | Themen |
 |--------|--------|
 | **Erledigt** | Inventar-Hygiene (#0); E4 (#1); E7 (#2); **P1-6** (#4); Welle-5 Rollen; Typed-Supabase **T1–T4** (#3); **#8** `references`-Pfade; **#9** Invite-SQL skip; **#7** DE/EN-Dateinamen (ki-entwurf/sperrlink) |
-| **In Arbeit** | #6 `{ ok }` → `{ success }` (Slice 2 Extract) |
-| **Offen (Queue)** | #5 God-Files (Boy-Scout) · #6 Rest (Approvals/Cron) |
+| **In Arbeit** | #6 `{ ok }` → `{ success }` (Slice 3 Internal-Approval) |
+| **Offen (Queue)** | #5 God-Files (Boy-Scout) · #6 Rest (Bulk/CC/Cron) |
 | **Geparkt** | Pilot (H3/E1/G2); Massen-Renames |
 
 **Hebel jetzt:** Boy-Scout #5–6 bei Feature-Touch. Big-Bang-Queue leer.
@@ -29,7 +29,7 @@
 | **3** | Typed-Supabase Cast-Abbau | ✅ T1–T4 | Rest-Casts nur Boundaries (HTTP/RPC/Json); Boy-Scout bei Touch | — | CI: `typecheck` vor Build |
 | **4** | P1-6 Accounts Naming | ✅ App/Lib | DB-Tabelle `companies` / `company_id` / Firmennamen-Helfer **bewusst offen** | — | nicht anfassen ohne Produktentscheid |
 | **5** | God-File-Nacharbeit | offen (Boy-Scout) | Overview / Share-Link / MS-Feed weiter slicen **nur bei Feature-Touch** | M ongoing | kein eigener Big-Bang-PR |
-| **6** | `{ ok }` → `{ success }` | Slice 1–2 ✅ | Auth/CRM + Document-Extract/Deal-Docs | S remaining | nächster: Internal-Approval; Cron-JSON bewusst später |
+| **6** | `{ ok }` → `{ success }` | Slice 1–3 ✅ | Auth/CRM + Extract + Internal-Approval | XS–S remaining | nächster: Bulk-Upload / Semantic-Search; Cron-JSON bewusst später |
 | **7** | P3-3 DE/EN-Dateinamen | ✅ Slice | `ai-draft-*`, `customer-control-link-email`; API `/api/ai-draft` + Redirect; UI-Copy „Sperrlink“/Event `ki_entwurf_generated` bleiben | — | Rest nur bei Touch |
 | **8** | `references`/`evidence` Pfade | ✅ | App = `references` (Routen/Ordner/`ROUTES`); Redirects `/dashboard/evidence` bleiben; `evidence_events` bleibt | — | Rest-`evidence` nur Domänenbegriff (RFP-Belege) |
 | **9** | DB-Legacy Invite-Helfer | ✅ skip | App-`.rpc`-Caller = 0, aber **SQL-intern** weiter von Invite-RPCs genutzt → nicht droppen | — | behalten |
@@ -83,7 +83,8 @@ Die Funktionen bleiben **DB-intern** (Invite create/accept/list RPCs in Migratio
 |-------|-------|
 | 1 Auth/CRM | ✅ password-policy (`Result`), magic-link, `requireCrmAdmin`, `hubSpotApiFetch` + HubSpot-Caller |
 | 2 Document-Extract | ✅ `extractPlainText*`, RFP-Extract, `extractPlainTextFromBuffer`, Deal-Upload-Validate, `loadDealDocumentAsFile`, `runDealRfpAnalyze` |
-| Rest | offen: Internal-Approval, Bulk-Import-UI, Cron/Push-JSON (`ok` als HTTP-Body) |
+| 3 Internal-Approval | ✅ context / complete / delegate + Token-Page/Actions |
+| Rest | offen: Bulk-Import-Upload, Semantic-Search, Dev-Preview, NDA-Checks, Cron/Push-JSON |
 
 Cron-/Push-Responses mit `{ ok: true }` sind **HTTP-Vertrags**-ähnlich — separat entscheiden, nicht blind umbiegen.
 

--- a/lib/references/complete-internal-approval.ts
+++ b/lib/references/complete-internal-approval.ts
@@ -7,19 +7,19 @@ import { notifyInternalTeamInternalApproved } from '@/lib/references/approval-wo
 
 export type ConfirmInternalApprovalResult =
   | {
-      ok: true
+      success: true
       referenceId: string
       referenceTitle: string
       alreadyApproved: boolean
     }
-  | { ok: false; reason: 'invalid' | 'not_pending' }
+  | { success: false; reason: 'invalid' | 'not_pending' }
 
 export async function confirmInternalApprovalFromToken(
   admin: SupabaseClient<Database>,
   token: string,
 ): Promise<ConfirmInternalApprovalResult> {
   const trimmed = token.trim()
-  if (!trimmed) return { ok: false, reason: 'invalid' }
+  if (!trimmed) return { success: false, reason: 'invalid' }
 
   const { data: row, error } = await admin
     .from('references')
@@ -29,12 +29,12 @@ export async function confirmInternalApprovalFromToken(
     .eq('approval_internal_review_token', trimmed)
     .maybeSingle()
 
-  if (error || !row?.id) return { ok: false, reason: 'invalid' }
+  if (error || !row?.id) return { success: false, reason: 'invalid' }
 
   const internal = String(row.approval_internal_status ?? '').toLowerCase()
   if (internal === 'approved_internal') {
     return {
-      ok: true,
+      success: true,
       referenceId: row.id,
       referenceTitle: String(row.title ?? 'Referenz'),
       alreadyApproved: true,
@@ -42,7 +42,7 @@ export async function confirmInternalApprovalFromToken(
   }
 
   if (internal !== 'pending_internal') {
-    return { ok: false, reason: 'not_pending' }
+    return { success: false, reason: 'not_pending' }
   }
 
   const { error: updateError } = await admin
@@ -55,7 +55,7 @@ export async function confirmInternalApprovalFromToken(
     .eq('id', row.id)
     .eq('approval_internal_status', 'pending_internal')
 
-  if (updateError) return { ok: false, reason: 'invalid' }
+  if (updateError) return { success: false, reason: 'invalid' }
 
   const orgId = row.organization_id
   if (orgId) {
@@ -77,7 +77,7 @@ export async function confirmInternalApprovalFromToken(
   })
 
   return {
-    ok: true,
+    success: true,
     referenceId: row.id,
     referenceTitle: String(row.title ?? 'Referenz'),
     alreadyApproved: false,

--- a/lib/references/delegate-internal-approval.ts
+++ b/lib/references/delegate-internal-approval.ts
@@ -10,8 +10,8 @@ import { sendInternalApprovalReviewEmail } from '@/lib/references/internal-appro
 import { isApprovalRecipientEmail } from '@/lib/references/approval-recipient-input'
 
 export type DelegateInternalApprovalResult =
-  | { ok: true; delegatedToEmail: string; emailSent: boolean }
-  | { ok: false; reason: 'invalid' | 'not_pending' | 'invalid_email' }
+  | { success: true; delegatedToEmail: string; emailSent: boolean }
+  | { success: false; reason: 'invalid' | 'not_pending' | 'invalid_email' }
 
 export async function delegateInternalApprovalFromToken(
   admin: SupabaseClient<Database>,
@@ -20,8 +20,8 @@ export async function delegateInternalApprovalFromToken(
 ): Promise<DelegateInternalApprovalResult> {
   const trimmedToken = token.trim()
   const email = delegateEmail.trim().toLowerCase()
-  if (!trimmedToken) return { ok: false, reason: 'invalid' }
-  if (!isApprovalRecipientEmail(email)) return { ok: false, reason: 'invalid_email' }
+  if (!trimmedToken) return { success: false, reason: 'invalid' }
+  if (!isApprovalRecipientEmail(email)) return { success: false, reason: 'invalid_email' }
 
   const { data: row, error } = await admin
     .from('references')
@@ -41,10 +41,10 @@ export async function delegateInternalApprovalFromToken(
     .eq('approval_internal_review_token', trimmedToken)
     .maybeSingle()
 
-  if (error || !row?.id) return { ok: false, reason: 'invalid' }
+  if (error || !row?.id) return { success: false, reason: 'invalid' }
 
   const internal = String(row.approval_internal_status ?? '').toLowerCase()
-  if (internal !== 'pending_internal') return { ok: false, reason: 'not_pending' }
+  if (internal !== 'pending_internal') return { success: false, reason: 'not_pending' }
 
   const newToken = randomUUID()
   const accountCompanyName = companyNameFromReferenceRow(row.companies, 'Account')
@@ -61,7 +61,7 @@ export async function delegateInternalApprovalFromToken(
     .eq('id', row.id)
     .eq('approval_internal_status', 'pending_internal')
 
-  if (updateError) return { ok: false, reason: 'invalid' }
+  if (updateError) return { success: false, reason: 'invalid' }
 
   const orgId = row.organization_id
   if (orgId) {
@@ -94,5 +94,5 @@ export async function delegateInternalApprovalFromToken(
     referenceId: row.id,
   })
 
-  return { ok: true, delegatedToEmail: email, emailSent }
+  return { success: true, delegatedToEmail: email, emailSent }
 }

--- a/lib/references/internal-approval-context.ts
+++ b/lib/references/internal-approval-context.ts
@@ -4,7 +4,7 @@ import type { SupabaseClient } from '@supabase/supabase-js'
 
 export type InternalApprovalPageContext =
   | {
-      ok: true
+      success: true
       referenceId: string
       referenceTitle: string
       accountCompanyName: string
@@ -14,14 +14,14 @@ export type InternalApprovalPageContext =
       alreadyApproved: boolean
       canAct: boolean
     }
-  | { ok: false; reason: 'invalid' | 'not_pending' }
+  | { success: false; reason: 'invalid' | 'not_pending' }
 
 export async function getInternalApprovalPageContext(
   admin: SupabaseClient,
   token: string,
 ): Promise<InternalApprovalPageContext> {
   const trimmed = token.trim()
-  if (!trimmed) return { ok: false, reason: 'invalid' }
+  if (!trimmed) return { success: false, reason: 'invalid' }
 
   const { data: row, error } = await admin
     .from('references')
@@ -40,7 +40,7 @@ export async function getInternalApprovalPageContext(
     .eq('approval_internal_review_token', trimmed)
     .maybeSingle()
 
-  if (error || !row?.id) return { ok: false, reason: 'invalid' }
+  if (error || !row?.id) return { success: false, reason: 'invalid' }
 
   const internal = String(row.approval_internal_status ?? '').toLowerCase()
   const company = Array.isArray(row.companies) ? row.companies[0] : row.companies
@@ -51,7 +51,7 @@ export async function getInternalApprovalPageContext(
 
   if (internal === 'approved_internal') {
     return {
-      ok: true,
+      success: true,
       referenceId: row.id as string,
       referenceTitle: String(row.title ?? 'Referenz'),
       accountCompanyName,
@@ -67,11 +67,11 @@ export async function getInternalApprovalPageContext(
   }
 
   if (internal !== 'pending_internal') {
-    return { ok: false, reason: 'not_pending' }
+    return { success: false, reason: 'not_pending' }
   }
 
   return {
-    ok: true,
+    success: true,
     referenceId: row.id as string,
     referenceTitle: String(row.title ?? 'Referenz'),
     accountCompanyName,


### PR DESCRIPTION
## Summary
- Queue **#6** Slice 3: `internal-approval-context`, `complete-internal-approval`, `delegate-internal-approval` + Token-Page/Actions.
- Rest ~46 `{ ok }`-Literale (Bulk-Upload, Semantic-Search, Dev-Preview, Cron/Push, …).

## Test plan
- [x] `npm run typecheck`
- [ ] Internen Freigabe-Link öffnen (gültig / ungültig / bereits freigegeben)
- [ ] Bestätigen + Delegieren


Made with [Cursor](https://cursor.com)