### PR TITLE
fix(sharing): restore SupabaseClient import

### DIFF
--- a/lib/references/library/sharing-create.ts
+++ b/lib/references/library/sharing-create.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import { randomBytes } from 'crypto'
+import type { SupabaseClient } from '@supabase/supabase-js'
 import { createServerSupabaseClient } from '@/lib/supabase/server'
 import { generatePortfolioSlug } from '@/lib/slug'
 import { logEvent } from '@/lib/events/log-event'


### PR DESCRIPTION
## Summary
- Behebt Typecheck-Regression aus #59: fehlender `SupabaseClient`-Import in `sharing-create.ts`.

## Test plan
- [x] `npm run typecheck`


Made with [Cursor](https://cursor.com)