### PR TITLE
refactor(#5): split reference-detail-sheet into cards

### DIFF
--- a/app/dashboard/overview/reference-detail-sheet.tsx
+++ b/app/dashboard/overview/reference-detail-sheet.tsx
@@ -3,31 +3,17 @@
 import type { Dispatch, MouseEvent, SetStateAction } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
-import { toast } from 'sonner'
 import {
-  Building2,
-  Calendar,
   Eye,
-  ExternalLink,
-  FileText,
-  Globe,
   LinkIcon,
-  Mail,
-  MapPinIcon,
   Pencil,
-  Phone,
   Send,
   StarIcon,
-  Tag01Icon,
-  Timer,
   Trash2,
-  UserIcon,
-  Users,
 } from '@hugeicons/core-free-icons'
 
 import { ReferenceStatusWithHint } from '@/components/reference-status-with-hint'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent } from '@/components/ui/card'
 import {
   Dialog,
   DialogContent,
@@ -36,29 +22,16 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
-import { formatIndustryDisplay } from '@/lib/constants/industries'
 import {
-  diffMonthsUtc,
-  formatReferenceDate,
   formatNumberDe,
-  formatReferenceVolume,
   normalizeOrgDateDisplayFormat,
   type OrgDateDisplayFormat,
 } from '@/lib/format'
-import { formatContractTypeDisplay } from '@/lib/references/contract-type'
 import { AppIcon } from '@/lib/icons'
 import { ROUTES } from '@/lib/routes'
 import { isSystemAdmin } from '@/lib/roles/capability-access'
@@ -68,8 +41,13 @@ import {
 } from '@/lib/roles/profile-guards'
 
 import type { ReferenceAssetRow, ReferenceRow } from '../actions'
-import { updateReferenceAssetCategory } from '../actions'
 import type { Profile } from '../dashboard-types'
+import { ReferenceDetailFilesCard } from './reference-detail/reference-detail-files-card'
+import {
+  ReferenceDetailProjectCard,
+  type ReferenceDetailExternalContact,
+} from './reference-detail/reference-detail-project-card'
+import { ReferenceDetailStoryCard } from './reference-detail/reference-detail-story-card'
 
 export function ReferenceDetailSheet({
   open,
@@ -90,15 +68,7 @@ export function ReferenceDetailSheet({
   onOpenChange: (open: boolean) => void
   selectedRef: ReferenceRow | null
   profile: Profile
-  externalContacts: {
-    id: string
-    company_id: string
-    first_name: string | null
-    last_name: string | null
-    email: string | null
-    role: string | null
-    phone?: string | null
-  }[]
+  externalContacts: ReferenceDetailExternalContact[]
   detailAssets: ReferenceAssetRow[]
   detailAssetsLoading: boolean
   setDetailAssets: Dispatch<SetStateAction<ReferenceAssetRow[]>>
@@ -189,529 +159,23 @@ export function ReferenceDetailSheet({
             {/* Ein scrollbarer Bereich: gleiche 4-Karten-Struktur wie Referenz erstellen */}
             <div className="flex-1 overflow-y-auto px-6 py-6 md:px-8 md:py-8">
               <div className="space-y-6 pt-4">
-                {/* Card 1: Story (Herausforderung & Lösung + Tags) */}
-                <Card>
-                  <CardContent className="space-y-4">
-                    {selectedRef.customer_challenge || selectedRef.our_solution ? (
-                      <div className="space-y-7">
-                        {selectedRef.customer_challenge ? (
-                          <div className="space-y-3">
-                            <span className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
-                              Herausforderung des Kunden
-                            </span>
-                            <p className="text-foreground text-sm leading-relaxed">
-                              {selectedRef.customer_challenge}
-                            </p>
-                          </div>
-                        ) : null}
-                        {selectedRef.our_solution ? (
-                          <div className="space-y-3">
-                            <span className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
-                              Unsere Lösung
-                            </span>
-                            <p className="text-foreground text-sm leading-relaxed">
-                              {selectedRef.our_solution}
-                            </p>
-                          </div>
-                        ) : null}
-                      </div>
-                    ) : null}
-                    <div className="space-y-2">
-                      <span className="text-muted-foreground flex items-center gap-1.5 text-xs font-medium">
-                        <AppIcon icon={Tag01Icon} size={12} /> Tags
-                      </span>
-                      <div className="flex flex-wrap gap-1.5">
-                        {selectedRef.tags ? (
-                          selectedRef.tags
-                            .split(/[\s,]+/)
-                            .map((tag) => normalizeTagLabel(tag))
-                            .filter(Boolean)
-                            .map((tag) => (
-                              <span
-                                key={tag}
-                                className="rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-foreground"
-                              >
-                                {tag}
-                              </span>
-                            ))
-                        ) : (
-                          <span className="text-xs font-medium text-muted-foreground">
-                            —
-                          </span>
-                        )}
-                      </div>
-                    </div>
-                  </CardContent>
-                </Card>
-
-                {/* Card 2: Projektdetails (Volumen, Vertragsart, Zeitraum, Unternehmensdetails, Kontakte) */}
-                <Card>
-                  <CardContent className="space-y-4">
-                    <div className="space-y-2">
-                      <span className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
-                        Projektdetails
-                      </span>
-                      <div className="grid grid-cols-2 gap-x-6 gap-y-3">
-                        <div className="space-y-0.5">
-                          <span className="text-muted-foreground flex items-center gap-1.5 text-xs font-medium">
-                            <AppIcon icon={FileText} size={12} /> Volumen
-                          </span>
-                          <p
-                            className={`pl-4 text-xs font-medium ${selectedRef.volume_eur ? 'text-foreground' : 'text-muted-foreground'}`}
-                          >
-                            {selectedRef.volume_eur
-                              ? formatReferenceVolume(selectedRef.volume_eur)
-                              : '—'}
-                          </p>
-                        </div>
-                        <div className="space-y-0.5">
-                          <span className="text-muted-foreground flex items-center gap-1.5 text-xs font-medium">
-                            <AppIcon icon={FileText} size={12} /> Vertragsart
-                          </span>
-                          <p
-                            className={`pl-4 text-xs font-medium ${selectedRef.contract_type ? 'text-foreground' : 'text-muted-foreground'}`}
-                          >
-                            {formatContractTypeDisplay(selectedRef.contract_type) || '—'}
-                          </p>
-                        </div>
-                        <div className="space-y-0.5">
-                          <span className="text-muted-foreground flex items-center gap-1.5 text-xs font-medium">
-                            <AppIcon icon={Calendar} size={12} /> Projektstart
-                          </span>
-                          <p
-                            className={`pl-4 text-xs font-medium ${selectedRef.project_start ? 'text-foreground' : 'text-muted-foreground'}`}
-                          >
-                            {selectedRef.project_start
-                              ? formatReferenceDate(selectedRef.project_start, dateFmt)
-                              : '—'}
-                          </p>
-                        </div>
-                        <div className="space-y-0.5">
-                          <span className="text-muted-foreground flex items-center gap-1.5 text-xs font-medium">
-                            <AppIcon icon={Timer} size={12} /> Projektende / Dauer
-                          </span>
-                          {(() => {
-                            const start = selectedRef.project_start
-                            const end = selectedRef.project_end
-                            const status = selectedRef.project_status
-                            const label =
-                              status === 'active'
-                                ? 'Aktiv'
-                                : end
-                                  ? formatReferenceDate(end, dateFmt)
-                                  : '—'
-                            const nowIso = new Date().toISOString()
-                            const duration =
-                              selectedRef.duration_months != null
-                                ? selectedRef.duration_months
-                                : start && end
-                                  ? diffMonthsUtc(start, end)
-                                  : status === 'active' && start
-                                    ? diffMonthsUtc(start, nowIso)
-                                    : null
-                            return (
-                              <p className="pl-4 text-xs font-medium text-foreground">
-                                {duration != null
-                                  ? `${label} (${duration} Monate)`
-                                  : label}
-                              </p>
-                            )
-                          })()}
-                        </div>
-                        <div className="space-y-0.5">
-                          <span className="text-muted-foreground flex items-center gap-1.5 text-xs font-medium">
-                            <AppIcon icon={Building2} size={12} /> Aktueller Dienstleister
-                          </span>
-                          <p
-                            className={`pl-4 text-xs font-medium ${selectedRef.incumbent_provider ? 'text-foreground' : 'text-muted-foreground'}`}
-                          >
-                            {selectedRef.incumbent_provider || '—'}
-                          </p>
-                        </div>
-                        <div className="space-y-0.5">
-                          <span className="text-muted-foreground flex items-center gap-1.5 text-xs font-medium">
-                            <AppIcon icon={Users} size={12} /> Beteiligte Wettbewerber
-                          </span>
-                          <p
-                            className={`pl-4 text-xs font-medium ${selectedRef.competitors ? 'text-foreground' : 'text-muted-foreground'}`}
-                          >
-                            {selectedRef.competitors || '—'}
-                          </p>
-                        </div>
-                      </div>
-                    </div>
-
-                    <hr className="border-border/60" />
-
-                    <div className="space-y-2">
-                      <span className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
-                        Unternehmensdetails
-                      </span>
-                      <div className="grid grid-cols-2 gap-x-6 gap-y-3">
-                        <div className="space-y-0.5">
-                          <span className="text-muted-foreground flex items-center gap-1.5 text-xs font-medium">
-                            <AppIcon icon={Building2} size={12} /> Industrie
-                          </span>
-                          <p
-                            className={`pl-4 text-xs font-medium ${selectedRef.industry ? 'text-foreground' : 'text-muted-foreground'}`}
-                          >
-                            {formatIndustryDisplay(selectedRef.industry) || '—'}
-                          </p>
-                        </div>
-                        <div className="space-y-0.5">
-                          <span className="text-muted-foreground flex items-center gap-1.5 text-xs font-medium">
-                            <AppIcon icon={MapPinIcon} size={12} /> HQ
-                          </span>
-                          <p
-                            className={`pl-4 text-xs font-medium ${selectedRef.country ? 'text-foreground' : 'text-muted-foreground'}`}
-                          >
-                            {selectedRef.country || '—'}
-                          </p>
-                        </div>
-                        <div className="space-y-0.5">
-                          <span className="text-muted-foreground flex items-center gap-1.5 text-xs font-medium">
-                            <AppIcon icon={Globe} size={12} /> Website
-                          </span>
-                          <div className="pl-4">
-                            {selectedRef.website ? (
-                              <a
-                                href={selectedRef.website}
-                                target="_blank"
-                                rel="noreferrer"
-                                className="text-primary hover:underline inline-flex items-center gap-1 text-xs font-medium"
-                              >
-                                Öffnen <AppIcon icon={ExternalLink} size={12} />
-                              </a>
-                            ) : (
-                              <p className="text-xs font-medium text-muted-foreground">
-                                —
-                              </p>
-                            )}
-                          </div>
-                        </div>
-                        <div className="space-y-0.5">
-                          <span className="text-muted-foreground flex items-center gap-1.5 text-xs font-medium">
-                            <AppIcon icon={UserIcon} size={12} /> Mitarbeiter
-                          </span>
-                          <p
-                            className={`pl-4 text-xs font-medium ${selectedRef.employee_count != null ? 'text-foreground' : 'text-muted-foreground'}`}
-                          >
-                            {formatNumberDe(selectedRef.employee_count)}
-                          </p>
-                        </div>
-                      </div>
-                    </div>
-
-                    <hr className="border-border/60" />
-
-                    <div className="space-y-2">
-                      <span className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
-                        Kontakte
-                      </span>
-                      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                        <div className="space-y-1">
-                          <span className="text-muted-foreground flex items-center gap-1.5 text-xs font-medium">
-                            <AppIcon icon={UserIcon} size={12} /> Interner Ansprechpartner
-                          </span>
-                          <p className="pl-4 text-xs font-medium">
-                            {selectedRef.contact_display ||
-                              selectedRef.contact_email ||
-                              'Nicht zugewiesen'}
-                          </p>
-                          <div className="text-muted-foreground flex flex-wrap items-center gap-2 pl-4">
-                            {selectedRef.contact_email && (
-                              <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <a
-                                    href={`mailto:${selectedRef.contact_email}`}
-                                    className="inline-flex items-center gap-1 text-[10px] hover:underline"
-                                  >
-                                    <AppIcon icon={Mail} size={14} />
-                                    {selectedRef.contact_email}
-                                  </a>
-                                </TooltipTrigger>
-                                <TooltipContent>
-                                  E-Mail: {selectedRef.contact_email}
-                                </TooltipContent>
-                              </Tooltip>
-                            )}
-                          </div>
-                          <p className="text-muted-foreground pl-4 text-[10px]">
-                            Account Owner
-                          </p>
-                        </div>
-                        <div className="space-y-1">
-                          <span className="text-muted-foreground flex items-center gap-1.5 text-xs font-medium">
-                            <AppIcon icon={UserIcon} size={12} /> Kundenansprechpartner
-                          </span>
-                          {(() => {
-                            const ext = selectedRef.customer_contact_id
-                              ? externalContacts?.find(
-                                  (c) => c.id === selectedRef.customer_contact_id,
-                                )
-                              : undefined
-                            const displayName =
-                              selectedRef.customer_contact ||
-                              (ext
-                                ? [ext.first_name, ext.last_name]
-                                    .filter(Boolean)
-                                    .join(' ')
-                                : null) ||
-                              '—'
-                            const email = ext?.email ?? null
-                            const phone = ext?.phone ?? null
-                            const role = ext?.role ?? null
-                            return (
-                              <>
-                                <p
-                                  className={`pl-4 text-xs font-medium ${displayName !== '—' ? 'text-foreground' : 'text-muted-foreground'}`}
-                                >
-                                  {displayName}
-                                </p>
-                                <div className="text-muted-foreground flex flex-wrap items-center gap-2 pl-4">
-                                  {email && (
-                                    <Tooltip>
-                                      <TooltipTrigger asChild>
-                                        <a
-                                          href={`mailto:${email}`}
-                                          className="inline-flex items-center gap-1 text-[10px] hover:underline"
-                                        >
-                                          <AppIcon icon={Mail} size={14} />
-                                          {email}
-                                        </a>
-                                      </TooltipTrigger>
-                                      <TooltipContent>E-Mail: {email}</TooltipContent>
-                                    </Tooltip>
-                                  )}
-                                  {phone && (
-                                    <Tooltip>
-                                      <TooltipTrigger asChild>
-                                        <a
-                                          href={`tel:${phone}`}
-                                          className="inline-flex items-center gap-1 text-[10px] hover:underline"
-                                        >
-                                          <AppIcon icon={Phone} size={14} />
-                                          {phone}
-                                        </a>
-                                      </TooltipTrigger>
-                                      <TooltipContent>Telefon: {phone}</TooltipContent>
-                                    </Tooltip>
-                                  )}
-                                </div>
-                                {role && (
-                                  <p className="text-muted-foreground pl-4 text-[10px]">
-                                    {role}
-                                  </p>
-                                )}
-                              </>
-                            )
-                          })()}
-                        </div>
-                      </div>
-                    </div>
-                  </CardContent>
-                </Card>
-
-                {/* Card 3: Strategie & Anhänge (Dateien, Historie) */}
-                <Card className="bg-muted/30">
-                  <CardContent className="space-y-4">
-                    <div className="space-y-2">
-                      <span className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
-                        Dateien
-                      </span>
-                      {detailAssetsLoading ? (
-                        <div className="flex h-24 items-center justify-center rounded-lg border border-dashed text-muted-foreground text-sm">
-                          Dateien werden geladen…
-                        </div>
-                      ) : detailAssets.length === 0 && !selectedRef.file_path ? (
-                        <div className="text-muted-foreground bg-muted/10 flex h-24 flex-col items-center justify-center gap-1 rounded-lg border border-dashed text-xs">
-                          <span>📎</span>
-                          <p>Keine Dateien vorhanden.</p>
-                        </div>
-                      ) : (
-                        <Tabs defaultValue="sales" className="w-full">
-                          <TabsList className="grid w-full grid-cols-3">
-                            <TabsTrigger value="sales">Sales Material</TabsTrigger>
-                            <TabsTrigger value="contract">Verträge</TabsTrigger>
-                            <TabsTrigger value="other">Sonstiges</TabsTrigger>
-                          </TabsList>
-                          {(['sales', 'contract', 'other'] as const).map((cat) => {
-                            const legacyFile =
-                              cat === 'other' &&
-                              detailAssets.length === 0 &&
-                              selectedRef.file_path
-                                ? {
-                                    path: selectedRef.file_path,
-                                    name:
-                                      selectedRef.file_path.split('/').pop() ??
-                                      'Dokument',
-                                    isLegacy: true as const,
-                                  }
-                                : null
-                            const assetsInCat = detailAssets.filter(
-                              (a) => a.category === cat,
-                            )
-                            const hasLegacy = !!legacyFile
-                            const hasItems = assetsInCat.length > 0 || hasLegacy
-                            return (
-                              <TabsContent key={cat} value={cat} className="mt-2">
-                                {!hasItems ? (
-                                  <p className="text-muted-foreground py-4 text-center text-sm">
-                                    Keine Dateien in dieser Kategorie.
-                                  </p>
-                                ) : (
-                                  <ul className="space-y-2">
-                                    {legacyFile && (
-                                      <li className="flex items-center justify-between gap-2 rounded-lg border p-3">
-                                        <div className="flex min-w-0 items-center gap-2">
-                                          <AppIcon
-                                            icon={FileText}
-                                            size={16}
-                                            className="shrink-0 text-muted-foreground"
-                                          />
-                                          <span className="truncate text-sm">
-                                            {legacyFile.name}
-                                          </span>
-                                        </div>
-                                        <Button
-                                          variant="outline"
-                                          size="sm"
-                                          className="h-7 shrink-0 text-xs"
-                                          asChild
-                                        >
-                                          <a
-                                            href={`${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/references/${legacyFile.path}`}
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                          >
-                                            <AppIcon
-                                              icon={ExternalLink}
-                                              size={12}
-                                              className="mr-1"
-                                            />{' '}
-                                            Öffnen
-                                          </a>
-                                        </Button>
-                                      </li>
-                                    )}
-                                    {assetsInCat.map((asset) => (
-                                      <li
-                                        key={asset.id}
-                                        className="flex flex-wrap items-center justify-between gap-2 rounded-lg border p-3"
-                                      >
-                                        <div className="flex min-w-0 flex-1 items-center gap-2">
-                                          <AppIcon
-                                            icon={FileText}
-                                            size={16}
-                                            className="shrink-0 text-muted-foreground"
-                                          />
-                                          <span className="truncate text-sm">
-                                            {asset.file_name ||
-                                              asset.file_path.split('/').pop() ||
-                                              'Dokument'}
-                                          </span>
-                                        </div>
-                                        <div className="flex items-center gap-2">
-                                          {isSystemAdmin(profile.systemRole) && (
-                                            <Select
-                                              value={asset.category}
-                                              onValueChange={async (
-                                                value: 'sales' | 'contract' | 'other',
-                                              ) => {
-                                                const res =
-                                                  await updateReferenceAssetCategory(
-                                                    asset.id,
-                                                    value,
-                                                  )
-                                                if (res.success) {
-                                                  setDetailAssets((prev) =>
-                                                    prev.map((a) =>
-                                                      a.id === asset.id
-                                                        ? { ...a, category: value }
-                                                        : a,
-                                                    ),
-                                                  )
-                                                  toast.success('Kategorie aktualisiert.')
-                                                } else {
-                                                  toast.error(
-                                                    res.error ??
-                                                      'Fehler beim Aktualisieren.',
-                                                  )
-                                                }
-                                              }}
-                                            >
-                                              <SelectTrigger className="h-8 w-[130px] text-xs">
-                                                <SelectValue />
-                                              </SelectTrigger>
-                                              <SelectContent>
-                                                <SelectItem value="sales">
-                                                  Sales Material
-                                                </SelectItem>
-                                                <SelectItem value="contract">
-                                                  Verträge
-                                                </SelectItem>
-                                                <SelectItem value="other">
-                                                  Sonstiges
-                                                </SelectItem>
-                                              </SelectContent>
-                                            </Select>
-                                          )}
-                                          <Button
-                                            variant="outline"
-                                            size="sm"
-                                            className="h-7 shrink-0 text-xs"
-                                            asChild
-                                          >
-                                            <a
-                                              href={`${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/references/${asset.file_path}`}
-                                              target="_blank"
-                                              rel="noopener noreferrer"
-                                            >
-                                              <AppIcon
-                                                icon={ExternalLink}
-                                                size={12}
-                                                className="mr-1"
-                                              />{' '}
-                                              Öffnen
-                                            </a>
-                                          </Button>
-                                        </div>
-                                      </li>
-                                    ))}
-                                  </ul>
-                                )}
-                              </TabsContent>
-                            )
-                          })}
-                        </Tabs>
-                      )}
-                    </div>
-                    <div className="space-y-2">
-                      <span className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
-                        Historie
-                      </span>
-                      <div className="relative ml-1.5 space-y-4 border-l pl-4">
-                        <div className="relative">
-                          <span className="bg-primary ring-background absolute -left-[17px] top-0.5 h-2 w-2 rounded-full ring-2" />
-                          <p className="text-xs font-medium">Referenz erstellt</p>
-                          <p className="text-muted-foreground mt-1 text-[10px]">
-                            {formatReferenceDate(selectedRef.created_at, dateFmt)}
-                          </p>
-                        </div>
-                        {selectedRef.updated_at &&
-                          selectedRef.updated_at !== selectedRef.created_at && (
-                            <div className="relative">
-                              <span className="bg-muted-foreground/50 ring-background absolute -left-[17px] top-0.5 h-2 w-2 rounded-full ring-2" />
-                              <p className="text-xs font-medium">Letzte Änderung</p>
-                              <p className="text-muted-foreground mt-1 text-[10px]">
-                                {formatReferenceDate(selectedRef.updated_at, dateFmt)}
-                              </p>
-                            </div>
-                          )}
-                      </div>
-                    </div>
-                  </CardContent>
-                </Card>
+                <ReferenceDetailStoryCard
+                  selectedRef={selectedRef}
+                  normalizeTagLabel={normalizeTagLabel}
+                />
+                <ReferenceDetailProjectCard
+                  selectedRef={selectedRef}
+                  externalContacts={externalContacts}
+                  dateFmt={dateFmt}
+                />
+                <ReferenceDetailFilesCard
+                  selectedRef={selectedRef}
+                  profile={profile}
+                  detailAssets={detailAssets}
+                  detailAssetsLoading={detailAssetsLoading}
+                  setDetailAssets={setDetailAssets}
+                  dateFmt={dateFmt}
+                />
               </div>
             </div>
 

--- a/app/dashboard/overview/reference-detail/reference-detail-files-card.tsx
+++ b/app/dashboard/overview/reference-detail/reference-detail-files-card.tsx
@@ -1,0 +1,224 @@
+'use client'
+
+import type { Dispatch, SetStateAction } from 'react'
+import { toast } from 'sonner'
+import { ExternalLink, FileText } from '@hugeicons/core-free-icons'
+
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import {
+  formatReferenceDate,
+  type OrgDateDisplayFormat,
+} from '@/lib/format'
+import { AppIcon } from '@/lib/icons'
+import { isSystemAdmin } from '@/lib/roles/capability-access'
+
+import type { ReferenceAssetRow, ReferenceRow } from '../../actions'
+import { updateReferenceAssetCategory } from '../../actions'
+import type { Profile } from '../../dashboard-types'
+
+export function ReferenceDetailFilesCard({
+  selectedRef,
+  profile,
+  detailAssets,
+  detailAssetsLoading,
+  setDetailAssets,
+  dateFmt,
+}: {
+  selectedRef: ReferenceRow
+  profile: Profile
+  detailAssets: ReferenceAssetRow[]
+  detailAssetsLoading: boolean
+  setDetailAssets: Dispatch<SetStateAction<ReferenceAssetRow[]>>
+  dateFmt: OrgDateDisplayFormat
+}) {
+  return (
+    <Card className="bg-muted/30">
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <span className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
+            Dateien
+          </span>
+          {detailAssetsLoading ? (
+            <div className="flex h-24 items-center justify-center rounded-lg border border-dashed text-muted-foreground text-sm">
+              Dateien werden geladen…
+            </div>
+          ) : detailAssets.length === 0 && !selectedRef.file_path ? (
+            <div className="text-muted-foreground bg-muted/10 flex h-24 flex-col items-center justify-center gap-1 rounded-lg border border-dashed text-xs">
+              <span>📎</span>
+              <p>Keine Dateien vorhanden.</p>
+            </div>
+          ) : (
+            <Tabs defaultValue="sales" className="w-full">
+              <TabsList className="grid w-full grid-cols-3">
+                <TabsTrigger value="sales">Sales Material</TabsTrigger>
+                <TabsTrigger value="contract">Verträge</TabsTrigger>
+                <TabsTrigger value="other">Sonstiges</TabsTrigger>
+              </TabsList>
+              {(['sales', 'contract', 'other'] as const).map((cat) => {
+                const legacyFile =
+                  cat === 'other' && detailAssets.length === 0 && selectedRef.file_path
+                    ? {
+                        path: selectedRef.file_path,
+                        name: selectedRef.file_path.split('/').pop() ?? 'Dokument',
+                        isLegacy: true as const,
+                      }
+                    : null
+                const assetsInCat = detailAssets.filter((a) => a.category === cat)
+                const hasLegacy = !!legacyFile
+                const hasItems = assetsInCat.length > 0 || hasLegacy
+                return (
+                  <TabsContent key={cat} value={cat} className="mt-2">
+                    {!hasItems ? (
+                      <p className="text-muted-foreground py-4 text-center text-sm">
+                        Keine Dateien in dieser Kategorie.
+                      </p>
+                    ) : (
+                      <ul className="space-y-2">
+                        {legacyFile && (
+                          <li className="flex items-center justify-between gap-2 rounded-lg border p-3">
+                            <div className="flex min-w-0 items-center gap-2">
+                              <AppIcon
+                                icon={FileText}
+                                size={16}
+                                className="shrink-0 text-muted-foreground"
+                              />
+                              <span className="truncate text-sm">{legacyFile.name}</span>
+                            </div>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              className="h-7 shrink-0 text-xs"
+                              asChild
+                            >
+                              <a
+                                href={`${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/references/${legacyFile.path}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                              >
+                                <AppIcon icon={ExternalLink} size={12} className="mr-1" />{' '}
+                                Öffnen
+                              </a>
+                            </Button>
+                          </li>
+                        )}
+                        {assetsInCat.map((asset) => (
+                          <li
+                            key={asset.id}
+                            className="flex flex-wrap items-center justify-between gap-2 rounded-lg border p-3"
+                          >
+                            <div className="flex min-w-0 flex-1 items-center gap-2">
+                              <AppIcon
+                                icon={FileText}
+                                size={16}
+                                className="shrink-0 text-muted-foreground"
+                              />
+                              <span className="truncate text-sm">
+                                {asset.file_name ||
+                                  asset.file_path.split('/').pop() ||
+                                  'Dokument'}
+                              </span>
+                            </div>
+                            <div className="flex items-center gap-2">
+                              {isSystemAdmin(profile.systemRole) && (
+                                <Select
+                                  value={asset.category}
+                                  onValueChange={async (
+                                    value: 'sales' | 'contract' | 'other',
+                                  ) => {
+                                    const res = await updateReferenceAssetCategory(
+                                      asset.id,
+                                      value,
+                                    )
+                                    if (res.success) {
+                                      setDetailAssets((prev) =>
+                                        prev.map((a) =>
+                                          a.id === asset.id
+                                            ? { ...a, category: value }
+                                            : a,
+                                        ),
+                                      )
+                                      toast.success('Kategorie aktualisiert.')
+                                    } else {
+                                      toast.error(
+                                        res.error ?? 'Fehler beim Aktualisieren.',
+                                      )
+                                    }
+                                  }}
+                                >
+                                  <SelectTrigger className="h-8 w-[130px] text-xs">
+                                    <SelectValue />
+                                  </SelectTrigger>
+                                  <SelectContent>
+                                    <SelectItem value="sales">Sales Material</SelectItem>
+                                    <SelectItem value="contract">Verträge</SelectItem>
+                                    <SelectItem value="other">Sonstiges</SelectItem>
+                                  </SelectContent>
+                                </Select>
+                              )}
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                className="h-7 shrink-0 text-xs"
+                                asChild
+                              >
+                                <a
+                                  href={`${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/references/${asset.file_path}`}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                >
+                                  <AppIcon
+                                    icon={ExternalLink}
+                                    size={12}
+                                    className="mr-1"
+                                  />{' '}
+                                  Öffnen
+                                </a>
+                              </Button>
+                            </div>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </TabsContent>
+                )
+              })}
+            </Tabs>
+          )}
+        </div>
+        <div className="space-y-2">
+          <span className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
+            Historie
+          </span>
+          <div className="relative ml-1.5 space-y-4 border-l pl-4">
+            <div className="relative">
+              <span className="bg-primary ring-background absolute -left-[17px] top-0.5 h-2 w-2 rounded-full ring-2" />
+              <p className="text-xs font-medium">Referenz erstellt</p>
+              <p className="text-muted-foreground mt-1 text-[10px]">
+                {formatReferenceDate(selectedRef.created_at, dateFmt)}
+              </p>
+            </div>
+            {selectedRef.updated_at &&
+              selectedRef.updated_at !== selectedRef.created_at && (
+                <div className="relative">
+                  <span className="bg-muted-foreground/50 ring-background absolute -left-[17px] top-0.5 h-2 w-2 rounded-full ring-2" />
+                  <p className="text-xs font-medium">Letzte Änderung</p>
+                  <p className="text-muted-foreground mt-1 text-[10px]">
+                    {formatReferenceDate(selectedRef.updated_at, dateFmt)}
+                  </p>
+                </div>
+              )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/dashboard/overview/reference-detail/reference-detail-project-card.tsx
+++ b/app/dashboard/overview/reference-detail/reference-detail-project-card.tsx
@@ -1,0 +1,309 @@
+'use client'
+
+import {
+  Building2,
+  Calendar,
+  ExternalLink,
+  FileText,
+  Globe,
+  Mail,
+  MapPinIcon,
+  Phone,
+  Timer,
+  UserIcon,
+  Users,
+} from '@hugeicons/core-free-icons'
+
+import { Card, CardContent } from '@/components/ui/card'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { formatIndustryDisplay } from '@/lib/constants/industries'
+import {
+  diffMonthsUtc,
+  formatNumberDe,
+  formatReferenceDate,
+  formatReferenceVolume,
+  type OrgDateDisplayFormat,
+} from '@/lib/format'
+import { formatContractTypeDisplay } from '@/lib/references/contract-type'
+import { AppIcon } from '@/lib/icons'
+
+import type { ReferenceRow } from '../../actions'
+
+export type ReferenceDetailExternalContact = {
+  id: string
+  company_id: string
+  first_name: string | null
+  last_name: string | null
+  email: string | null
+  role: string | null
+  phone?: string | null
+}
+
+export function ReferenceDetailProjectCard({
+  selectedRef,
+  externalContacts,
+  dateFmt,
+}: {
+  selectedRef: ReferenceRow
+  externalContacts: ReferenceDetailExternalContact[]
+  dateFmt: OrgDateDisplayFormat
+}) {
+  return (
+    <Card>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <span className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
+            Projektdetails
+          </span>
+          <div className="grid grid-cols-2 gap-x-6 gap-y-3">
+            <div className="space-y-0.5">
+              <span className="text-muted-foreground flex items-center gap-1.5 text-xs font-medium">
+                <AppIcon icon={FileText} size={12} /> Volumen
+              </span>
+              <p
+                className={`pl-4 text-xs font-medium ${selectedRef.volume_eur ? 'text-foreground' : 'text-muted-foreground'}`}
+              >
+                {selectedRef.volume_eur
+                  ? formatReferenceVolume(selectedRef.volume_eur)
+                  : '—'}
+              </p>
+            </div>
+            <div className="space-y-0.5">
+              <span className="text-muted-foreground flex items-center gap-1.5 text-xs font-medium">
+                <AppIcon icon={FileText} size={12} /> Vertragsart
+              </span>
+              <p
+                className={`pl-4 text-xs font-medium ${selectedRef.contract_type ? 'text-foreground' : 'text-muted-foreground'}`}
+              >
+                {formatContractTypeDisplay(selectedRef.contract_type) || '—'}
+              </p>
+            </div>
+            <div className="space-y-0.5">
+              <span className="text-muted-foreground flex items-center gap-1.5 text-xs font-medium">
+                <AppIcon icon={Calendar} size={12} /> Projektstart
+              </span>
+              <p
+                className={`pl-4 text-xs font-medium ${selectedRef.project_start ? 'text-foreground' : 'text-muted-foreground'}`}
+              >
+                {selectedRef.project_start
+                  ? formatReferenceDate(selectedRef.project_start, dateFmt)
+                  : '—'}
+              </p>
+            </div>
+            <div className="space-y-0.5">
+              <span className="text-muted-foreground flex items-center gap-1.5 text-xs font-medium">
+                <AppIcon icon={Timer} size={12} /> Projektende / Dauer
+              </span>
+              {(() => {
+                const start = selectedRef.project_start
+                const end = selectedRef.project_end
+                const status = selectedRef.project_status
+                const label =
+                  status === 'active'
+                    ? 'Aktiv'
+                    : end
+                      ? formatReferenceDate(end, dateFmt)
+                      : '—'
+                const nowIso = new Date().toISOString()
+                const duration =
+                  selectedRef.duration_months != null
+                    ? selectedRef.duration_months
+                    : start && end
+                      ? diffMonthsUtc(start, end)
+                      : status === 'active' && start
+                        ? diffMonthsUtc(start, nowIso)
+                        : null
+                return (
+                  <p className="pl-4 text-xs font-medium text-foreground">
+                    {duration != null ? `${label} (${duration} Monate)` : label}
+                  </p>
+                )
+              })()}
+            </div>
+            <div className="space-y-0.5">
+              <span className="text-muted-foreground flex items-center gap-1.5 text-xs font-medium">
+                <AppIcon icon={Building2} size={12} /> Aktueller Dienstleister
+              </span>
+              <p
+                className={`pl-4 text-xs font-medium ${selectedRef.incumbent_provider ? 'text-foreground' : 'text-muted-foreground'}`}
+              >
+                {selectedRef.incumbent_provider || '—'}
+              </p>
+            </div>
+            <div className="space-y-0.5">
+              <span className="text-muted-foreground flex items-center gap-1.5 text-xs font-medium">
+                <AppIcon icon={Users} size={12} /> Beteiligte Wettbewerber
+              </span>
+              <p
+                className={`pl-4 text-xs font-medium ${selectedRef.competitors ? 'text-foreground' : 'text-muted-foreground'}`}
+              >
+                {selectedRef.competitors || '—'}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <hr className="border-border/60" />
+
+        <div className="space-y-2">
+          <span className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
+            Unternehmensdetails
+          </span>
+          <div className="grid grid-cols-2 gap-x-6 gap-y-3">
+            <div className="space-y-0.5">
+              <span className="text-muted-foreground flex items-center gap-1.5 text-xs font-medium">
+                <AppIcon icon={Building2} size={12} /> Industrie
+              </span>
+              <p
+                className={`pl-4 text-xs font-medium ${selectedRef.industry ? 'text-foreground' : 'text-muted-foreground'}`}
+              >
+                {formatIndustryDisplay(selectedRef.industry) || '—'}
+              </p>
+            </div>
+            <div className="space-y-0.5">
+              <span className="text-muted-foreground flex items-center gap-1.5 text-xs font-medium">
+                <AppIcon icon={MapPinIcon} size={12} /> HQ
+              </span>
+              <p
+                className={`pl-4 text-xs font-medium ${selectedRef.country ? 'text-foreground' : 'text-muted-foreground'}`}
+              >
+                {selectedRef.country || '—'}
+              </p>
+            </div>
+            <div className="space-y-0.5">
+              <span className="text-muted-foreground flex items-center gap-1.5 text-xs font-medium">
+                <AppIcon icon={Globe} size={12} /> Website
+              </span>
+              <div className="pl-4">
+                {selectedRef.website ? (
+                  <a
+                    href={selectedRef.website}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-primary hover:underline inline-flex items-center gap-1 text-xs font-medium"
+                  >
+                    Öffnen <AppIcon icon={ExternalLink} size={12} />
+                  </a>
+                ) : (
+                  <p className="text-xs font-medium text-muted-foreground">—</p>
+                )}
+              </div>
+            </div>
+            <div className="space-y-0.5">
+              <span className="text-muted-foreground flex items-center gap-1.5 text-xs font-medium">
+                <AppIcon icon={UserIcon} size={12} /> Mitarbeiter
+              </span>
+              <p
+                className={`pl-4 text-xs font-medium ${selectedRef.employee_count != null ? 'text-foreground' : 'text-muted-foreground'}`}
+              >
+                {formatNumberDe(selectedRef.employee_count)}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <hr className="border-border/60" />
+
+        <div className="space-y-2">
+          <span className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
+            Kontakte
+          </span>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div className="space-y-1">
+              <span className="text-muted-foreground flex items-center gap-1.5 text-xs font-medium">
+                <AppIcon icon={UserIcon} size={12} /> Interner Ansprechpartner
+              </span>
+              <p className="pl-4 text-xs font-medium">
+                {selectedRef.contact_display ||
+                  selectedRef.contact_email ||
+                  'Nicht zugewiesen'}
+              </p>
+              <div className="text-muted-foreground flex flex-wrap items-center gap-2 pl-4">
+                {selectedRef.contact_email && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <a
+                        href={`mailto:${selectedRef.contact_email}`}
+                        className="inline-flex items-center gap-1 text-[10px] hover:underline"
+                      >
+                        <AppIcon icon={Mail} size={14} />
+                        {selectedRef.contact_email}
+                      </a>
+                    </TooltipTrigger>
+                    <TooltipContent>E-Mail: {selectedRef.contact_email}</TooltipContent>
+                  </Tooltip>
+                )}
+              </div>
+              <p className="text-muted-foreground pl-4 text-[10px]">Account Owner</p>
+            </div>
+            <div className="space-y-1">
+              <span className="text-muted-foreground flex items-center gap-1.5 text-xs font-medium">
+                <AppIcon icon={UserIcon} size={12} /> Kundenansprechpartner
+              </span>
+              {(() => {
+                const ext = selectedRef.customer_contact_id
+                  ? externalContacts?.find((c) => c.id === selectedRef.customer_contact_id)
+                  : undefined
+                const displayName =
+                  selectedRef.customer_contact ||
+                  (ext
+                    ? [ext.first_name, ext.last_name].filter(Boolean).join(' ')
+                    : null) ||
+                  '—'
+                const email = ext?.email ?? null
+                const phone = ext?.phone ?? null
+                const role = ext?.role ?? null
+                return (
+                  <>
+                    <p
+                      className={`pl-4 text-xs font-medium ${displayName !== '—' ? 'text-foreground' : 'text-muted-foreground'}`}
+                    >
+                      {displayName}
+                    </p>
+                    <div className="text-muted-foreground flex flex-wrap items-center gap-2 pl-4">
+                      {email && (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <a
+                              href={`mailto:${email}`}
+                              className="inline-flex items-center gap-1 text-[10px] hover:underline"
+                            >
+                              <AppIcon icon={Mail} size={14} />
+                              {email}
+                            </a>
+                          </TooltipTrigger>
+                          <TooltipContent>E-Mail: {email}</TooltipContent>
+                        </Tooltip>
+                      )}
+                      {phone && (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <a
+                              href={`tel:${phone}`}
+                              className="inline-flex items-center gap-1 text-[10px] hover:underline"
+                            >
+                              <AppIcon icon={Phone} size={14} />
+                              {phone}
+                            </a>
+                          </TooltipTrigger>
+                          <TooltipContent>Telefon: {phone}</TooltipContent>
+                        </Tooltip>
+                      )}
+                    </div>
+                    {role && (
+                      <p className="text-muted-foreground pl-4 text-[10px]">{role}</p>
+                    )}
+                  </>
+                )
+              })()}
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/dashboard/overview/reference-detail/reference-detail-story-card.tsx
+++ b/app/dashboard/overview/reference-detail/reference-detail-story-card.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { Tag01Icon } from '@hugeicons/core-free-icons'
+
+import { Card, CardContent } from '@/components/ui/card'
+import { AppIcon } from '@/lib/icons'
+
+import type { ReferenceRow } from '../../actions'
+
+export function ReferenceDetailStoryCard({
+  selectedRef,
+  normalizeTagLabel,
+}: {
+  selectedRef: ReferenceRow
+  normalizeTagLabel: (raw: string) => string
+}) {
+  return (
+    <Card>
+      <CardContent className="space-y-4">
+        {selectedRef.customer_challenge || selectedRef.our_solution ? (
+          <div className="space-y-7">
+            {selectedRef.customer_challenge ? (
+              <div className="space-y-3">
+                <span className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
+                  Herausforderung des Kunden
+                </span>
+                <p className="text-foreground text-sm leading-relaxed">
+                  {selectedRef.customer_challenge}
+                </p>
+              </div>
+            ) : null}
+            {selectedRef.our_solution ? (
+              <div className="space-y-3">
+                <span className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
+                  Unsere Lösung
+                </span>
+                <p className="text-foreground text-sm leading-relaxed">
+                  {selectedRef.our_solution}
+                </p>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+        <div className="space-y-2">
+          <span className="text-muted-foreground flex items-center gap-1.5 text-xs font-medium">
+            <AppIcon icon={Tag01Icon} size={12} /> Tags
+          </span>
+          <div className="flex flex-wrap gap-1.5">
+            {selectedRef.tags ? (
+              selectedRef.tags
+                .split(/[\s,]+/)
+                .map((tag) => normalizeTagLabel(tag))
+                .filter(Boolean)
+                .map((tag) => (
+                  <span
+                    key={tag}
+                    className="rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-foreground"
+                  >
+                    {tag}
+                  </span>
+                ))
+            ) : (
+              <span className="text-xs font-medium text-muted-foreground">—</span>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/docs/tech-debt-offen-backlog.md
+++ b/docs/tech-debt-offen-backlog.md
@@ -12,7 +12,7 @@
 |--------|--------|
 | **Erledigt** | Inventar-Hygiene (#0); E4 (#1); E7 (#2); **P1-6** (#4); Welle-5 Rollen; Typed-Supabase **T1–T4** (#3); **#8** `references`-Pfade; **#9** Invite-SQL skip; **#7** DE/EN-Dateinamen; **#6** Lib-Results (Cron/Push-JSON geparkt) |
 | **In Arbeit** | — |
-| **Offen (Queue)** | #5 God-Files (Boy-Scout) · #6 Cron/Push-JSON (bewusst geparkt) |
+| **Offen (Queue)** | #5 God-Files (weiter slicen) · #6 Cron/Push-JSON (bewusst geparkt) |
 | **Geparkt** | Pilot (H3/E1/G2); Massen-Renames |
 
 **Hebel jetzt:** Boy-Scout #5 bei Feature-Touch; #6 Cron/Push nur mit bewusstem API-Change.
@@ -28,7 +28,7 @@
 | **2** | E7 Schema-Sync | ✅ T1–T4 | Types bei Migrationen regenerieren (`db:types`) | XS ongoing | bei Schema-Change |
 | **3** | Typed-Supabase Cast-Abbau | ✅ T1–T4 | Rest-Casts nur Boundaries (HTTP/RPC/Json); Boy-Scout bei Touch | — | CI: `typecheck` vor Build |
 | **4** | P1-6 Accounts Naming | ✅ App/Lib | DB-Tabelle `companies` / `company_id` / Firmennamen-Helfer **bewusst offen** | — | nicht anfassen ohne Produktentscheid |
-| **5** | God-File-Nacharbeit | offen (Boy-Scout) | Overview / Share-Link / MS-Feed weiter slicen **nur bei Feature-Touch** | M ongoing | kein eigener Big-Bang-PR |
+| **5** | God-File-Nacharbeit | Slice 1 ✅ | `reference-detail-sheet` → Story/Project/Files-Cards (~783→~250 Orchestrierung) | M ongoing | nächster: readiness-actions oder overview |
 | **6** | `{ ok }` → `{ success }` | Lib ✅ | Slices 1–4; Rest nur Cron/Push-HTTP-Body | XS | Cron/Push separat wenn Monitoring-Clients ok |
 | **7** | P3-3 DE/EN-Dateinamen | ✅ Slice | `ai-draft-*`, `customer-control-link-email`; API `/api/ai-draft` + Redirect; UI-Copy „Sperrlink“/Event `ki_entwurf_generated` bleiben | — | Rest nur bei Touch |
 | **8** | `references`/`evidence` Pfade | ✅ | App = `references` (Routen/Ordner/`ROUTES`); Redirects `/dashboard/evidence` bleiben; `evidence_events` bleibt | — | Rest-`evidence` nur Domänenbegriff (RFP-Belege) |


### PR DESCRIPTION
## Summary
- Queue **#5** Slice 1: `reference-detail-sheet.tsx` (~783 → ~247 Orchestrierung).
- Extrahiert: Story-, Projekt- und Dateien/Historie-Cards unter `overview/reference-detail/`.
- Kein Verhaltens-Diff; Header/Footer bleiben im Sheet.

## Test plan
- [x] `npm run typecheck`
- [ ] Overview: Referenz-Detail-Sheet öffnen (Story, Projektdetails, Dateien-Tabs, Historie)
- [ ] Favorit / Kundenlink / Bearbeiten / Löschen / Freigabe-CTA
- [ ] Asset-Kategorie ändern (Admin)


Made with [Cursor](https://cursor.com)