### PR TITLE
refactor(#5): split compliance bulk upload dialog (slice 6)

### DIFF
--- a/app/dashboard/overview/compliance-bulk-groups-panel.tsx
+++ b/app/dashboard/overview/compliance-bulk-groups-panel.tsx
@@ -1,0 +1,191 @@
+'use client'
+
+import { RefreshCw } from 'lucide-react'
+import { Cancel01Icon, FileText } from '@hugeicons/core-free-icons'
+import type { DragEvent } from 'react'
+
+import { ComplianceDocumentTypeCombobox } from '@/app/dashboard/overview/compliance-document-type-combobox'
+import { AppIcon } from '@/lib/icons'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Input } from '@/components/ui/input'
+import type { ComplianceDocumentTypeOption } from '@/lib/compliance/document-types'
+import { cn } from '@/lib/utils'
+
+import {
+  HEADER_CLASS,
+  ROW_GRID_CLASS,
+  type BulkFileItem,
+  type BulkGroup,
+} from './compliance-bulk-upload-types'
+
+export function ComplianceBulkGroupsPanel({
+  groups,
+  typeOptions,
+  setTypeOptions,
+  selectedGroupIds,
+  dragOverGroupId,
+  setDragOverGroupId,
+  draggingFileKey,
+  setDraggingFileKey,
+  saving,
+  typesLoading,
+  toggleGroupSelection,
+  updateGroupTitle,
+  handleDocumentTypeChange,
+  removeFile,
+  fileChipKey,
+  handleFileChipDragStart,
+  handleDocumentsDrop,
+  onManageTypesClick,
+}: {
+  groups: BulkGroup[]
+  typeOptions: ComplianceDocumentTypeOption[]
+  setTypeOptions: (options: ComplianceDocumentTypeOption[]) => void
+  selectedGroupIds: Set<string>
+  dragOverGroupId: string | null
+  setDragOverGroupId: (
+    value: string | null | ((prev: string | null) => string | null),
+  ) => void
+  draggingFileKey: string | null
+  setDraggingFileKey: (value: string | null) => void
+  saving: boolean
+  typesLoading: boolean
+  toggleGroupSelection: (groupId: string, checked: boolean) => void
+  updateGroupTitle: (groupId: string, title: string) => void
+  handleDocumentTypeChange: (groupId: string, slug: string) => void
+  removeFile: (groupId: string, fileIndex: number) => void
+  fileChipKey: (groupId: string, item: BulkFileItem) => string
+  handleFileChipDragStart: (
+    event: DragEvent<HTMLDivElement>,
+    groupId: string,
+    fileIndex: number,
+    chipKey: string,
+  ) => void
+  handleDocumentsDrop: (event: DragEvent<HTMLDivElement>, toGroupId: string) => void
+  onManageTypesClick: () => void
+}) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-border bg-white">
+      <div className="flex shrink-0 gap-3 border-b border-border bg-white px-3 py-2">
+        <div className="size-4 shrink-0" aria-hidden />
+        <div className={cn(ROW_GRID_CLASS, HEADER_CLASS)}>
+          <span>Zertifikatstyp</span>
+          <span>Titel</span>
+          <span>Dokumente</span>
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto bg-white">
+        {groups.map((group) => {
+          const previewPending = group.files.some((f) => f.extracting)
+          return (
+            <div
+              key={group.id}
+              className="flex items-center gap-3 border-b border-border bg-white px-3 py-2.5 last:border-b-0"
+            >
+              <Checkbox
+                className="self-center"
+                checked={selectedGroupIds.has(group.id)}
+                disabled={saving}
+                onCheckedChange={(checked) =>
+                  toggleGroupSelection(group.id, checked === true)
+                }
+                aria-label={`${group.title || 'Zertifikat'} auswählen`}
+              />
+
+              <div className={ROW_GRID_CLASS}>
+                <div className="min-w-0">
+                  <ComplianceDocumentTypeCombobox
+                    options={typeOptions}
+                    value={group.documentType}
+                    onValueChange={(slug) => handleDocumentTypeChange(group.id, slug)}
+                    onOptionsChange={setTypeOptions}
+                    disabled={saving || previewPending || typesLoading}
+                    onManageTypesClick={onManageTypesClick}
+                  />
+                </div>
+
+                <div className="flex min-w-0 flex-1 items-center gap-1.5">
+                  <Input
+                    value={group.title}
+                    onChange={(e) => updateGroupTitle(group.id, e.target.value)}
+                    disabled={saving || previewPending}
+                    className="h-8 min-w-0 flex-1 text-sm"
+                    placeholder="Titel"
+                    aria-label="Zertifikatstitel"
+                  />
+                  {previewPending ? (
+                    <RefreshCw
+                      className="size-4 shrink-0 animate-spin text-muted-foreground"
+                      aria-hidden
+                    />
+                  ) : null}
+                </div>
+
+                <div
+                  className={cn(
+                    'flex min-h-9 min-w-0 flex-wrap gap-1.5 rounded-md transition-colors lg:justify-end',
+                    dragOverGroupId === group.id &&
+                      'bg-primary/10 ring-1 ring-inset ring-primary/40',
+                  )}
+                  onDragOver={(event) => {
+                    event.preventDefault()
+                    event.stopPropagation()
+                    event.dataTransfer.dropEffect = 'move'
+                    setDragOverGroupId(group.id)
+                  }}
+                  onDragLeave={(event) => {
+                    if (!event.currentTarget.contains(event.relatedTarget as Node)) {
+                      setDragOverGroupId((prev) => (prev === group.id ? null : prev))
+                    }
+                  }}
+                  onDrop={(event) => handleDocumentsDrop(event, group.id)}
+                >
+                  {group.files.map((item, fileIndex) => {
+                    const chipKey = fileChipKey(group.id, item)
+                    return (
+                      <div
+                        key={chipKey}
+                        draggable={!saving}
+                        onDragStart={(event) =>
+                          handleFileChipDragStart(event, group.id, fileIndex, chipKey)
+                        }
+                        onDragEnd={() => {
+                          setDraggingFileKey(null)
+                          setDragOverGroupId(null)
+                        }}
+                        className={cn(
+                          'flex max-w-full cursor-grab items-center gap-1 rounded-md border border-border bg-background px-2 py-1 text-xs shadow-sm active:cursor-grabbing',
+                          draggingFileKey === chipKey && 'opacity-50',
+                        )}
+                      >
+                        <AppIcon
+                          icon={FileText}
+                          size={12}
+                          className="shrink-0 text-muted-foreground"
+                        />
+                        <span className="max-w-[100px] truncate sm:max-w-[120px]">
+                          {item.file.name}
+                        </span>
+                        <button
+                          type="button"
+                          disabled={saving}
+                          onClick={() => removeFile(group.id, fileIndex)}
+                          onMouseDown={(event) => event.stopPropagation()}
+                          className="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                          aria-label={`${item.file.name} entfernen`}
+                        >
+                          <AppIcon icon={Cancel01Icon} size={12} />
+                        </button>
+                      </div>
+                    )
+                  })}
+                </div>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/overview/compliance-bulk-upload-dialog.tsx
+++ b/app/dashboard/overview/compliance-bulk-upload-dialog.tsx
@@ -1,23 +1,7 @@
 'use client'
 
-import { useCallback, useMemo, useState } from 'react'
-import { Loader2, RefreshCw } from 'lucide-react'
-import { Cancel01Icon, FileText, Loader } from '@hugeicons/core-free-icons'
-import { useRouter } from 'next/navigation'
-import { toast } from 'sonner'
-import { log } from '@/lib/observability/logger'
-
-import {
-  extractComplianceCertificateMetadataFromPdf,
-  uploadComplianceDocumentsBatch,
-} from '@/app/dashboard/settings/compliance-actions'
-import { listComplianceDocumentTypeOptions } from '@/app/dashboard/settings/compliance-document-type-actions'
-import { ComplianceDocumentTypeCombobox } from '@/app/dashboard/overview/compliance-document-type-combobox'
 import { ComplianceDocumentTypesDialog } from '@/app/dashboard/overview/compliance-document-types-dialog'
 import { ComplianceMultiPdfDropzone } from '@/app/dashboard/overview/compliance-multi-pdf-dropzone'
-import { AppIcon } from '@/lib/icons'
-import { Button } from '@/components/ui/button'
-import { Checkbox } from '@/components/ui/checkbox'
 import {
   Dialog,
   DialogContent,
@@ -25,445 +9,33 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import { Input } from '@/components/ui/input'
-import {
-  getSystemComplianceDocumentTypes,
-  type ComplianceDocumentTypeOption,
-} from '@/lib/compliance/document-types'
-import { inferComplianceDocumentTypeFromUpload } from '@/lib/compliance/document-icon'
-import { buildDefaultComplianceTitle } from '@/lib/compliance/upload-filename'
 import { cn } from '@/lib/utils'
 
-const DIALOG_CLASS =
-  'flex max-h-[min(90vh,920px)] w-[calc(100vw-2rem)] max-w-[90vw] flex-col gap-0 overflow-hidden border-0 p-0 sm:max-w-[90vw] lg:max-w-7xl'
+import { ComplianceBulkGroupsPanel } from './compliance-bulk-groups-panel'
+import { ComplianceBulkUploadFooter } from './compliance-bulk-upload-footer'
+import { DIALOG_CLASS } from './compliance-bulk-upload-types'
+import { useComplianceBulkUpload } from './use-compliance-bulk-upload'
 
-const ROW_GRID_CLASS =
-  'grid flex-1 grid-cols-1 gap-2 lg:grid-cols-[minmax(160px,240px)_minmax(0,1fr)_minmax(180px,34%)] lg:items-center lg:gap-4'
-
-const HEADER_CLASS = 'text-xs font-medium text-muted-foreground'
-
-const FILE_DRAG_MIME = 'application/x-refstack-compliance-bulk-file'
-
-type BulkFileItem = {
-  id: string
-  file: File
-  validUntil: string
-  validUntilManuallyEdited: boolean
-  extracting: boolean
-  expiryAutoFilled: boolean
-}
-
-type BulkGroup = {
-  id: string
-  documentType: string
-  title: string
-  titleManuallyEdited: boolean
-  typeManuallyEdited: boolean
-  typeAutoFilled: boolean
-  files: BulkFileItem[]
-}
-
-type Props = {
+export function ComplianceBulkUploadDialog({
+  open,
+  onOpenChange,
+}: {
   open: boolean
   onOpenChange: (open: boolean) => void
-}
-
-function createFileItem(file: File): BulkFileItem {
-  return {
-    id: crypto.randomUUID(),
-    file,
-    validUntil: '',
-    validUntilManuallyEdited: false,
-    extracting: true,
-    expiryAutoFilled: false,
-  }
-}
-
-function createGroupForFile(
-  file: File,
-  typeOptions: ComplianceDocumentTypeOption[],
-): BulkGroup {
-  const inferredType =
-    inferComplianceDocumentTypeFromUpload({ title: '', fileName: file.name }) ??
-    'iso_27001'
-  return {
-    id: crypto.randomUUID(),
-    documentType: inferredType,
-    title: buildDefaultComplianceTitle(inferredType, typeOptions),
-    titleManuallyEdited: false,
-    typeManuallyEdited: false,
-    typeAutoFilled: Boolean(inferredType),
-    files: [createFileItem(file)],
-  }
-}
-
-function autoGroupByDocumentType(incoming: BulkGroup[]): BulkGroup[] {
-  const byType = new Map<string, BulkGroup>()
-
-  for (const group of incoming) {
-    const key = group.documentType
-    const existing = byType.get(key)
-    if (!existing) {
-      byType.set(key, { ...group, files: [...group.files] })
-      continue
-    }
-    byType.set(key, {
-      ...existing,
-      files: [...existing.files, ...group.files],
-      typeAutoFilled: existing.typeAutoFilled || group.typeAutoFilled,
-      title: existing.titleManuallyEdited
-        ? existing.title
-        : existing.title || group.title,
-      titleManuallyEdited: existing.titleManuallyEdited,
-      typeManuallyEdited: existing.typeManuallyEdited || group.typeManuallyEdited,
-    })
-  }
-
-  return Array.from(byType.values())
-}
-
-export function ComplianceBulkUploadDialog({ open, onOpenChange }: Props) {
-  const router = useRouter()
-  const [groups, setGroups] = useState<BulkGroup[]>([])
-  const [typeOptions, setTypeOptions] = useState<ComplianceDocumentTypeOption[]>(() =>
-    getSystemComplianceDocumentTypes(),
-  )
-  const [typesLoading, setTypesLoading] = useState(false)
-  const [typesDialogOpen, setTypesDialogOpen] = useState(false)
-  const [saving, setSaving] = useState(false)
-  const [selectedGroupIds, setSelectedGroupIds] = useState<Set<string>>(() => new Set())
-  const [dragOverGroupId, setDragOverGroupId] = useState<string | null>(null)
-  const [draggingFileKey, setDraggingFileKey] = useState<string | null>(null)
-
-  const totalFiles = useMemo(
-    () => groups.reduce((sum, group) => sum + group.files.length, 0),
-    [groups],
-  )
-  const hasFiles = groups.length > 0
-  const canMergeSelected = selectedGroupIds.size >= 2
-  const anyExtracting = groups.some((group) =>
-    group.files.some((file) => file.extracting),
-  )
-
-  const loadTypes = useCallback(async () => {
-    setTypesLoading(true)
-    const result = await listComplianceDocumentTypeOptions()
-    setTypesLoading(false)
-    if (!result.success) {
-      toast.error(result.error)
-      return
-    }
-    setTypeOptions(result.types)
-  }, [])
-
-  const groupIdsKey = groups.map((g) => g.id).join(',')
-  const [prevGroupIdsKey, setPrevGroupIdsKey] = useState(groupIdsKey)
-  if (groupIdsKey !== prevGroupIdsKey) {
-    setPrevGroupIdsKey(groupIdsKey)
-    const valid = new Set(groups.map((g) => g.id))
-    const next = new Set([...selectedGroupIds].filter((id) => valid.has(id)))
-    if (next.size !== selectedGroupIds.size) {
-      setSelectedGroupIds(next)
-    }
-  }
-
-  function reset() {
-    setGroups([])
-    setTypeOptions(getSystemComplianceDocumentTypes())
-    setSelectedGroupIds(new Set())
-    setDragOverGroupId(null)
-    setDraggingFileKey(null)
-  }
-
-  async function enrichAfterAdd(
-    fileId: string,
-    file: File,
-    options: ComplianceDocumentTypeOption[],
-  ) {
-    const formData = new FormData()
-    formData.set('file', file)
-    const result = await extractComplianceCertificateMetadataFromPdf(formData)
-
-    setGroups((prev) => {
-      const hostIndex = prev.findIndex((g) => g.files.some((f) => f.id === fileId))
-      if (hostIndex < 0) return prev
-
-      const host = prev[hostIndex]!
-      const updatedFiles = host.files.map((item) => {
-        if (item.id !== fileId) return item
-        let next = { ...item, extracting: false }
-        if (!result.success) return next
-        if (
-          !item.validUntilManuallyEdited &&
-          result.validUntil &&
-          result.expiryConfidence !== 'none'
-        ) {
-          next = {
-            ...next,
-            validUntil: result.validUntil,
-            expiryAutoFilled: true,
-          }
-        }
-        return next
-      })
-
-      let updatedHost: BulkGroup = { ...host, files: updatedFiles }
-
-      if (
-        !host.typeManuallyEdited &&
-        result.success &&
-        result.documentType &&
-        updatedFiles.length === 1
-      ) {
-        updatedHost = {
-          ...updatedHost,
-          documentType: result.documentType,
-          typeAutoFilled: true,
-          title: host.titleManuallyEdited
-            ? host.title
-            : buildDefaultComplianceTitle(result.documentType, options),
-        }
-      }
-
-      const without = prev.filter((_, i) => i !== hostIndex)
-      return autoGroupByDocumentType([...without, updatedHost])
-    })
-  }
-
-  function addFiles(files: File[]) {
-    const prepared = files.map((file) => createGroupForFile(file, typeOptions))
-    const fileItems = prepared.flatMap((g) => g.files)
-
-    setGroups((prev) => {
-      const beforeCount = prev.length + prepared.length
-      const next = autoGroupByDocumentType([...prev, ...prepared])
-      if (beforeCount > next.length) {
-        const autoGroupedCount = next
-          .filter((g) => g.files.length > 1)
-          .reduce((s, g) => s + g.files.length, 0)
-        if (autoGroupedCount > 0) {
-          toast.info(
-            `${autoGroupedCount} Dateien wurden automatisch nach Zertifikatstyp gruppiert.`,
-          )
-        }
-      }
-      return next
-    })
-
-    for (const item of fileItems) {
-      void enrichAfterAdd(item.id, item.file, typeOptions)
-    }
-  }
-
-  function toggleGroupSelection(groupId: string, checked: boolean) {
-    setSelectedGroupIds((prev) => {
-      const next = new Set(prev)
-      if (checked) next.add(groupId)
-      else next.delete(groupId)
-      return next
-    })
-  }
-
-  function updateGroupTitle(groupId: string, title: string) {
-    setGroups((prev) =>
-      prev.map((g) =>
-        g.id === groupId ? { ...g, title, titleManuallyEdited: true } : g,
-      ),
-    )
-  }
-
-  function handleDocumentTypeChange(groupId: string, slug: string) {
-    setGroups((prev) => {
-      const host = prev.find((g) => g.id === groupId)
-      if (!host) return prev
-      const updated: BulkGroup = {
-        ...host,
-        documentType: slug,
-        typeManuallyEdited: true,
-        typeAutoFilled: false,
-        title: host.titleManuallyEdited
-          ? host.title
-          : buildDefaultComplianceTitle(slug, typeOptions),
-      }
-      const without = prev.filter((g) => g.id !== groupId)
-      return autoGroupByDocumentType([...without, updated])
-    })
-  }
-
-  function removeFile(groupId: string, fileIndex: number) {
-    setGroups((prev) =>
-      prev
-        .map((g) =>
-          g.id === groupId
-            ? { ...g, files: g.files.filter((_, i) => i !== fileIndex) }
-            : g,
-        )
-        .filter((g) => g.files.length > 0),
-    )
-  }
-
-  function moveFile(fromGroupId: string, fileIndex: number, toGroupId: string) {
-    if (fromGroupId === toGroupId) return
-    setGroups((prev) => {
-      const source = prev.find((g) => g.id === fromGroupId)
-      const target = prev.find((g) => g.id === toGroupId)
-      const fileItem = source?.files[fileIndex]
-      if (!source || !target || !fileItem) return prev
-
-      return prev
-        .map((g) => {
-          if (g.id === fromGroupId) {
-            return { ...g, files: g.files.filter((_, i) => i !== fileIndex) }
-          }
-          if (g.id === toGroupId) {
-            return { ...g, files: [...g.files, fileItem] }
-          }
-          return g
-        })
-        .filter((g) => g.files.length > 0)
-    })
-  }
-
-  function mergeSelectedGroups(selectedIds: string[]) {
-    if (selectedIds.length < 2) return
-    setGroups((prev) => {
-      const idSet = new Set(selectedIds)
-      const selected = prev.filter((g) => idSet.has(g.id))
-      if (selected.length < 2) return prev
-      const rest = prev.filter((g) => !idSet.has(g.id))
-      const primary = selected[0]!
-      return [
-        ...rest,
-        {
-          ...primary,
-          files: selected.flatMap((g) => g.files),
-        },
-      ]
-    })
-  }
-
-  function fileChipKey(groupId: string, item: BulkFileItem) {
-    return `${groupId}:${item.id}`
-  }
-
-  function handleFileChipDragStart(
-    event: React.DragEvent<HTMLDivElement>,
-    groupId: string,
-    fileIndex: number,
-    chipKey: string,
-  ) {
-    if (saving) {
-      event.preventDefault()
-      return
-    }
-    event.dataTransfer.setData(
-      FILE_DRAG_MIME,
-      JSON.stringify({ fromGroupId: groupId, fileIndex }),
-    )
-    event.dataTransfer.effectAllowed = 'move'
-    setDraggingFileKey(chipKey)
-  }
-
-  function handleDocumentsDrop(
-    event: React.DragEvent<HTMLDivElement>,
-    toGroupId: string,
-  ) {
-    event.preventDefault()
-    event.stopPropagation()
-    setDragOverGroupId(null)
-    setDraggingFileKey(null)
-    try {
-      const raw = event.dataTransfer.getData(FILE_DRAG_MIME)
-      if (!raw) return
-      const payload = JSON.parse(raw) as { fromGroupId: string; fileIndex: number }
-      if (!payload.fromGroupId || typeof payload.fileIndex !== 'number') return
-      moveFile(payload.fromGroupId, payload.fileIndex, toGroupId)
-    } catch {
-      // ignore
-    }
-  }
-
-  async function handleSubmit() {
-    if (!totalFiles) {
-      toast.error('Bitte mindestens eine PDF-Datei auswählen.')
-      return
-    }
-    if (anyExtracting) {
-      toast.error('Bitte warten, bis alle PDFs analysiert wurden.')
-      return
-    }
-
-    const flat = groups.flatMap((group) =>
-      group.files.map((item, indexInGroup) => ({
-        title:
-          group.files.length === 1
-            ? group.title.trim()
-            : `${group.title.trim()} (${indexInGroup + 1})`,
-        documentType: group.documentType,
-        validUntil: item.validUntil.trim() || null,
-        file: item.file,
-      })),
-    )
-
-    const invalid = flat.find((row) => !row.title.trim())
-    if (invalid) {
-      toast.error('Jedes Zertifikat braucht einen Titel.')
-      return
-    }
-
-    setSaving(true)
-    const formData = new FormData()
-    formData.set(
-      'manifest',
-      JSON.stringify(
-        flat.map((row, index) => ({
-          title: row.title,
-          documentType: row.documentType,
-          validUntil: row.validUntil,
-          fileIndex: index,
-        })),
-      ),
-    )
-    flat.forEach((row, index) => {
-      formData.set(`file_${index}`, row.file)
-    })
-
-    const result = await uploadComplianceDocumentsBatch(formData)
-    setSaving(false)
-
-    if (!result.success) {
-      toast.error(result.error)
-      return
-    }
-
-    if (result.errors.length > 0) {
-      toast.error(`${result.uploaded} gespeichert, ${result.errors.length} Fehler.`)
-      log.error('complianceBulkUpload.partialErrors', {
-        uploaded: result.uploaded,
-        errors: result.errors,
-      })
-    } else {
-      toast.success(
-        `${result.uploaded} Zertifikat${result.uploaded !== 1 ? 'e' : ''} gespeichert.`,
-      )
-    }
-
-    reset()
-    onOpenChange(false)
-    router.refresh()
-  }
+}) {
+  const state = useComplianceBulkUpload(onOpenChange)
 
   return (
     <>
       <Dialog
         open={open}
         onOpenChange={(next) => {
-          if (next) void loadTypes()
-          else reset()
+          if (next) void state.loadTypes()
+          else state.reset()
           onOpenChange(next)
         }}
       >
-        <DialogContent className={DIALOG_CLASS} showCloseButton={!saving}>
+        <DialogContent className={DIALOG_CLASS} showCloseButton={!state.saving}>
           <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-6 py-4 md:px-10 md:py-5">
             <DialogHeader className="shrink-0 space-y-1 text-left">
               <DialogTitle>Zertifikate importieren</DialogTitle>
@@ -475,230 +47,59 @@ export function ComplianceBulkUploadDialog({ open, onOpenChange }: Props) {
             <div
               className={cn(
                 'min-h-0 flex-1 pt-3',
-                hasFiles ? 'flex flex-col overflow-hidden' : 'overflow-y-auto',
+                state.hasFiles ? 'flex flex-col overflow-hidden' : 'overflow-y-auto',
               )}
             >
-              {!hasFiles ? (
+              {!state.hasFiles ? (
                 <ComplianceMultiPdfDropzone
-                  onFilesSelected={addFiles}
-                  disabled={saving || typesLoading}
+                  onFilesSelected={state.addFiles}
+                  disabled={state.saving || state.typesLoading}
                 />
               ) : (
-                <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-border bg-white">
-                  <div className="flex shrink-0 gap-3 border-b border-border bg-white px-3 py-2">
-                    <div className="size-4 shrink-0" aria-hidden />
-                    <div className={cn(ROW_GRID_CLASS, HEADER_CLASS)}>
-                      <span>Zertifikatstyp</span>
-                      <span>Titel</span>
-                      <span>Dokumente</span>
-                    </div>
-                  </div>
-
-                  <div className="min-h-0 flex-1 overflow-y-auto bg-white">
-                    {groups.map((group) => {
-                      const previewPending = group.files.some((f) => f.extracting)
-                      return (
-                        <div
-                          key={group.id}
-                          className="flex items-center gap-3 border-b border-border bg-white px-3 py-2.5 last:border-b-0"
-                        >
-                          <Checkbox
-                            className="self-center"
-                            checked={selectedGroupIds.has(group.id)}
-                            disabled={saving}
-                            onCheckedChange={(checked) =>
-                              toggleGroupSelection(group.id, checked === true)
-                            }
-                            aria-label={`${group.title || 'Zertifikat'} auswählen`}
-                          />
-
-                          <div className={ROW_GRID_CLASS}>
-                            <div className="min-w-0">
-                              <ComplianceDocumentTypeCombobox
-                                options={typeOptions}
-                                value={group.documentType}
-                                onValueChange={(slug) =>
-                                  handleDocumentTypeChange(group.id, slug)
-                                }
-                                onOptionsChange={setTypeOptions}
-                                disabled={saving || previewPending || typesLoading}
-                                onManageTypesClick={() => setTypesDialogOpen(true)}
-                              />
-                            </div>
-
-                            <div className="flex min-w-0 flex-1 items-center gap-1.5">
-                              <Input
-                                value={group.title}
-                                onChange={(e) =>
-                                  updateGroupTitle(group.id, e.target.value)
-                                }
-                                disabled={saving || previewPending}
-                                className="h-8 min-w-0 flex-1 text-sm"
-                                placeholder="Titel"
-                                aria-label="Zertifikatstitel"
-                              />
-                              {previewPending ? (
-                                <RefreshCw
-                                  className="size-4 shrink-0 animate-spin text-muted-foreground"
-                                  aria-hidden
-                                />
-                              ) : null}
-                            </div>
-
-                            <div
-                              className={cn(
-                                'flex min-h-9 min-w-0 flex-wrap gap-1.5 rounded-md transition-colors lg:justify-end',
-                                dragOverGroupId === group.id &&
-                                  'bg-primary/10 ring-1 ring-inset ring-primary/40',
-                              )}
-                              onDragOver={(event) => {
-                                event.preventDefault()
-                                event.stopPropagation()
-                                event.dataTransfer.dropEffect = 'move'
-                                setDragOverGroupId(group.id)
-                              }}
-                              onDragLeave={(event) => {
-                                if (
-                                  !event.currentTarget.contains(
-                                    event.relatedTarget as Node,
-                                  )
-                                ) {
-                                  setDragOverGroupId((prev) =>
-                                    prev === group.id ? null : prev,
-                                  )
-                                }
-                              }}
-                              onDrop={(event) => handleDocumentsDrop(event, group.id)}
-                            >
-                              {group.files.map((item, fileIndex) => {
-                                const chipKey = fileChipKey(group.id, item)
-                                return (
-                                  <div
-                                    key={chipKey}
-                                    draggable={!saving}
-                                    onDragStart={(event) =>
-                                      handleFileChipDragStart(
-                                        event,
-                                        group.id,
-                                        fileIndex,
-                                        chipKey,
-                                      )
-                                    }
-                                    onDragEnd={() => {
-                                      setDraggingFileKey(null)
-                                      setDragOverGroupId(null)
-                                    }}
-                                    className={cn(
-                                      'flex max-w-full cursor-grab items-center gap-1 rounded-md border border-border bg-background px-2 py-1 text-xs shadow-sm active:cursor-grabbing',
-                                      draggingFileKey === chipKey && 'opacity-50',
-                                    )}
-                                  >
-                                    <AppIcon
-                                      icon={FileText}
-                                      size={12}
-                                      className="shrink-0 text-muted-foreground"
-                                    />
-                                    <span className="max-w-[100px] truncate sm:max-w-[120px]">
-                                      {item.file.name}
-                                    </span>
-                                    <button
-                                      type="button"
-                                      disabled={saving}
-                                      onClick={() => removeFile(group.id, fileIndex)}
-                                      onMouseDown={(event) => event.stopPropagation()}
-                                      className="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
-                                      aria-label={`${item.file.name} entfernen`}
-                                    >
-                                      <AppIcon icon={Cancel01Icon} size={12} />
-                                    </button>
-                                  </div>
-                                )
-                              })}
-                            </div>
-                          </div>
-                        </div>
-                      )
-                    })}
-                  </div>
-                </div>
+                <ComplianceBulkGroupsPanel
+                  groups={state.groups}
+                  typeOptions={state.typeOptions}
+                  setTypeOptions={state.setTypeOptions}
+                  selectedGroupIds={state.selectedGroupIds}
+                  dragOverGroupId={state.dragOverGroupId}
+                  setDragOverGroupId={state.setDragOverGroupId}
+                  draggingFileKey={state.draggingFileKey}
+                  setDraggingFileKey={state.setDraggingFileKey}
+                  saving={state.saving}
+                  typesLoading={state.typesLoading}
+                  toggleGroupSelection={state.toggleGroupSelection}
+                  updateGroupTitle={state.updateGroupTitle}
+                  handleDocumentTypeChange={state.handleDocumentTypeChange}
+                  removeFile={state.removeFile}
+                  fileChipKey={state.fileChipKey}
+                  handleFileChipDragStart={state.handleFileChipDragStart}
+                  handleDocumentsDrop={state.handleDocumentsDrop}
+                  onManageTypesClick={() => state.setTypesDialogOpen(true)}
+                />
               )}
             </div>
 
-            <div className="shrink-0 border-t border-border py-3">
-              <div className="flex items-center gap-3">
-                {hasFiles ? (
-                  <div className="min-w-0 flex-1">
-                    <ComplianceMultiPdfDropzone
-                      id="compliance-bulk-pdf-dropzone-more"
-                      compact
-                      onFilesSelected={addFiles}
-                      disabled={saving || typesLoading}
-                    />
-                  </div>
-                ) : (
-                  <div className="flex-1" aria-hidden />
-                )}
-
-                <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="toolbar"
-                    disabled={!canMergeSelected || saving}
-                    onClick={() => {
-                      mergeSelectedGroups(Array.from(selectedGroupIds))
-                      setSelectedGroupIds(new Set())
-                    }}
-                  >
-                    Ausgewählte gruppieren
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="toolbar"
-                    disabled={saving}
-                    onClick={() => onOpenChange(false)}
-                  >
-                    Abbrechen
-                  </Button>
-                  <Button
-                    type="button"
-                    size="toolbar"
-                    disabled={totalFiles === 0 || saving || anyExtracting}
-                    onClick={() => void handleSubmit()}
-                  >
-                    {saving ? (
-                      <>
-                        <AppIcon icon={Loader} size={16} className="mr-2 animate-spin" />
-                        Speichern…
-                      </>
-                    ) : anyExtracting ? (
-                      <>
-                        <Loader2 className="mr-2 size-4 animate-spin" aria-hidden />
-                        Analysiere…
-                      </>
-                    ) : (
-                      'Import starten'
-                    )}
-                  </Button>
-                </div>
-              </div>
-              {totalFiles > 0 ? (
-                <p className="mt-1.5 text-right text-xs text-muted-foreground">
-                  {groups.length} Typ{groups.length !== 1 ? 'en' : ''} · {totalFiles}{' '}
-                  Datei
-                  {totalFiles !== 1 ? 'en' : ''}
-                </p>
-              ) : null}
-            </div>
+            <ComplianceBulkUploadFooter
+              hasFiles={state.hasFiles}
+              totalFiles={state.totalFiles}
+              groupsCount={state.groups.length}
+              saving={state.saving}
+              typesLoading={state.typesLoading}
+              anyExtracting={state.anyExtracting}
+              canMergeSelected={state.canMergeSelected}
+              onAddFiles={state.addFiles}
+              onMergeSelected={state.mergeSelectedAndClear}
+              onCancel={() => onOpenChange(false)}
+              onSubmit={() => void state.handleSubmit()}
+            />
           </div>
         </DialogContent>
       </Dialog>
 
       <ComplianceDocumentTypesDialog
-        open={typesDialogOpen}
-        onOpenChange={setTypesDialogOpen}
-        onTypesChange={setTypeOptions}
+        open={state.typesDialogOpen}
+        onOpenChange={state.setTypesDialogOpen}
+        onTypesChange={state.setTypeOptions}
       />
     </>
   )

--- a/app/dashboard/overview/compliance-bulk-upload-footer.tsx
+++ b/app/dashboard/overview/compliance-bulk-upload-footer.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import { Loader2 } from 'lucide-react'
+import { Loader } from '@hugeicons/core-free-icons'
+
+import { ComplianceMultiPdfDropzone } from '@/app/dashboard/overview/compliance-multi-pdf-dropzone'
+import { AppIcon } from '@/lib/icons'
+import { Button } from '@/components/ui/button'
+
+export function ComplianceBulkUploadFooter({
+  hasFiles,
+  totalFiles,
+  groupsCount,
+  saving,
+  typesLoading,
+  anyExtracting,
+  canMergeSelected,
+  onAddFiles,
+  onMergeSelected,
+  onCancel,
+  onSubmit,
+}: {
+  hasFiles: boolean
+  totalFiles: number
+  groupsCount: number
+  saving: boolean
+  typesLoading: boolean
+  anyExtracting: boolean
+  canMergeSelected: boolean
+  onAddFiles: (files: File[]) => void
+  onMergeSelected: () => void
+  onCancel: () => void
+  onSubmit: () => void
+}) {
+  return (
+    <div className="shrink-0 border-t border-border py-3">
+      <div className="flex items-center gap-3">
+        {hasFiles ? (
+          <div className="min-w-0 flex-1">
+            <ComplianceMultiPdfDropzone
+              id="compliance-bulk-pdf-dropzone-more"
+              compact
+              onFilesSelected={onAddFiles}
+              disabled={saving || typesLoading}
+            />
+          </div>
+        ) : (
+          <div className="flex-1" aria-hidden />
+        )}
+
+        <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="toolbar"
+            disabled={!canMergeSelected || saving}
+            onClick={onMergeSelected}
+          >
+            Ausgewählte gruppieren
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="toolbar"
+            disabled={saving}
+            onClick={onCancel}
+          >
+            Abbrechen
+          </Button>
+          <Button
+            type="button"
+            size="toolbar"
+            disabled={totalFiles === 0 || saving || anyExtracting}
+            onClick={onSubmit}
+          >
+            {saving ? (
+              <>
+                <AppIcon icon={Loader} size={16} className="mr-2 animate-spin" />
+                Speichern…
+              </>
+            ) : anyExtracting ? (
+              <>
+                <Loader2 className="mr-2 size-4 animate-spin" aria-hidden />
+                Analysiere…
+              </>
+            ) : (
+              'Import starten'
+            )}
+          </Button>
+        </div>
+      </div>
+      {totalFiles > 0 ? (
+        <p className="mt-1.5 text-right text-xs text-muted-foreground">
+          {groupsCount} Typ{groupsCount !== 1 ? 'en' : ''} · {totalFiles} Datei
+          {totalFiles !== 1 ? 'en' : ''}
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/app/dashboard/overview/compliance-bulk-upload-helpers.ts
+++ b/app/dashboard/overview/compliance-bulk-upload-helpers.ts
@@ -1,0 +1,63 @@
+import type { ComplianceDocumentTypeOption } from '@/lib/compliance/document-types'
+import { inferComplianceDocumentTypeFromUpload } from '@/lib/compliance/document-icon'
+import { buildDefaultComplianceTitle } from '@/lib/compliance/upload-filename'
+
+import type { BulkFileItem, BulkGroup } from './compliance-bulk-upload-types'
+
+export function createFileItem(file: File): BulkFileItem {
+  return {
+    id: crypto.randomUUID(),
+    file,
+    validUntil: '',
+    validUntilManuallyEdited: false,
+    extracting: true,
+    expiryAutoFilled: false,
+  }
+}
+
+export function createGroupForFile(
+  file: File,
+  typeOptions: ComplianceDocumentTypeOption[],
+): BulkGroup {
+  const inferredType =
+    inferComplianceDocumentTypeFromUpload({ title: '', fileName: file.name }) ??
+    'iso_27001'
+  return {
+    id: crypto.randomUUID(),
+    documentType: inferredType,
+    title: buildDefaultComplianceTitle(inferredType, typeOptions),
+    titleManuallyEdited: false,
+    typeManuallyEdited: false,
+    typeAutoFilled: Boolean(inferredType),
+    files: [createFileItem(file)],
+  }
+}
+
+export function autoGroupByDocumentType(incoming: BulkGroup[]): BulkGroup[] {
+  const byType = new Map<string, BulkGroup>()
+
+  for (const group of incoming) {
+    const key = group.documentType
+    const existing = byType.get(key)
+    if (!existing) {
+      byType.set(key, { ...group, files: [...group.files] })
+      continue
+    }
+    byType.set(key, {
+      ...existing,
+      files: [...existing.files, ...group.files],
+      typeAutoFilled: existing.typeAutoFilled || group.typeAutoFilled,
+      title: existing.titleManuallyEdited
+        ? existing.title
+        : existing.title || group.title,
+      titleManuallyEdited: existing.titleManuallyEdited,
+      typeManuallyEdited: existing.typeManuallyEdited || group.typeManuallyEdited,
+    })
+  }
+
+  return Array.from(byType.values())
+}
+
+export function fileChipKey(groupId: string, item: BulkFileItem): string {
+  return `${groupId}:${item.id}`
+}

--- a/app/dashboard/overview/compliance-bulk-upload-types.ts
+++ b/app/dashboard/overview/compliance-bulk-upload-types.ts
@@ -1,0 +1,37 @@
+import type { ComplianceDocumentTypeOption } from '@/lib/compliance/document-types'
+
+export const DIALOG_CLASS =
+  'flex max-h-[min(90vh,920px)] w-[calc(100vw-2rem)] max-w-[90vw] flex-col gap-0 overflow-hidden border-0 p-0 sm:max-w-[90vw] lg:max-w-7xl'
+
+export const ROW_GRID_CLASS =
+  'grid flex-1 grid-cols-1 gap-2 lg:grid-cols-[minmax(160px,240px)_minmax(0,1fr)_minmax(180px,34%)] lg:items-center lg:gap-4'
+
+export const HEADER_CLASS = 'text-xs font-medium text-muted-foreground'
+
+export const FILE_DRAG_MIME = 'application/x-refstack-compliance-bulk-file'
+
+export type BulkFileItem = {
+  id: string
+  file: File
+  validUntil: string
+  validUntilManuallyEdited: boolean
+  extracting: boolean
+  expiryAutoFilled: boolean
+}
+
+export type BulkGroup = {
+  id: string
+  documentType: string
+  title: string
+  titleManuallyEdited: boolean
+  typeManuallyEdited: boolean
+  typeAutoFilled: boolean
+  files: BulkFileItem[]
+}
+
+export type ComplianceBulkUploadDialogProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export type { ComplianceDocumentTypeOption }

--- a/app/dashboard/overview/use-compliance-bulk-upload.ts
+++ b/app/dashboard/overview/use-compliance-bulk-upload.ts
@@ -1,0 +1,391 @@
+'use client'
+
+import { useCallback, useMemo, useState, type DragEvent } from 'react'
+import { useRouter } from 'next/navigation'
+import { toast } from 'sonner'
+import { log } from '@/lib/observability/logger'
+
+import {
+  extractComplianceCertificateMetadataFromPdf,
+  uploadComplianceDocumentsBatch,
+} from '@/app/dashboard/settings/compliance-actions'
+import { listComplianceDocumentTypeOptions } from '@/app/dashboard/settings/compliance-document-type-actions'
+import {
+  getSystemComplianceDocumentTypes,
+  type ComplianceDocumentTypeOption,
+} from '@/lib/compliance/document-types'
+import { buildDefaultComplianceTitle } from '@/lib/compliance/upload-filename'
+
+import {
+  autoGroupByDocumentType,
+  createGroupForFile,
+  fileChipKey,
+} from './compliance-bulk-upload-helpers'
+import {
+  FILE_DRAG_MIME,
+  type BulkFileItem,
+  type BulkGroup,
+} from './compliance-bulk-upload-types'
+
+export function useComplianceBulkUpload(onOpenChange: (open: boolean) => void) {
+  const router = useRouter()
+  const [groups, setGroups] = useState<BulkGroup[]>([])
+  const [typeOptions, setTypeOptions] = useState<ComplianceDocumentTypeOption[]>(() =>
+    getSystemComplianceDocumentTypes(),
+  )
+  const [typesLoading, setTypesLoading] = useState(false)
+  const [typesDialogOpen, setTypesDialogOpen] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [selectedGroupIds, setSelectedGroupIds] = useState<Set<string>>(() => new Set())
+  const [dragOverGroupId, setDragOverGroupId] = useState<string | null>(null)
+  const [draggingFileKey, setDraggingFileKey] = useState<string | null>(null)
+
+  const totalFiles = useMemo(
+    () => groups.reduce((sum, group) => sum + group.files.length, 0),
+    [groups],
+  )
+  const hasFiles = groups.length > 0
+  const canMergeSelected = selectedGroupIds.size >= 2
+  const anyExtracting = groups.some((group) =>
+    group.files.some((file) => file.extracting),
+  )
+
+  const loadTypes = useCallback(async () => {
+    setTypesLoading(true)
+    const result = await listComplianceDocumentTypeOptions()
+    setTypesLoading(false)
+    if (!result.success) {
+      toast.error(result.error)
+      return
+    }
+    setTypeOptions(result.types)
+  }, [])
+
+  const groupIdsKey = groups.map((g) => g.id).join(',')
+  const [prevGroupIdsKey, setPrevGroupIdsKey] = useState(groupIdsKey)
+  if (groupIdsKey !== prevGroupIdsKey) {
+    setPrevGroupIdsKey(groupIdsKey)
+    const valid = new Set(groups.map((g) => g.id))
+    const next = new Set([...selectedGroupIds].filter((id) => valid.has(id)))
+    if (next.size !== selectedGroupIds.size) {
+      setSelectedGroupIds(next)
+    }
+  }
+
+  function reset() {
+    setGroups([])
+    setTypeOptions(getSystemComplianceDocumentTypes())
+    setSelectedGroupIds(new Set())
+    setDragOverGroupId(null)
+    setDraggingFileKey(null)
+  }
+
+  async function enrichAfterAdd(
+    fileId: string,
+    file: File,
+    options: ComplianceDocumentTypeOption[],
+  ) {
+    const formData = new FormData()
+    formData.set('file', file)
+    const result = await extractComplianceCertificateMetadataFromPdf(formData)
+
+    setGroups((prev) => {
+      const hostIndex = prev.findIndex((g) => g.files.some((f) => f.id === fileId))
+      if (hostIndex < 0) return prev
+
+      const host = prev[hostIndex]!
+      const updatedFiles = host.files.map((item) => {
+        if (item.id !== fileId) return item
+        let next = { ...item, extracting: false }
+        if (!result.success) return next
+        if (
+          !item.validUntilManuallyEdited &&
+          result.validUntil &&
+          result.expiryConfidence !== 'none'
+        ) {
+          next = {
+            ...next,
+            validUntil: result.validUntil,
+            expiryAutoFilled: true,
+          }
+        }
+        return next
+      })
+
+      let updatedHost: BulkGroup = { ...host, files: updatedFiles }
+
+      if (
+        !host.typeManuallyEdited &&
+        result.success &&
+        result.documentType &&
+        updatedFiles.length === 1
+      ) {
+        updatedHost = {
+          ...updatedHost,
+          documentType: result.documentType,
+          typeAutoFilled: true,
+          title: host.titleManuallyEdited
+            ? host.title
+            : buildDefaultComplianceTitle(result.documentType, options),
+        }
+      }
+
+      const without = prev.filter((_, i) => i !== hostIndex)
+      return autoGroupByDocumentType([...without, updatedHost])
+    })
+  }
+
+  function addFiles(files: File[]) {
+    const prepared = files.map((file) => createGroupForFile(file, typeOptions))
+    const fileItems = prepared.flatMap((g) => g.files)
+
+    setGroups((prev) => {
+      const beforeCount = prev.length + prepared.length
+      const next = autoGroupByDocumentType([...prev, ...prepared])
+      if (beforeCount > next.length) {
+        const autoGroupedCount = next
+          .filter((g) => g.files.length > 1)
+          .reduce((s, g) => s + g.files.length, 0)
+        if (autoGroupedCount > 0) {
+          toast.info(
+            `${autoGroupedCount} Dateien wurden automatisch nach Zertifikatstyp gruppiert.`,
+          )
+        }
+      }
+      return next
+    })
+
+    for (const item of fileItems) {
+      void enrichAfterAdd(item.id, item.file, typeOptions)
+    }
+  }
+
+  function toggleGroupSelection(groupId: string, checked: boolean) {
+    setSelectedGroupIds((prev) => {
+      const next = new Set(prev)
+      if (checked) next.add(groupId)
+      else next.delete(groupId)
+      return next
+    })
+  }
+
+  function updateGroupTitle(groupId: string, title: string) {
+    setGroups((prev) =>
+      prev.map((g) =>
+        g.id === groupId ? { ...g, title, titleManuallyEdited: true } : g,
+      ),
+    )
+  }
+
+  function handleDocumentTypeChange(groupId: string, slug: string) {
+    setGroups((prev) => {
+      const host = prev.find((g) => g.id === groupId)
+      if (!host) return prev
+      const updated: BulkGroup = {
+        ...host,
+        documentType: slug,
+        typeManuallyEdited: true,
+        typeAutoFilled: false,
+        title: host.titleManuallyEdited
+          ? host.title
+          : buildDefaultComplianceTitle(slug, typeOptions),
+      }
+      const without = prev.filter((g) => g.id !== groupId)
+      return autoGroupByDocumentType([...without, updated])
+    })
+  }
+
+  function removeFile(groupId: string, fileIndex: number) {
+    setGroups((prev) =>
+      prev
+        .map((g) =>
+          g.id === groupId
+            ? { ...g, files: g.files.filter((_, i) => i !== fileIndex) }
+            : g,
+        )
+        .filter((g) => g.files.length > 0),
+    )
+  }
+
+  function moveFile(fromGroupId: string, fileIndex: number, toGroupId: string) {
+    if (fromGroupId === toGroupId) return
+    setGroups((prev) => {
+      const source = prev.find((g) => g.id === fromGroupId)
+      const target = prev.find((g) => g.id === toGroupId)
+      const fileItem = source?.files[fileIndex]
+      if (!source || !target || !fileItem) return prev
+
+      return prev
+        .map((g) => {
+          if (g.id === fromGroupId) {
+            return { ...g, files: g.files.filter((_, i) => i !== fileIndex) }
+          }
+          if (g.id === toGroupId) {
+            return { ...g, files: [...g.files, fileItem] }
+          }
+          return g
+        })
+        .filter((g) => g.files.length > 0)
+    })
+  }
+
+  function mergeSelectedGroups(selectedIds: string[]) {
+    if (selectedIds.length < 2) return
+    setGroups((prev) => {
+      const idSet = new Set(selectedIds)
+      const selected = prev.filter((g) => idSet.has(g.id))
+      if (selected.length < 2) return prev
+      const rest = prev.filter((g) => !idSet.has(g.id))
+      const primary = selected[0]!
+      return [
+        ...rest,
+        {
+          ...primary,
+          files: selected.flatMap((g) => g.files),
+        },
+      ]
+    })
+  }
+
+  function handleFileChipDragStart(
+    event: DragEvent<HTMLDivElement>,
+    groupId: string,
+    fileIndex: number,
+    chipKey: string,
+  ) {
+    if (saving) {
+      event.preventDefault()
+      return
+    }
+    event.dataTransfer.setData(
+      FILE_DRAG_MIME,
+      JSON.stringify({ fromGroupId: groupId, fileIndex }),
+    )
+    event.dataTransfer.effectAllowed = 'move'
+    setDraggingFileKey(chipKey)
+  }
+
+  function handleDocumentsDrop(event: DragEvent<HTMLDivElement>, toGroupId: string) {
+    event.preventDefault()
+    event.stopPropagation()
+    setDragOverGroupId(null)
+    setDraggingFileKey(null)
+    try {
+      const raw = event.dataTransfer.getData(FILE_DRAG_MIME)
+      if (!raw) return
+      const payload = JSON.parse(raw) as { fromGroupId: string; fileIndex: number }
+      if (!payload.fromGroupId || typeof payload.fileIndex !== 'number') return
+      moveFile(payload.fromGroupId, payload.fileIndex, toGroupId)
+    } catch {
+      // ignore
+    }
+  }
+
+  async function handleSubmit() {
+    if (!totalFiles) {
+      toast.error('Bitte mindestens eine PDF-Datei auswählen.')
+      return
+    }
+    if (anyExtracting) {
+      toast.error('Bitte warten, bis alle PDFs analysiert wurden.')
+      return
+    }
+
+    const flat = groups.flatMap((group) =>
+      group.files.map((item, indexInGroup) => ({
+        title:
+          group.files.length === 1
+            ? group.title.trim()
+            : `${group.title.trim()} (${indexInGroup + 1})`,
+        documentType: group.documentType,
+        validUntil: item.validUntil.trim() || null,
+        file: item.file,
+      })),
+    )
+
+    const invalid = flat.find((row) => !row.title.trim())
+    if (invalid) {
+      toast.error('Jedes Zertifikat braucht einen Titel.')
+      return
+    }
+
+    setSaving(true)
+    const formData = new FormData()
+    formData.set(
+      'manifest',
+      JSON.stringify(
+        flat.map((row, index) => ({
+          title: row.title,
+          documentType: row.documentType,
+          validUntil: row.validUntil,
+          fileIndex: index,
+        })),
+      ),
+    )
+    flat.forEach((row, index) => {
+      formData.set(`file_${index}`, row.file)
+    })
+
+    const result = await uploadComplianceDocumentsBatch(formData)
+    setSaving(false)
+
+    if (!result.success) {
+      toast.error(result.error)
+      return
+    }
+
+    if (result.errors.length > 0) {
+      toast.error(`${result.uploaded} gespeichert, ${result.errors.length} Fehler.`)
+      log.error('complianceBulkUpload.partialErrors', {
+        uploaded: result.uploaded,
+        errors: result.errors,
+      })
+    } else {
+      toast.success(
+        `${result.uploaded} Zertifikat${result.uploaded !== 1 ? 'e' : ''} gespeichert.`,
+      )
+    }
+
+    reset()
+    onOpenChange(false)
+    router.refresh()
+  }
+
+  function mergeSelectedAndClear() {
+    mergeSelectedGroups(Array.from(selectedGroupIds))
+    setSelectedGroupIds(new Set())
+  }
+
+  return {
+    groups,
+    typeOptions,
+    setTypeOptions,
+    typesLoading,
+    typesDialogOpen,
+    setTypesDialogOpen,
+    saving,
+    selectedGroupIds,
+    dragOverGroupId,
+    setDragOverGroupId,
+    draggingFileKey,
+    setDraggingFileKey,
+    totalFiles,
+    hasFiles,
+    canMergeSelected,
+    anyExtracting,
+    loadTypes,
+    reset,
+    addFiles,
+    toggleGroupSelection,
+    updateGroupTitle,
+    handleDocumentTypeChange,
+    removeFile,
+    fileChipKey,
+    handleFileChipDragStart,
+    handleDocumentsDrop,
+    handleSubmit,
+    mergeSelectedAndClear,
+  }
+}
+
+export type { BulkFileItem, BulkGroup }

--- a/docs/tech-debt-offen-backlog.md
+++ b/docs/tech-debt-offen-backlog.md
@@ -28,7 +28,7 @@
 | **2** | E7 Schema-Sync | ✅ T1–T4 | Types bei Migrationen regenerieren (`db:types`) | XS ongoing | bei Schema-Change |
 | **3** | Typed-Supabase Cast-Abbau | ✅ T1–T4 | Rest-Casts nur Boundaries (HTTP/RPC/Json); Boy-Scout bei Touch | — | CI: `typecheck` vor Build |
 | **4** | P1-6 Accounts Naming | ✅ App/Lib | DB-Tabelle `companies` / `company_id` / Firmennamen-Helfer **bewusst offen** | — | nicht anfassen ohne Produktentscheid |
-| **5** | God-File-Nacharbeit | Slice 1–5 ✅ | Detail-Sheet, Readiness, sharing, overview-Hooks, watchlist-manage | M ongoing | nächster: weitere God-Files bei Touch |
+| **5** | God-File-Nacharbeit | Slice 1–6 ✅ | Detail-Sheet, Readiness, sharing, overview-Hooks, watchlist, compliance-bulk-upload | M ongoing | nächster: bulk-import / deals-client / deal-documents |
 | **6** | `{ ok }` → `{ success }` | Lib ✅ | Slices 1–4; Rest nur Cron/Push-HTTP-Body | XS | Cron/Push separat wenn Monitoring-Clients ok |
 | **7** | P3-3 DE/EN-Dateinamen | ✅ Slice | `ai-draft-*`, `customer-control-link-email`; API `/api/ai-draft` + Redirect; UI-Copy „Sperrlink“/Event `ki_entwurf_generated` bleiben | — | Rest nur bei Touch |
 | **8** | `references`/`evidence` Pfade | ✅ | App = `references` (Routen/Ordner/`ROUTES`); Redirects `/dashboard/evidence` bleiben; `evidence_events` bleibt | — | Rest-`evidence` nur Domänenbegriff (RFP-Belege) |


### PR DESCRIPTION
## Summary
- Split `compliance-bulk-upload-dialog.tsx` (~705 → ~106 orchestrator) into types, helpers, `useComplianceBulkUpload`, groups panel, and footer
- Behavior unchanged (auto-group by type, PDF enrich, DnD between groups, batch submit)
- Backlog: God-File slices 1–6; next candidates bulk-import / deals-client / deal-documents

## Test plan
- [ ] Open Zertifikate bulk upload: empty dropzone → add PDFs
- [ ] Auto-group by document type; edit title/type; select + merge groups
- [ ] Drag file chips between groups; remove chip
- [ ] Wait for PDF analysis spinner; submit import
- [ ] Manage types dialog still updates options


Made with [Cursor](https://cursor.com)