### PR TITLE
fix(sharing): restore Vercel build after sharing split

### DIFF
--- a/lib/references/library/sharing-create.ts
+++ b/lib/references/library/sharing-create.ts
@@ -18,14 +18,8 @@ import {
   hashCustomerManageToken,
   linkExpiryDaysFromWorkflow,
   parsePortfolioRpcJson,
+  type CreateSharedPortfolioRecipient,
 } from '@/lib/references/library/sharing-helpers'
-
-export type CreateSharedPortfolioRecipient = {
-  label: string
-  visitorEmail?: string | null
-  externalContactId?: string | null
-  companyId?: string | null
-}
 
 function generatePortfolioRecipientToken(): string {
   return randomBytes(18)

--- a/lib/references/library/sharing-helpers.ts
+++ b/lib/references/library/sharing-helpers.ts
@@ -1,5 +1,3 @@
-'use server'
-
 import { createHash, randomBytes } from 'crypto'
 import type { SupabaseClient } from '@supabase/supabase-js'
 import type { Json } from '@/lib/database.types'
@@ -10,6 +8,13 @@ import { log } from '@/lib/observability/logger'
 import { hasActiveCustomerApprovalWorkflow } from '@/lib/references/effective-customer-approval'
 
 import type { ReferenceRow } from '@/app/dashboard/actions'
+
+export type CreateSharedPortfolioRecipient = {
+  label: string
+  visitorEmail?: string | null
+  externalContactId?: string | null
+  companyId?: string | null
+}
 
 export function generateCustomerManageToken(): string {
   return randomBytes(32).toString('hex')

--- a/lib/references/library/sharing.ts
+++ b/lib/references/library/sharing.ts
@@ -1,9 +1,10 @@
-'use server'
-
 /**
  * Share-/Portfolio-API (Barrel). Implementierung in sharing-*.ts.
+ *
+ * Kein `'use server'` hier: Turbopack erlaubt in Server-Action-Dateien keine
+ * Re-Exports/`export type` — nur async Function-Exports.
  */
-export type { CreateSharedPortfolioRecipient } from '@/lib/references/library/sharing-create'
+export type { CreateSharedPortfolioRecipient } from '@/lib/references/library/sharing-helpers'
 export {
   createSharedPortfolioImpl,
   getPortfolioManageAndPreviewUrlsForApprovalEmail,


### PR DESCRIPTION
## Summary
- Build-Fix für #59: `'use server'`-Barrel darf bei Turbopack keine Re-Exports/`export type` haben.
- `'use server'` von `sharing.ts` (Barrel) und `sharing-helpers.ts` entfernt; Type nach Helpers verschoben.
- Create/Manage/Queries behalten `'use server'` (nur async Exports).

## Test plan
- [x] `npm run typecheck`
- [x] `npm run build`
- [ ] Vercel Preview/Production Deploy grün


Made with [Cursor](https://cursor.com)