### PR TITLE
refactor(#6): ok→success bulk/search/misc (lib done)

### DIFF
--- a/app/dashboard/accounts/nda-actions.ts
+++ b/app/dashboard/accounts/nda-actions.ts
@@ -106,15 +106,15 @@ async function assertCompanyInOrg(
   supabase: Awaited<ReturnType<typeof createServerSupabaseClient>>,
   companyId: string,
   orgId: string,
-): Promise<{ ok: true } | { ok: false; error: string }> {
+): Promise<{ success: true } | { success: false; error: string }> {
   const { data } = await supabase
     .from('companies')
     .select('id')
     .eq('id', companyId)
     .eq('organization_id', orgId)
     .maybeSingle()
-  if (!data) return { ok: false, error: 'Firma nicht gefunden.' }
-  return { ok: true }
+  if (!data) return { success: false, error: 'Firma nicht gefunden.' }
+  return { success: true }
 }
 
 export async function getNdaAgreementsByCompanyId(
@@ -126,7 +126,7 @@ export async function getNdaAgreementsByCompanyId(
   if ('error' in auth) return { success: false, error: auth.error }
 
   const companyCheck = await assertCompanyInOrg(auth.supabase, companyId, auth.orgId)
-  if (!companyCheck.ok) return { success: false, error: companyCheck.error }
+  if (!companyCheck.success) return { success: false, error: companyCheck.error }
 
   const { data, error: initialError } = await auth.supabase
     .from('nda_agreements')
@@ -229,7 +229,7 @@ export async function createNdaAgreement(payload: {
     payload.companyId,
     auth.orgId,
   )
-  if (!companyCheck.ok) return { success: false, error: companyCheck.error }
+  if (!companyCheck.success) return { success: false, error: companyCheck.error }
 
   const baseRow = {
     organization_id: auth.orgId,

--- a/app/dashboard/command-center/actions.ts
+++ b/app/dashboard/command-center/actions.ts
@@ -61,7 +61,7 @@ export async function searchHomepageSemanticAction(
     salesVisibleOnly: auth.salesVisibleOnly,
   })
 
-  if (!semantic.ok) {
+  if (!semantic.success) {
     return { success: false, query: q, error: semantic.error }
   }
 
@@ -99,14 +99,14 @@ export async function searchHomepageUniversalAction(
           organizationId: auth.orgId,
           salesVisibleOnly: auth.salesVisibleOnly,
         })
-      : Promise.resolve({ ok: false as const, error: 'OPENAI_API_KEY fehlt' }),
+      : Promise.resolve({ success: false as const, error: 'OPENAI_API_KEY fehlt' }),
     searchHomepageBuckets(auth.supabase, q),
   ])
 
-  const referenceHits = semanticResult.ok ? semanticResult.hits : []
+  const referenceHits = semanticResult.success ? semanticResult.hits : []
   const semanticWarning = !apiKey
     ? 'Semantische Referenzsuche ist deaktiviert (OPENAI_API_KEY fehlt).'
-    : !semanticResult.ok
+    : !semanticResult.success
       ? semanticResult.error
       : undefined
 

--- a/app/dashboard/dev-preview-role-actions.ts
+++ b/app/dashboard/dev-preview-role-actions.ts
@@ -16,30 +16,30 @@ function revalidateDashboardRole() {
   revalidatePath(ROUTES.home, 'layout')
 }
 
-export type SetDevPreviewRoleResult = { ok: true } | { ok: false; error: string }
+export type SetDevPreviewRoleResult = { success: true } | { success: false; error: string }
 
 async function assertDevRolePreviewAllowed(): Promise<
-  SetDevPreviewRoleResult | { ok: true }
+  SetDevPreviewRoleResult | { success: true }
 > {
   const profile = await getRequestProfile()
   if (!profile) {
-    return { ok: false, error: 'Profil nicht gefunden.' }
+    return { success: false, error: 'Profil nicht gefunden.' }
   }
   const { systemRole } = parseProfileRoles(profile)
   if (!canUseDevRolePreview(systemRole)) {
     return {
-      ok: false,
+      success: false,
       error: 'Rollen-Vorschau ist in dieser Umgebung nicht verfügbar.',
     }
   }
-  return { ok: true }
+  return { success: true }
 }
 
 export async function setDevPreviewRole(
   preview: DevRolePreview,
 ): Promise<SetDevPreviewRoleResult> {
   const allowed = await assertDevRolePreviewAllowed()
-  if (!allowed.ok) return allowed
+  if (!allowed.success) return allowed
 
   try {
     const jar = await cookies()
@@ -50,10 +50,10 @@ export async function setDevPreviewRole(
       httpOnly: true,
     })
     revalidateDashboardRole()
-    return { ok: true }
+    return { success: true }
   } catch (e) {
     return {
-      ok: false,
+      success: false,
       error: e instanceof Error ? e.message : 'Rolle konnte nicht gesetzt werden.',
     }
   }
@@ -61,11 +61,11 @@ export async function setDevPreviewRole(
 
 export async function clearDevPreviewRole() {
   const allowed = await assertDevRolePreviewAllowed()
-  if (!allowed.ok) {
+  if (!allowed.success) {
     return allowed
   }
   const jar = await cookies()
   jar.set(DEV_ROLE_COOKIE, '', { path: '/', maxAge: 0 })
   revalidateDashboardRole()
-  return { ok: true as const }
+  return { success: true as const }
 }

--- a/app/dashboard/overview/bulk-import-dialog.tsx
+++ b/app/dashboard/overview/bulk-import-dialog.tsx
@@ -253,7 +253,7 @@ export function BulkImportDialog({
               refId,
               group.files,
             )
-            if (!upload.ok) {
+            if (!upload.success) {
               uploadFailed = true
               toast.error(
                 upload.error ??

--- a/app/dashboard/settings/settings-dev-role-card.tsx
+++ b/app/dashboard/settings/settings-dev-role-card.tsx
@@ -32,7 +32,7 @@ export function SettingsDevRoleCard({
   function apply(preview: DevRolePreview) {
     start(async () => {
       const res = await setDevPreviewRole(preview)
-      if (!res.ok) {
+      if (!res.success) {
         toast.error(res.error ?? 'Rolle konnte nicht gesetzt werden.')
         return
       }
@@ -44,7 +44,7 @@ export function SettingsDevRoleCard({
   function clear() {
     start(async () => {
       const res = await clearDevPreviewRole()
-      if (!res.ok) {
+      if (!res.success) {
         toast.error(res.error ?? 'Anzeige konnte nicht zurückgesetzt werden.')
         return
       }

--- a/app/dashboard/settings/settings-workspace-card.tsx
+++ b/app/dashboard/settings/settings-workspace-card.tsx
@@ -94,8 +94,8 @@ export function SettingsWorkspaceCard({
   const [subdomainStatus, setSubdomainStatus] = useState<{
     checking: boolean
     message: string | null
-    ok: boolean | null
-  }>({ checking: false, message: null, ok: null })
+    available: boolean | null
+  }>({ checking: false, message: null, available: null })
 
   const subdomainDirty =
     normalizeSubdomainInput(subdomain ?? '') !== normalizeSubdomainInput(savedSubdomain)
@@ -139,31 +139,31 @@ export function SettingsWorkspaceCard({
     if (!organizationId || onSubdomainChange == null) return
     const value = normalizeSubdomainInput(subdomain ?? '')
     if (!value) {
-      setSubdomainStatus({ checking: false, message: null, ok: null })
+      setSubdomainStatus({ checking: false, message: null, available: null })
       return
     }
     if (value === normalizeSubdomainInput(savedSubdomain)) {
-      setSubdomainStatus({ checking: false, message: 'Aktuelle Subdomain', ok: true })
+      setSubdomainStatus({ checking: false, message: 'Aktuelle Subdomain', available: true })
       return
     }
     const formatError = validateSubdomainFormat(value)
     if (formatError) {
-      setSubdomainStatus({ checking: false, message: formatError, ok: false })
+      setSubdomainStatus({ checking: false, message: formatError, available: false })
       return
     }
 
     let cancelled = false
-    setSubdomainStatus({ checking: true, message: 'Prüfe Verfügbarkeit …', ok: null })
+    setSubdomainStatus({ checking: true, message: 'Prüfe Verfügbarkeit …', available: null })
     const timer = window.setTimeout(() => {
       void checkSubdomainAvailability(value, organizationId).then((result) => {
         if (cancelled) return
         if (result.available) {
-          setSubdomainStatus({ checking: false, message: 'Verfügbar', ok: true })
+          setSubdomainStatus({ checking: false, message: 'Verfügbar', available: true })
         } else {
           setSubdomainStatus({
             checking: false,
             message: result.error ?? 'Nicht verfügbar',
-            ok: false,
+            available: false,
           })
         }
       })
@@ -377,9 +377,9 @@ export function SettingsWorkspaceCard({
                 {subdomainStatus.message ? (
                   <p
                     className={`text-[11px] ${
-                      subdomainStatus.ok === false
+                      subdomainStatus.available === false
                         ? 'text-destructive'
-                        : subdomainStatus.ok === true
+                        : subdomainStatus.available === true
                           ? 'text-emerald-700'
                           : 'text-muted-foreground'
                     }`}

--- a/components/dashboard/dashboard-user-menu.tsx
+++ b/components/dashboard/dashboard-user-menu.tsx
@@ -67,7 +67,7 @@ export function DashboardUserMenu({
   function selectDevRole(preview: DevRolePreview) {
     startRoleSwitch(async () => {
       const res = await setDevPreviewRole(preview)
-      if (!res.ok) {
+      if (!res.success) {
         toast.error(res.error ?? 'Rolle konnte nicht gesetzt werden.')
         return
       }
@@ -79,7 +79,7 @@ export function DashboardUserMenu({
   function resetDevRole() {
     startRoleSwitch(async () => {
       const res = await clearDevPreviewRole()
-      if (!res.ok) {
+      if (!res.success) {
         toast.error(res.error ?? 'Anzeige konnte nicht zurückgesetzt werden.')
         return
       }

--- a/docs/tech-debt-offen-backlog.md
+++ b/docs/tech-debt-offen-backlog.md
@@ -10,12 +10,12 @@
 
 | Status | Themen |
 |--------|--------|
-| **Erledigt** | Inventar-Hygiene (#0); E4 (#1); E7 (#2); **P1-6** (#4); Welle-5 Rollen; Typed-Supabase **T1–T4** (#3); **#8** `references`-Pfade; **#9** Invite-SQL skip; **#7** DE/EN-Dateinamen (ki-entwurf/sperrlink) |
-| **In Arbeit** | #6 `{ ok }` → `{ success }` (Slice 3 Internal-Approval) |
-| **Offen (Queue)** | #5 God-Files (Boy-Scout) · #6 Rest (Bulk/CC/Cron) |
+| **Erledigt** | Inventar-Hygiene (#0); E4 (#1); E7 (#2); **P1-6** (#4); Welle-5 Rollen; Typed-Supabase **T1–T4** (#3); **#8** `references`-Pfade; **#9** Invite-SQL skip; **#7** DE/EN-Dateinamen; **#6** Lib-Results (Cron/Push-JSON geparkt) |
+| **In Arbeit** | — |
+| **Offen (Queue)** | #5 God-Files (Boy-Scout) · #6 Cron/Push-JSON (bewusst geparkt) |
 | **Geparkt** | Pilot (H3/E1/G2); Massen-Renames |
 
-**Hebel jetzt:** Boy-Scout #5–6 bei Feature-Touch. Big-Bang-Queue leer.
+**Hebel jetzt:** Boy-Scout #5 bei Feature-Touch; #6 Cron/Push nur mit bewusstem API-Change.
 
 ---
 
@@ -29,7 +29,7 @@
 | **3** | Typed-Supabase Cast-Abbau | ✅ T1–T4 | Rest-Casts nur Boundaries (HTTP/RPC/Json); Boy-Scout bei Touch | — | CI: `typecheck` vor Build |
 | **4** | P1-6 Accounts Naming | ✅ App/Lib | DB-Tabelle `companies` / `company_id` / Firmennamen-Helfer **bewusst offen** | — | nicht anfassen ohne Produktentscheid |
 | **5** | God-File-Nacharbeit | offen (Boy-Scout) | Overview / Share-Link / MS-Feed weiter slicen **nur bei Feature-Touch** | M ongoing | kein eigener Big-Bang-PR |
-| **6** | `{ ok }` → `{ success }` | Slice 1–3 ✅ | Auth/CRM + Extract + Internal-Approval | XS–S remaining | nächster: Bulk-Upload / Semantic-Search; Cron-JSON bewusst später |
+| **6** | `{ ok }` → `{ success }` | Lib ✅ | Slices 1–4; Rest nur Cron/Push-HTTP-Body | XS | Cron/Push separat wenn Monitoring-Clients ok |
 | **7** | P3-3 DE/EN-Dateinamen | ✅ Slice | `ai-draft-*`, `customer-control-link-email`; API `/api/ai-draft` + Redirect; UI-Copy „Sperrlink“/Event `ki_entwurf_generated` bleiben | — | Rest nur bei Touch |
 | **8** | `references`/`evidence` Pfade | ✅ | App = `references` (Routen/Ordner/`ROUTES`); Redirects `/dashboard/evidence` bleiben; `evidence_events` bleibt | — | Rest-`evidence` nur Domänenbegriff (RFP-Belege) |
 | **9** | DB-Legacy Invite-Helfer | ✅ skip | App-`.rpc`-Caller = 0, aber **SQL-intern** weiter von Invite-RPCs genutzt → nicht droppen | — | behalten |
@@ -84,7 +84,8 @@ Die Funktionen bleiben **DB-intern** (Invite create/accept/list RPCs in Migratio
 | 1 Auth/CRM | ✅ password-policy (`Result`), magic-link, `requireCrmAdmin`, `hubSpotApiFetch` + HubSpot-Caller |
 | 2 Document-Extract | ✅ `extractPlainText*`, RFP-Extract, `extractPlainTextFromBuffer`, Deal-Upload-Validate, `loadDealDocumentAsFile`, `runDealRfpAnalyze` |
 | 3 Internal-Approval | ✅ context / complete / delegate + Token-Page/Actions |
-| Rest | offen: Bulk-Import-Upload, Semantic-Search, Dev-Preview, NDA-Checks, Cron/Push-JSON |
+| 4 Bulk / Search / Misc | ✅ bulk-import-upload, semantic search, NDA `assertCompanyInOrg`, Dev-Preview-Role, Workspace-Subdomain-Status (`available`) |
+| Geparkt | Cron/Push `NextResponse.json({ ok })` — HTTP-Vertrag; nicht blind umbiegen |
 
 Cron-/Push-Responses mit `{ ok: true }` sind **HTTP-Vertrags**-ähnlich — separat entscheiden, nicht blind umbiegen.
 
@@ -112,8 +113,8 @@ Bei Feature-PRs mitnehmen, **kein** Massen-PR:
 
 ## Session-Start (kurz)
 
-1. Dieses Dokument lesen — Default: Boy-Scout #5–6 bei Feature-Touch.  
-2. Kein weiterer Big-Bang in der offenen Queue.  
+1. Dieses Dokument lesen — Default: Boy-Scout #5 bei Feature-Touch.  
+2. Kein weiterer Big-Bang in der offenen Queue (#6 Lib erledigt; Cron/Push geparkt).  
 3. Nach Abschluss: Status hier + Inventar anpassen.
 
 ---

--- a/lib/command-center/search-references-semantic.ts
+++ b/lib/command-center/search-references-semantic.ts
@@ -88,10 +88,10 @@ async function runSemanticMatch(
 export async function searchHomepageReferencesSemantic(
   params: SemanticSearchParams,
 ): Promise<
-  { ok: true; hits: HomepageSemanticReferenceHit[] } | { ok: false; error: string }
+  { success: true; hits: HomepageSemanticReferenceHit[] } | { success: false; error: string }
 > {
   const trimmed = params.query.trim()
-  if (!trimmed) return { ok: true, hits: [] }
+  if (!trimmed) return { success: true, hits: [] }
 
   const volumeConstraint = parseVolumeConstraintFromQuery(trimmed)
   const matchCount = params.matchCount ?? HOME_SEMANTIC_MATCH_COUNT
@@ -104,7 +104,7 @@ export async function searchHomepageReferencesSemantic(
     source: 'homepage',
   })
 
-  if (error) return { ok: false, error }
+  if (error) return { success: false, error }
 
   const matchedRows = volumeConstraint
     ? rows.filter((r) => referenceVolumeMatchesConstraint(r.volume_eur, volumeConstraint))
@@ -155,18 +155,18 @@ export async function searchHomepageReferencesSemantic(
     durationMs,
   })
 
-  return { ok: true, hits }
+  return { success: true, hits }
 }
 
 /** Legacy-Fallback für gemischte Command-Search. */
 export async function searchReferencesSemanticLegacy(
   params: SemanticSearchParams,
 ): Promise<
-  | { ok: true; hits: Extract<CommandSearchResult, { kind: 'reference' }>[] }
-  | { ok: false; error: string }
+  | { success: true; hits: Extract<CommandSearchResult, { kind: 'reference' }>[] }
+  | { success: false; error: string }
 > {
   const trimmed = params.query.trim()
-  if (!trimmed) return { ok: true, hits: [] }
+  if (!trimmed) return { success: true, hits: [] }
 
   const { rows, error, durationMs } = await runSemanticMatch({
     ...params,
@@ -176,7 +176,7 @@ export async function searchReferencesSemanticLegacy(
     source: 'command',
   })
 
-  if (error) return { ok: false, error }
+  if (error) return { success: false, error }
 
   const hits = rows.map((r) => ({
     kind: 'reference' as const,
@@ -195,5 +195,5 @@ export async function searchReferencesSemanticLegacy(
     durationMs,
   })
 
-  return { ok: true, hits }
+  return { success: true, hits }
 }

--- a/lib/references/bulk-import-upload.ts
+++ b/lib/references/bulk-import-upload.ts
@@ -10,16 +10,16 @@ export async function uploadBulkImportFilesForReference(
   organizationId: string,
   referenceId: string,
   files: File[],
-): Promise<{ ok: boolean; error?: string }> {
+): Promise<{ success: boolean; error?: string }> {
   if (!organizationId?.trim() || !referenceId?.trim() || files.length === 0) {
-    return { ok: false, error: 'Upload-Parameter unvollständig.' }
+    return { success: false, error: 'Upload-Parameter unvollständig.' }
   }
 
   const supabase = createClient()
   const {
     data: { user },
   } = await supabase.auth.getUser()
-  if (!user) return { ok: false, error: 'Nicht angemeldet.' }
+  if (!user) return { success: false, error: 'Nicht angemeldet.' }
 
   let firstPath: string | null = null
 
@@ -36,7 +36,7 @@ export async function uploadBulkImportFilesForReference(
       const error = /bucket not found/i.test(raw)
         ? 'Storage-Bucket „references“ ist nicht angelegt. Bitte Supabase-Migrationen ausführen (20260510220000_references_storage_bucket.sql).'
         : raw
-      return { ok: false, error }
+      return { success: false, error }
     }
 
     const { data: publicUrlData } = supabase.storage
@@ -55,7 +55,7 @@ export async function uploadBulkImportFilesForReference(
     })
 
     if (!attach.success) {
-      return { ok: false, error: attach.error }
+      return { success: false, error: attach.error }
     }
 
     if (!firstPath) {
@@ -64,8 +64,8 @@ export async function uploadBulkImportFilesForReference(
   }
 
   if (!firstPath) {
-    return { ok: false, error: 'Keine Datei konnte gespeichert werden.' }
+    return { success: false, error: 'Keine Datei konnte gespeichert werden.' }
   }
 
-  return { ok: true }
+  return { success: true }
 }


### PR DESCRIPTION
## Summary
- Queue **#6** Slice 4: Bulk-Import-Upload, Semantic-Search, NDA-Org-Check, Dev-Preview-Role, Workspace-Subdomain-Status (`available`).
- Lib-`{ ok }`-Results damit weitgehend weg; **Cron/Push-JSON** bewusst geparkt (~15 Literale).

## Test plan
- [x] `npm run typecheck`
- [ ] Bulk-Import Datei-Upload an Referenz
- [ ] Homepage/Command-Center semantische Suche
- [ ] Dev-Rollen-Vorschau umschalten
- [ ] Settings Subdomain-Verfügbarkeit


Made with [Cursor](https://cursor.com)