### PR TITLE
refactor(#5): extract dashboard overview hooks (slice 4)

### DIFF
--- a/app/dashboard/dashboard-overview.tsx
+++ b/app/dashboard/dashboard-overview.tsx
@@ -4,17 +4,11 @@ import React from 'react'
 import dynamic from 'next/dynamic'
 import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
-import type { ReferenceRow, ReferenceAssetRow } from './actions'
+import type { ReferenceRow } from './actions'
 import { ROUTES } from '@/lib/routes'
 import { isSalesAppView, userCanCreateReference } from '@/lib/roles/reference-access'
 import { isSystemAdmin } from '@/lib/roles/capability-access'
-import {
-  createSharedPortfolio,
-  deleteReference,
-  getExistingShareForReference,
-  getReferenceAssets,
-  toggleFavorite,
-} from './actions'
+import { deleteReference, toggleFavorite } from './actions'
 import type { Profile } from './dashboard-types'
 import { ReferenceLibraryToolbar } from './overview/reference-library-toolbar'
 import { ComplianceDocumentsTable } from './overview/compliance-documents-table'
@@ -28,20 +22,12 @@ import {
   useReferenceLibraryMode,
 } from '@/lib/references/library/reference-library-mode-store'
 import type { ComplianceDocumentRow } from '@/app/dashboard/settings/compliance-actions'
-import { type ReferenceColumnKey } from './overview/reference-table-column-renders'
 import {
   COLUMN_KEYS,
   COLUMN_LABELS,
-  COLUMN_ORDER_STORAGE_KEY,
-  COLUMN_SIZING_STORAGE_KEY,
-  COLUMN_VISIBLE_STORAGE_KEY,
-  DEFAULT_VISIBLE,
   REFERENCE_SHOW_EXPIRED_CERTS_KEY,
   STATUS_LABELS,
-  loadColumnOrderFromStorage,
-  loadReferenceColumnWidthsFromStorage,
   loadShowExpiredCertificatesFromStorage,
-  loadVisibleColumnsFromStorage,
 } from './overview/reference-overview-columns'
 import {
   buildReferenceFilterOptions,
@@ -54,12 +40,18 @@ import {
   buildCompanyIndustryById,
   buildCompanyLogoById,
 } from './overview/reference-company-maps'
+import {
+  copyReferenceShareLink,
+  createAndCopyCollectionShareLink,
+} from './overview/reference-overview-share-link'
 import { ReferencesOverviewBrandfetchSync } from './overview/references-overview-brandfetch-sync'
 import { ReferencesBulkActionsBar } from './overview/references-bulk-actions-bar'
+import type { ReferenceColumnKey } from './overview/reference-table-column-types'
+import { useReferenceDetailSheet } from './overview/use-reference-detail-sheet'
+import { useReferenceOverviewColumns } from './overview/use-reference-overview-columns'
 import { useReferencesOverviewDialogsState } from './overview/use-references-overview-dialogs-state'
 import { ReferenceOnboardingEmptyState } from '@/app/dashboard/references/components/reference-onboarding-empty-state'
 import { toast } from 'sonner'
-import { clampColumnWidth, saveColumnWidthsToStorage } from '@/lib/table-column-sizing'
 import type { OrgDateDisplayFormat } from '@/lib/format'
 import { canViewComplianceReferenceSegment } from '@/lib/references/library/reference-proof-segment-access'
 import type { ReferenceVolumeFilter } from '@/lib/references/reference-volume-filter'
@@ -165,10 +157,16 @@ export function DashboardOverview({
     profile.functionRole,
   )
   const [rowMenuOpenId, setRowMenuOpenId] = useState<string | null>(null)
-  const [selectedRef, setSelectedRef] = useState<ReferenceRow | null>(null)
-  const [sheetOpen, setSheetOpen] = useState(false)
-  const [detailAssets, setDetailAssets] = useState<ReferenceAssetRow[]>([])
-  const [detailAssetsLoading, setDetailAssetsLoading] = useState(false)
+  const {
+    selectedRef,
+    setSelectedRef,
+    sheetOpen,
+    setSheetOpen,
+    detailAssets,
+    setDetailAssets,
+    detailAssetsLoading,
+    handleReferenceSheetOpenChange,
+  } = useReferenceDetailSheet()
   const {
     setComplianceUploadOpen,
     setComplianceBulkUploadOpen,
@@ -184,24 +182,18 @@ export function DashboardOverview({
   } = useReferencesOverviewDialogsState()
   const [pageSize, setPageSize] = useState(30)
   const [pageIndex, setPageIndex] = useState(0)
-  const [visibleColumns, setVisibleColumns] = useState<
-    Record<(typeof COLUMN_KEYS)[number], boolean>
-  >(loadVisibleColumnsFromStorage)
-  const [columnOrder, setColumnOrder] = useState<ReferenceColumnKey[]>(() =>
-    loadColumnOrderFromStorage(),
-  )
-  const [columnWidths, setColumnWidths] = useState<Record<ReferenceColumnKey, number>>(
-    () => loadReferenceColumnWidthsFromStorage(),
-  )
-  const [dragOverColumn, setDragOverColumn] = useState<string | null>(null)
-
-  const handleReferenceSheetOpenChange = useCallback((open: boolean) => {
-    setSheetOpen(open)
-    if (!open) {
-      setDetailAssets([])
-      setDetailAssetsLoading(false)
-    }
-  }, [])
+  const {
+    visibleColumns,
+    setVisibleColumns,
+    columnOrder,
+    columnWidths,
+    dragOverColumn,
+    setDragOverColumn,
+    handleColumnWidthChange,
+    resetVisibleColumns,
+    orderedVisibleColumnKeys,
+    moveColumnOrder,
+  } = useReferenceOverviewColumns()
 
   useLayoutEffect(() => {
     syncReferenceLibraryModeFromStorage()
@@ -239,72 +231,9 @@ export function DashboardOverview({
     }
   }, [showExpiredCertificates])
 
-  useEffect(() => {
-    if (!selectedRef?.id || !sheetOpen) return
-    let cancelled = false
-    void (async () => {
-      setDetailAssetsLoading(true)
-      try {
-        const assets = await getReferenceAssets(selectedRef.id)
-        if (!cancelled) setDetailAssets(assets)
-      } finally {
-        if (!cancelled) setDetailAssetsLoading(false)
-      }
-    })()
-    return () => {
-      cancelled = true
-    }
-  }, [selectedRef?.id, sheetOpen])
-
-  useEffect(() => {
-    try {
-      localStorage.setItem(COLUMN_ORDER_STORAGE_KEY, JSON.stringify(columnOrder))
-    } catch {
-      /* ignore */
-    }
-  }, [columnOrder])
-
-  useEffect(() => {
-    saveColumnWidthsToStorage(COLUMN_SIZING_STORAGE_KEY, columnWidths)
-  }, [columnWidths])
-
-  const handleColumnWidthChange = useCallback(
-    (column: ReferenceColumnKey, width: number) => {
-      setColumnWidths((prev) => ({
-        ...prev,
-        [column]: clampColumnWidth(width),
-      }))
-    },
-    [],
+  const [favoriteIds, setFavoriteIds] = useState<Set<string>>(
+    () => new Set(initialReferences.filter((r) => r.is_favorited).map((r) => r.id)),
   )
-
-  useEffect(() => {
-    try {
-      localStorage.setItem(COLUMN_VISIBLE_STORAGE_KEY, JSON.stringify(visibleColumns))
-    } catch {
-      /* ignore */
-    }
-  }, [visibleColumns])
-
-  const resetVisibleColumns = useCallback(() => {
-    setVisibleColumns({ ...DEFAULT_VISIBLE })
-  }, [])
-
-  const orderedVisibleColumnKeys = useMemo(
-    () => columnOrder.filter((k) => visibleColumns[k]),
-    [columnOrder, visibleColumns],
-  )
-
-  const moveColumnOrder = useCallback((from: string, to: string) => {
-    if (from === to) return
-    setColumnOrder((prev) => {
-      const next = prev.filter((k) => k !== from)
-      const insertAt = next.indexOf(to as ReferenceColumnKey)
-      if (insertAt === -1) return prev
-      next.splice(insertAt, 0, from as ReferenceColumnKey)
-      return next
-    })
-  }, [])
 
   const handleToggleFavorite = (id: string, e?: React.MouseEvent) => {
     e?.stopPropagation()
@@ -331,10 +260,6 @@ export function DashboardOverview({
       },
     )
   }
-
-  const [favoriteIds, setFavoriteIds] = useState<Set<string>>(
-    () => new Set(initialReferences.filter((r) => r.is_favorited).map((r) => r.id)),
-  )
 
   const referencesWithLocalFavorites = useMemo(
     () =>
@@ -469,25 +394,6 @@ export function DashboardOverview({
     toast.success('ID in die Zwischenablage kopiert')
   }
 
-  async function copyReferenceShareLink(referenceId: string) {
-    const existing = await getExistingShareForReference(referenceId)
-    let shareUrl = existing?.url ?? null
-    if (!shareUrl) {
-      const created = await createSharedPortfolio([referenceId])
-      if (!created.success) {
-        toast.error(created.error ?? 'Kundenlink konnte nicht erstellt werden.')
-        return
-      }
-      shareUrl = created.url
-    }
-    const absoluteUrl =
-      shareUrl.startsWith('http://') || shareUrl.startsWith('https://')
-        ? shareUrl
-        : new URL(shareUrl, window.location.origin).toString()
-    await navigator.clipboard.writeText(absoluteUrl)
-    toast.success('Kundenlink kopiert.')
-  }
-
   const canCreateReference = userCanCreateReference(
     profile.functionRole,
     profile.systemRole,
@@ -592,20 +498,7 @@ export function DashboardOverview({
             onClearSelection={() => setSelectedRefIds(new Set())}
             onBulkDelete={() => setBulkDeleteConfirmOpen(true)}
             onCreateSharedPortfolio={async () => {
-              const selected = Array.from(selectedRefIds)
-              const result = await createSharedPortfolio(selected)
-              if (!result.success) {
-                toast.error(
-                  result.error ?? 'Kollektions-Link konnte nicht erstellt werden.',
-                )
-                return
-              }
-              const absoluteUrl =
-                result.url.startsWith('http://') || result.url.startsWith('https://')
-                  ? result.url
-                  : new URL(result.url, window.location.origin).toString()
-              await navigator.clipboard.writeText(absoluteUrl)
-              toast.success('Kollektions-Link erstellt und kopiert.')
+              await createAndCopyCollectionShareLink(Array.from(selectedRefIds))
             }}
             onDownloadPdfs={() => {
               const base = process.env.NEXT_PUBLIC_SUPABASE_URL

--- a/app/dashboard/overview/reference-overview-share-link.ts
+++ b/app/dashboard/overview/reference-overview-share-link.ts
@@ -1,0 +1,42 @@
+import { toast } from 'sonner'
+
+import {
+  createSharedPortfolio,
+  getExistingShareForReference,
+} from '@/app/dashboard/actions'
+
+function toAbsoluteShareUrl(shareUrl: string): string {
+  if (shareUrl.startsWith('http://') || shareUrl.startsWith('https://')) {
+    return shareUrl
+  }
+  return new URL(shareUrl, window.location.origin).toString()
+}
+
+/** Bestehenden oder neuen Kundenlink für eine Referenz in die Zwischenablage kopieren. */
+export async function copyReferenceShareLink(referenceId: string): Promise<void> {
+  const existing = await getExistingShareForReference(referenceId)
+  let shareUrl = existing?.url ?? null
+  if (!shareUrl) {
+    const created = await createSharedPortfolio([referenceId])
+    if (!created.success) {
+      toast.error(created.error ?? 'Kundenlink konnte nicht erstellt werden.')
+      return
+    }
+    shareUrl = created.url
+  }
+  await navigator.clipboard.writeText(toAbsoluteShareUrl(shareUrl))
+  toast.success('Kundenlink kopiert.')
+}
+
+/** Kollektions-Link für mehrere Referenzen erstellen und kopieren. */
+export async function createAndCopyCollectionShareLink(
+  referenceIds: string[],
+): Promise<void> {
+  const result = await createSharedPortfolio(referenceIds)
+  if (!result.success) {
+    toast.error(result.error ?? 'Kollektions-Link konnte nicht erstellt werden.')
+    return
+  }
+  await navigator.clipboard.writeText(toAbsoluteShareUrl(result.url))
+  toast.success('Kollektions-Link erstellt und kopiert.')
+}

--- a/app/dashboard/overview/use-reference-detail-sheet.ts
+++ b/app/dashboard/overview/use-reference-detail-sheet.ts
@@ -1,0 +1,49 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+
+import type { ReferenceAssetRow, ReferenceRow } from '@/app/dashboard/actions'
+import { getReferenceAssets } from '@/app/dashboard/actions'
+
+export function useReferenceDetailSheet() {
+  const [selectedRef, setSelectedRef] = useState<ReferenceRow | null>(null)
+  const [sheetOpen, setSheetOpen] = useState(false)
+  const [detailAssets, setDetailAssets] = useState<ReferenceAssetRow[]>([])
+  const [detailAssetsLoading, setDetailAssetsLoading] = useState(false)
+
+  const handleReferenceSheetOpenChange = useCallback((open: boolean) => {
+    setSheetOpen(open)
+    if (!open) {
+      setDetailAssets([])
+      setDetailAssetsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!selectedRef?.id || !sheetOpen) return
+    let cancelled = false
+    void (async () => {
+      setDetailAssetsLoading(true)
+      try {
+        const assets = await getReferenceAssets(selectedRef.id)
+        if (!cancelled) setDetailAssets(assets)
+      } finally {
+        if (!cancelled) setDetailAssetsLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [selectedRef?.id, sheetOpen])
+
+  return {
+    selectedRef,
+    setSelectedRef,
+    sheetOpen,
+    setSheetOpen,
+    detailAssets,
+    setDetailAssets,
+    detailAssetsLoading,
+    handleReferenceSheetOpenChange,
+  }
+}

--- a/app/dashboard/overview/use-reference-overview-columns.ts
+++ b/app/dashboard/overview/use-reference-overview-columns.ts
@@ -1,0 +1,93 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import { clampColumnWidth, saveColumnWidthsToStorage } from '@/lib/table-column-sizing'
+
+import {
+  COLUMN_KEYS,
+  COLUMN_ORDER_STORAGE_KEY,
+  COLUMN_SIZING_STORAGE_KEY,
+  COLUMN_VISIBLE_STORAGE_KEY,
+  DEFAULT_VISIBLE,
+  loadColumnOrderFromStorage,
+  loadReferenceColumnWidthsFromStorage,
+  loadVisibleColumnsFromStorage,
+} from './reference-overview-columns'
+import type { ReferenceColumnKey } from './reference-table-column-types'
+
+export function useReferenceOverviewColumns() {
+  const [visibleColumns, setVisibleColumns] = useState<
+    Record<(typeof COLUMN_KEYS)[number], boolean>
+  >(loadVisibleColumnsFromStorage)
+  const [columnOrder, setColumnOrder] = useState<ReferenceColumnKey[]>(() =>
+    loadColumnOrderFromStorage(),
+  )
+  const [columnWidths, setColumnWidths] = useState<Record<ReferenceColumnKey, number>>(
+    () => loadReferenceColumnWidthsFromStorage(),
+  )
+  const [dragOverColumn, setDragOverColumn] = useState<string | null>(null)
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(COLUMN_ORDER_STORAGE_KEY, JSON.stringify(columnOrder))
+    } catch {
+      /* ignore */
+    }
+  }, [columnOrder])
+
+  useEffect(() => {
+    saveColumnWidthsToStorage(COLUMN_SIZING_STORAGE_KEY, columnWidths)
+  }, [columnWidths])
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(COLUMN_VISIBLE_STORAGE_KEY, JSON.stringify(visibleColumns))
+    } catch {
+      /* ignore */
+    }
+  }, [visibleColumns])
+
+  const handleColumnWidthChange = useCallback(
+    (column: ReferenceColumnKey, width: number) => {
+      setColumnWidths((prev) => ({
+        ...prev,
+        [column]: clampColumnWidth(width),
+      }))
+    },
+    [],
+  )
+
+  const resetVisibleColumns = useCallback(() => {
+    setVisibleColumns({ ...DEFAULT_VISIBLE })
+  }, [])
+
+  const orderedVisibleColumnKeys = useMemo(
+    () => columnOrder.filter((k) => visibleColumns[k]),
+    [columnOrder, visibleColumns],
+  )
+
+  const moveColumnOrder = useCallback((from: string, to: string) => {
+    if (from === to) return
+    setColumnOrder((prev) => {
+      const next = prev.filter((k) => k !== from)
+      const insertAt = next.indexOf(to as ReferenceColumnKey)
+      if (insertAt === -1) return prev
+      next.splice(insertAt, 0, from as ReferenceColumnKey)
+      return next
+    })
+  }, [])
+
+  return {
+    visibleColumns,
+    setVisibleColumns,
+    columnOrder,
+    columnWidths,
+    dragOverColumn,
+    setDragOverColumn,
+    handleColumnWidthChange,
+    resetVisibleColumns,
+    orderedVisibleColumnKeys,
+    moveColumnOrder,
+  }
+}

--- a/docs/tech-debt-offen-backlog.md
+++ b/docs/tech-debt-offen-backlog.md
@@ -28,7 +28,7 @@
 | **2** | E7 Schema-Sync | ✅ T1–T4 | Types bei Migrationen regenerieren (`db:types`) | XS ongoing | bei Schema-Change |
 | **3** | Typed-Supabase Cast-Abbau | ✅ T1–T4 | Rest-Casts nur Boundaries (HTTP/RPC/Json); Boy-Scout bei Touch | — | CI: `typecheck` vor Build |
 | **4** | P1-6 Accounts Naming | ✅ App/Lib | DB-Tabelle `companies` / `company_id` / Firmennamen-Helfer **bewusst offen** | — | nicht anfassen ohne Produktentscheid |
-| **5** | God-File-Nacharbeit | Slice 1–3 ✅ | Detail-Sheet, Readiness-Actions, `sharing.ts` → create/manage/queries/helpers | M ongoing | nächster: overview / watchlist |
+| **5** | God-File-Nacharbeit | Slice 1–4 ✅ | Detail-Sheet, Readiness-Actions, `sharing.ts`, overview-Hooks (Spalten/Sheet/Share) | M ongoing | nächster: watchlist / Filter-State |
 | **6** | `{ ok }` → `{ success }` | Lib ✅ | Slices 1–4; Rest nur Cron/Push-HTTP-Body | XS | Cron/Push separat wenn Monitoring-Clients ok |
 | **7** | P3-3 DE/EN-Dateinamen | ✅ Slice | `ai-draft-*`, `customer-control-link-email`; API `/api/ai-draft` + Redirect; UI-Copy „Sperrlink“/Event `ki_entwurf_generated` bleiben | — | Rest nur bei Touch |
 | **8** | `references`/`evidence` Pfade | ✅ | App = `references` (Routen/Ordner/`ROUTES`); Redirects `/dashboard/evidence` bleiben; `evidence_events` bleibt | — | Rest-`evidence` nur Domänenbegriff (RFP-Belege) |


### PR DESCRIPTION
## Summary
- Extract `useReferenceOverviewColumns`, `useReferenceDetailSheet`, and share-link helpers from `dashboard-overview.tsx` (~734 → ~627 lines)
- Keep behavior identical (localStorage columns, sheet asset load, single/collection share copy)
- Update tech-debt backlog: God-File slices 1–4 done; next watchlist/filter-state

## Test plan
- [ ] Dashboard overview table: column visibility/order/resize persist after reload
- [ ] Open reference detail sheet: assets load; close clears assets
- [ ] Row share: copy customer link (existing + new)
- [ ] Bulk bar: create & copy collection share link
- [ ] Favorites toggle still optimistic + toast


Made with [Cursor](https://cursor.com)