### PR TITLE
refactor(#5): split bulk import dialog (slice 7)

### DIFF
--- a/app/dashboard/overview/bulk-import-dialog.tsx
+++ b/app/dashboard/overview/bulk-import-dialog.tsx
@@ -1,20 +1,7 @@
 'use client'
 
-import React, { useEffect, useState } from 'react'
-import { useRouter } from 'next/navigation'
-import { toast } from 'sonner'
-import { AlertTriangle, RefreshCw } from 'lucide-react'
-import {
-  UploadIcon,
-  FileText,
-  Cancel01Icon,
-  Loader,
-  PencilEdit01Icon,
-} from '@hugeicons/core-free-icons'
+import type { Dispatch, RefObject, SetStateAction } from 'react'
 
-import { AppIcon } from '@/lib/icons'
-import { Button } from '@/components/ui/button'
-import { Checkbox } from '@/components/ui/checkbox'
 import {
   Dialog,
   DialogContent,
@@ -22,39 +9,19 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import { Input } from '@/components/ui/input'
-import { AccountsToolbarTooltip } from '@/app/dashboard/accounts/components/accounts-toolbar-tooltip'
-import { cn } from '@/lib/utils'
-import { isSuspiciousBulkImportProjectName } from '@/lib/references/bulk-import-preview-utils'
-
-import { bulkCreateReferencesFromFiles } from '../actions'
-import { runBulkImportExtractionForReference } from '@/lib/references/library/bulk-import-post-process'
-import { extractBulkImportReferenceFromFile } from '@/lib/references/bulk-import-extract-client'
-import { uploadBulkImportFilesForReference } from '@/lib/references/bulk-import-upload'
-import { createClient } from '@/lib/supabase/client'
-import type { BulkImportExtractionResult } from '@/lib/references/bulk-import-review-types'
 import { BULK_IMPORT_MAX_FILES } from '@/lib/references/bulk-import-limits'
+import { cn } from '@/lib/utils'
+
+import { BulkImportDropzone } from './bulk-import-dropzone'
+import { BulkImportFooter } from './bulk-import-footer'
+import { BulkImportGroupsPanel } from './bulk-import-groups-panel'
 import {
   BulkImportReviewDialog,
-  type BulkImportReviewItem,
 } from './bulk-import-review-dialog'
+import { BULK_IMPORT_DIALOG_CLASS, type BulkImportGroupItem } from './bulk-import-types'
+import { useBulkImportDialog } from './use-bulk-import-dialog'
 
-export type BulkImportGroupItem = {
-  id: string
-  projectName: string
-  companyName?: string
-  files: File[]
-}
-
-const BULK_IMPORT_DIALOG_CLASS =
-  'flex max-h-[min(90vh,920px)] w-[calc(100vw-2rem)] max-w-[90vw] flex-col gap-0 overflow-hidden border-0 p-0 sm:max-w-[90vw] lg:max-w-7xl'
-
-const BULK_IMPORT_ROW_GRID_CLASS =
-  'grid flex-1 grid-cols-1 gap-2 lg:grid-cols-[minmax(140px,220px)_minmax(0,1fr)_minmax(180px,34%)] lg:items-center lg:gap-4'
-
-const BULK_IMPORT_HEADER_CLASS = 'text-xs font-medium text-muted-foreground'
-
-const BULK_IMPORT_FILE_DRAG_MIME = 'application/x-refstack-bulk-import-file'
+export type { BulkImportGroupItem }
 
 export function BulkImportDialog({
   open,
@@ -77,8 +44,8 @@ export function BulkImportDialog({
   loading: boolean
   onLoadingChange?: (loading: boolean) => void
   groups: BulkImportGroupItem[]
-  setGroups: React.Dispatch<React.SetStateAction<BulkImportGroupItem[]>>
-  dropRef: React.RefObject<HTMLInputElement | null>
+  setGroups: Dispatch<SetStateAction<BulkImportGroupItem[]>>
+  dropRef: RefObject<HTMLInputElement | null>
   addFiles: (files: File[]) => void
   removeFile: (groupId: string, fileIndex: number) => void
   moveFile: (fromGroupId: string, fileIndex: number, toGroupId: string) => void
@@ -87,310 +54,18 @@ export function BulkImportDialog({
   mergeSelectedGroups: (groupIds: string[]) => void
   previewPendingFiles: Set<File>
 }) {
-  const router = useRouter()
-  const totalFiles = groups.reduce((s, g) => s + g.files.length, 0)
-  const [reviewOpen, setReviewOpen] = useState(false)
-  const [reviewItems, setReviewItems] = useState<BulkImportReviewItem[]>([])
-  const [extractionProgress, setExtractionProgress] = useState<{
-    current: number
-    total: number
-  } | null>(null)
-  const [selectedGroupIds, setSelectedGroupIds] = useState<Set<string>>(() => new Set())
-  const [editingCompanyId, setEditingCompanyId] = useState<string | null>(null)
-  const [companyDraft, setCompanyDraft] = useState('')
-  const [dragOverGroupId, setDragOverGroupId] = useState<string | null>(null)
-  const [draggingFileKey, setDraggingFileKey] = useState<string | null>(null)
-
-  const hasFiles = groups.length > 0
-  const selectedCount = selectedGroupIds.size
-  const canMergeSelected = selectedCount >= 2
-
-  useEffect(() => {
-    if (!open) {
-      setSelectedGroupIds(new Set())
-      setEditingCompanyId(null)
-      setCompanyDraft('')
-      setDragOverGroupId(null)
-      setDraggingFileKey(null)
-    }
-  }, [open])
-
-  useEffect(() => {
-    setSelectedGroupIds((prev) => {
-      const valid = new Set(groups.map((g) => g.id))
-      const next = new Set([...prev].filter((id) => valid.has(id)))
-      return next.size === prev.size ? prev : next
-    })
-  }, [groups])
-
-  function toggleGroupSelection(groupId: string, checked: boolean) {
-    setSelectedGroupIds((prev) => {
-      const next = new Set(prev)
-      if (checked) next.add(groupId)
-      else next.delete(groupId)
-      return next
-    })
-  }
-
-  function startCompanyEdit(group: BulkImportGroupItem) {
-    setEditingCompanyId(group.id)
-    setCompanyDraft(group.companyName ?? '')
-  }
-
-  function commitCompanyEdit(groupId: string) {
-    setCompanyName(groupId, companyDraft)
-    setEditingCompanyId(null)
-    setCompanyDraft('')
-  }
-
-  function isGroupPreviewPending(group: BulkImportGroupItem) {
-    return group.files.some((file) => previewPendingFiles.has(file))
-  }
-
-  function fileChipKey(groupId: string, file: File) {
-    return `${groupId}:${file.name}:${file.size}:${file.lastModified}`
-  }
-
-  function handleFileChipDragStart(
-    event: React.DragEvent<HTMLDivElement>,
-    groupId: string,
-    fileIndex: number,
-    chipKey: string,
-  ) {
-    if (loading) {
-      event.preventDefault()
-      return
-    }
-    event.dataTransfer.setData(
-      BULK_IMPORT_FILE_DRAG_MIME,
-      JSON.stringify({ fromGroupId: groupId, fileIndex }),
-    )
-    event.dataTransfer.effectAllowed = 'move'
-    setDraggingFileKey(chipKey)
-  }
-
-  function handleDocumentsDragOver(
-    event: React.DragEvent<HTMLDivElement>,
-    groupId: string,
-  ) {
-    event.preventDefault()
-    event.stopPropagation()
-    event.dataTransfer.dropEffect = 'move'
-    setDragOverGroupId(groupId)
-  }
-
-  function handleDocumentsDrop(
-    event: React.DragEvent<HTMLDivElement>,
-    toGroupId: string,
-  ) {
-    event.preventDefault()
-    event.stopPropagation()
-    setDragOverGroupId(null)
-    setDraggingFileKey(null)
-
-    try {
-      const raw = event.dataTransfer.getData(BULK_IMPORT_FILE_DRAG_MIME)
-      if (!raw) return
-      const payload = JSON.parse(raw) as { fromGroupId: string; fileIndex: number }
-      if (!payload.fromGroupId || typeof payload.fileIndex !== 'number') return
-      moveFile(payload.fromGroupId, payload.fileIndex, toGroupId)
-    } catch {
-      // Ungültige Drag-Daten ignorieren
-    }
-  }
-
-  const handleImport = async () => {
-    const formData = new FormData()
-    formData.append(
-      'groups',
-      JSON.stringify(
-        groups.map((g) => ({
-          projectName: g.projectName,
-          companyName: g.companyName ?? '',
-          fileCount: g.files.length,
-        })),
-      ),
-    )
-    groups.forEach((g) => {
-      g.files.forEach((f) => formData.append('files', f))
-    })
-
-    onLoadingChange?.(true)
-    setExtractionProgress(null)
-    try {
-      const result = await bulkCreateReferencesFromFiles(formData)
-      if (!result.success) {
-        toast.error(result.error)
-        return
-      }
-
-      const ids = result.referenceIds
-      let organizationId =
-        'organizationId' in result ? String(result.organizationId ?? '') : ''
-      if (!organizationId) {
-        const supabase = createClient()
-        const {
-          data: { user },
-        } = await supabase.auth.getUser()
-        if (user) {
-          const { data: profile } = await supabase
-            .from('profiles')
-            .select('organization_id')
-            .eq('id', user.id)
-            .single()
-          organizationId = String(profile?.organization_id ?? '')
-        }
-      }
-
-      let uploadFailed = false
-      if (ids.length > 0 && organizationId) {
-        let refIdx = 0
-        for (const group of groups) {
-          const refId = ids[refIdx]
-          if (refId && group.files.length > 0) {
-            const upload = await uploadBulkImportFilesForReference(
-              organizationId,
-              refId,
-              group.files,
-            )
-            if (!upload.success) {
-              uploadFailed = true
-              toast.error(
-                upload.error ??
-                  `Datei für „${group.projectName}“ konnte nicht gespeichert werden.`,
-                { duration: 8000 },
-              )
-            }
-          }
-          refIdx += 1
-        }
-      }
-      if (uploadFailed) {
-        onLoadingChange?.(false)
-        setExtractionProgress(null)
-        router.refresh()
-        return
-      }
-
-      if (ids.length === 0) {
-        toast.error(
-          result.created === 0
-            ? 'Es wurde keine Referenz angelegt. Bitte Dateien prüfen.'
-            : 'Nach dem Import fehlten Referenz-IDs für die Extraktion.',
-        )
-        onOpenChange(false)
-        setGroups([])
-        router.refresh()
-        return
-      }
-      let completeCount = 0
-      const pendingReview: BulkImportReviewItem[] = []
-
-      for (let i = 0; i < ids.length; i++) {
-        setExtractionProgress({ current: i + 1, total: ids.length })
-        const id = ids[i]!
-        const primaryFile = groups[i]?.files[0]
-        let r: BulkImportExtractionResult
-        if (primaryFile && primaryFile.size > 0) {
-          r = await extractBulkImportReferenceFromFile(id, primaryFile)
-        } else {
-          r = await runBulkImportExtractionForReference(id)
-        }
-        if (!r.success) {
-          pendingReview.push({
-            referenceId: id,
-            title: 'Referenz',
-            needsInput: true,
-            extractionOk: false,
-            extractionError: r.error,
-            suggestions: {},
-          })
-          continue
-        }
-        if (!r.needsInput) completeCount++
-        const showReview =
-          r.needsInput ||
-          !r.extractionOk ||
-          Boolean(String(r.extractionError ?? '').trim())
-        if (showReview) {
-          pendingReview.push({
-            referenceId: r.referenceId,
-            title: r.title,
-            needsInput: r.needsInput,
-            extractionOk: r.extractionOk,
-            extractionError: r.extractionError,
-            suggestions: r.suggestions,
-          })
-        }
-      }
-
-      const needsMoreCount = ids.length - completeCount
-      if (needsMoreCount > 0) {
-        toast.success(
-          `${completeCount} Referenzen erfolgreich importiert, ${needsMoreCount} Referenzen benötigen weiteren Input.`,
-          { duration: 6500 },
-        )
-      } else {
-        toast.success(
-          `${completeCount} Referenz${completeCount !== 1 ? 'en' : ''} erfolgreich importiert.`,
-          { duration: 5000 },
-        )
-      }
-
-      onOpenChange(false)
-      setGroups([])
-      router.refresh()
-      setExtractionProgress(null)
-
-      if (pendingReview.length > 0) {
-        setReviewItems(pendingReview)
-        window.setTimeout(() => setReviewOpen(true), 400)
-      } else {
-        setReviewItems([])
-      }
-    } catch (e) {
-      toast.error(e instanceof Error ? e.message : 'Import fehlgeschlagen.')
-    } finally {
-      onLoadingChange?.(false)
-    }
-  }
-
-  function handleFileDrop(event: React.DragEvent) {
-    event.preventDefault()
-    event.stopPropagation()
-    if (loading) return
-    const list = event.dataTransfer.files ? Array.from(event.dataTransfer.files) : []
-    addFiles(list)
-  }
-
-  function renderDropZone(compact: boolean) {
-    return (
-      <div
-        role="button"
-        tabIndex={0}
-        onClick={() => !loading && dropRef.current?.click()}
-        onKeyDown={(e) => e.key === 'Enter' && !loading && dropRef.current?.click()}
-        onDragOver={(e) => {
-          e.preventDefault()
-          e.stopPropagation()
-        }}
-        onDrop={handleFileDrop}
-        className={cn(
-          'flex w-full min-w-0 cursor-pointer items-center justify-center rounded-lg border-2 border-dashed border-muted-foreground/30 bg-muted/20 text-muted-foreground transition-colors hover:border-muted-foreground/50 hover:bg-muted/30 disabled:pointer-events-none disabled:opacity-60',
-          compact
-            ? 'h-10 gap-2 px-3 text-left text-xs sm:text-sm'
-            : 'min-h-[160px] flex-col gap-2 p-6 text-center text-sm',
-        )}
-      >
-        <AppIcon icon={UploadIcon} size={compact ? 16 : 32} className="shrink-0" />
-        <span className={cn(compact && 'min-w-0 truncate')}>
-          {compact
-            ? `Weitere Dateien ablegen oder klicken (max. ${BULK_IMPORT_MAX_FILES})`
-            : `Dateien hier ablegen oder klicken (max. ${BULK_IMPORT_MAX_FILES})`}
-        </span>
-      </div>
-    )
-  }
+  const state = useBulkImportDialog({
+    open,
+    onOpenChange,
+    loading,
+    onLoadingChange,
+    groups,
+    setGroups,
+    moveFile,
+    setCompanyName,
+    mergeSelectedGroups,
+    previewPendingFiles,
+  })
 
   return (
     <>
@@ -408,11 +83,11 @@ export function BulkImportDialog({
             <div
               className={cn(
                 'min-h-0 flex-1 pt-3',
-                hasFiles ? 'flex flex-col overflow-hidden' : 'overflow-y-auto',
+                state.hasFiles ? 'flex flex-col overflow-hidden' : 'overflow-y-auto',
               )}
             >
               <input
-                ref={dropRef as React.RefObject<HTMLInputElement>}
+                ref={dropRef}
                 type="file"
                 multiple
                 accept=".pdf,.pptx,.ppt,.png,.jpg,.jpeg,.webp"
@@ -424,251 +99,60 @@ export function BulkImportDialog({
                 }}
               />
 
-              {!hasFiles ? renderDropZone(false) : null}
-
-              {hasFiles ? (
-                <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-border bg-white">
-                  <div className="flex shrink-0 gap-3 border-b border-border bg-white px-3 py-2">
-                    <div className="size-4 shrink-0" aria-hidden />
-                    <div
-                      className={cn(BULK_IMPORT_ROW_GRID_CLASS, BULK_IMPORT_HEADER_CLASS)}
-                    >
-                      <span>Kunde</span>
-                      <span>Referenztitel</span>
-                      <span>Dokumente</span>
-                    </div>
-                  </div>
-
-                  <div className="min-h-0 flex-1 overflow-y-auto bg-white">
-                    {groups.map((group) => {
-                      const previewPending = isGroupPreviewPending(group)
-                      const suspiciousTitle = isSuspiciousBulkImportProjectName(
-                        group.projectName,
-                      )
-                      const isEditingCompany = editingCompanyId === group.id
-
-                      return (
-                        <div
-                          key={group.id}
-                          className="flex items-center gap-3 border-b border-border bg-white px-3 py-2.5 last:border-b-0"
-                        >
-                          <Checkbox
-                            className="self-center"
-                            checked={selectedGroupIds.has(group.id)}
-                            disabled={loading}
-                            onCheckedChange={(checked) =>
-                              toggleGroupSelection(group.id, checked === true)
-                            }
-                            aria-label={`${group.projectName || 'Referenz'} auswählen`}
-                          />
-
-                          <div className={BULK_IMPORT_ROW_GRID_CLASS}>
-                            <div className="flex min-w-0 items-center gap-1.5">
-                              {isEditingCompany ? (
-                                <Input
-                                  value={companyDraft}
-                                  onChange={(e) => setCompanyDraft(e.target.value)}
-                                  onBlur={() => commitCompanyEdit(group.id)}
-                                  onKeyDown={(e) => {
-                                    if (e.key === 'Enter') commitCompanyEdit(group.id)
-                                    if (e.key === 'Escape') {
-                                      setEditingCompanyId(null)
-                                      setCompanyDraft('')
-                                    }
-                                  }}
-                                  disabled={loading}
-                                  autoFocus
-                                  className="h-7 min-w-0 flex-1 text-sm"
-                                />
-                              ) : (
-                                <>
-                                  <span
-                                    className={cn(
-                                      'min-w-0 truncate text-sm font-medium',
-                                      group.companyName
-                                        ? 'text-foreground'
-                                        : 'text-muted-foreground',
-                                    )}
-                                  >
-                                    {group.companyName?.trim() || '—'}
-                                  </span>
-                                  <AccountsToolbarTooltip label="Kunde bearbeiten">
-                                    <button
-                                      type="button"
-                                      disabled={loading}
-                                      onClick={() => startCompanyEdit(group)}
-                                      className="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
-                                      aria-label="Kunde bearbeiten"
-                                    >
-                                      <AppIcon icon={PencilEdit01Icon} size={14} />
-                                    </button>
-                                  </AccountsToolbarTooltip>
-                                </>
-                              )}
-                            </div>
-
-                            <div className="flex min-w-0 flex-1 items-center gap-1.5">
-                              <Input
-                                value={group.projectName}
-                                onChange={(e) => setGroupName(group.id, e.target.value)}
-                                disabled={loading}
-                                className="h-8 min-w-0 flex-1 text-sm"
-                                placeholder="Referenztitel"
-                                aria-label="Referenztitel"
-                              />
-                              {previewPending ? (
-                                <RefreshCw
-                                  className="size-4 shrink-0 animate-spin text-muted-foreground"
-                                  aria-hidden
-                                />
-                              ) : null}
-                              {!previewPending && suspiciousTitle ? (
-                                <AccountsToolbarTooltip label="Projektname prüfen — evtl. Zeitraum statt Titel erkannt">
-                                  <span className="inline-flex shrink-0 text-amber-600">
-                                    <AlertTriangle className="size-4" aria-hidden />
-                                  </span>
-                                </AccountsToolbarTooltip>
-                              ) : null}
-                            </div>
-
-                            <div
-                              className={cn(
-                                'flex min-h-9 min-w-0 flex-wrap gap-1.5 rounded-md transition-colors lg:justify-end',
-                                dragOverGroupId === group.id &&
-                                  'bg-primary/10 ring-1 ring-inset ring-primary/40',
-                              )}
-                              onDragOver={(event) =>
-                                handleDocumentsDragOver(event, group.id)
-                              }
-                              onDragLeave={(event) => {
-                                if (
-                                  !event.currentTarget.contains(
-                                    event.relatedTarget as Node,
-                                  )
-                                ) {
-                                  setDragOverGroupId((prev) =>
-                                    prev === group.id ? null : prev,
-                                  )
-                                }
-                              }}
-                              onDrop={(event) => handleDocumentsDrop(event, group.id)}
-                            >
-                              {group.files.map((file, fileIndex) => {
-                                const chipKey = fileChipKey(group.id, file)
-                                return (
-                                  <div
-                                    key={chipKey}
-                                    draggable={!loading}
-                                    onDragStart={(event) =>
-                                      handleFileChipDragStart(
-                                        event,
-                                        group.id,
-                                        fileIndex,
-                                        chipKey,
-                                      )
-                                    }
-                                    onDragEnd={() => {
-                                      setDraggingFileKey(null)
-                                      setDragOverGroupId(null)
-                                    }}
-                                    className={cn(
-                                      'flex max-w-full cursor-grab items-center gap-1 rounded-md border border-border bg-background px-2 py-1 text-xs shadow-sm active:cursor-grabbing',
-                                      draggingFileKey === chipKey && 'opacity-50',
-                                    )}
-                                  >
-                                    <AppIcon
-                                      icon={FileText}
-                                      size={12}
-                                      className="shrink-0 text-muted-foreground"
-                                    />
-                                    <span className="max-w-[100px] truncate sm:max-w-[120px]">
-                                      {file.name}
-                                    </span>
-                                    <button
-                                      type="button"
-                                      disabled={loading}
-                                      onClick={() => removeFile(group.id, fileIndex)}
-                                      onMouseDown={(event) => event.stopPropagation()}
-                                      className="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
-                                      aria-label={`${file.name} entfernen`}
-                                    >
-                                      <AppIcon icon={Cancel01Icon} size={12} />
-                                    </button>
-                                  </div>
-                                )
-                              })}
-                            </div>
-                          </div>
-                        </div>
-                      )
-                    })}
-                  </div>
-                </div>
-              ) : null}
+              {!state.hasFiles ? (
+                <BulkImportDropzone
+                  compact={false}
+                  loading={loading}
+                  dropRef={dropRef}
+                  onAddFiles={addFiles}
+                />
+              ) : (
+                <BulkImportGroupsPanel
+                  groups={groups}
+                  loading={loading}
+                  selectedGroupIds={state.selectedGroupIds}
+                  editingCompanyId={state.editingCompanyId}
+                  companyDraft={state.companyDraft}
+                  setCompanyDraft={state.setCompanyDraft}
+                  dragOverGroupId={state.dragOverGroupId}
+                  setDragOverGroupId={state.setDragOverGroupId}
+                  draggingFileKey={state.draggingFileKey}
+                  setDraggingFileKey={state.setDraggingFileKey}
+                  toggleGroupSelection={state.toggleGroupSelection}
+                  startCompanyEdit={state.startCompanyEdit}
+                  commitCompanyEdit={state.commitCompanyEdit}
+                  cancelCompanyEdit={state.cancelCompanyEdit}
+                  isGroupPreviewPending={state.isGroupPreviewPending}
+                  setGroupName={setGroupName}
+                  removeFile={removeFile}
+                  fileChipKey={state.fileChipKey}
+                  handleFileChipDragStart={state.handleFileChipDragStart}
+                  handleDocumentsDragOver={state.handleDocumentsDragOver}
+                  handleDocumentsDrop={state.handleDocumentsDrop}
+                />
+              )}
             </div>
 
-            <div className="shrink-0 border-t border-border py-3">
-              <div className="flex items-center gap-3">
-                {hasFiles ? (
-                  <div className="min-w-0 flex-1">{renderDropZone(true)}</div>
-                ) : (
-                  <div className="flex-1" aria-hidden />
-                )}
-
-                <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="toolbar"
-                    disabled={!canMergeSelected || loading}
-                    onClick={() => {
-                      mergeSelectedGroups(Array.from(selectedGroupIds))
-                      setSelectedGroupIds(new Set())
-                    }}
-                  >
-                    Ausgewählte gruppieren
-                  </Button>
-                  <Button
-                    variant="outline"
-                    size="toolbar"
-                    disabled={loading}
-                    onClick={() => onOpenChange(false)}
-                  >
-                    Abbrechen
-                  </Button>
-                  <Button
-                    size="toolbar"
-                    disabled={totalFiles === 0 || loading}
-                    onClick={() => void handleImport()}
-                  >
-                    {loading ? (
-                      <>
-                        <AppIcon icon={Loader} size={16} className="mr-2 animate-spin" />
-                        {extractionProgress
-                          ? `Extrahiere ${extractionProgress.current}/${extractionProgress.total}…`
-                          : 'Import läuft…'}
-                      </>
-                    ) : (
-                      'Import starten'
-                    )}
-                  </Button>
-                </div>
-              </div>
-              {totalFiles > 0 ? (
-                <p className="mt-1.5 text-right text-xs text-muted-foreground">
-                  {groups.length} Gruppe{groups.length !== 1 ? 'n' : ''} · {totalFiles}{' '}
-                  Datei
-                  {totalFiles !== 1 ? 'en' : ''}
-                </p>
-              ) : null}
-            </div>
+            <BulkImportFooter
+              hasFiles={state.hasFiles}
+              totalFiles={state.totalFiles}
+              groupsCount={groups.length}
+              loading={loading}
+              canMergeSelected={state.canMergeSelected}
+              extractionProgress={state.extractionProgress}
+              dropRef={dropRef}
+              onAddFiles={addFiles}
+              onMergeSelected={state.mergeSelectedAndClear}
+              onCancel={() => onOpenChange(false)}
+              onSubmit={() => void state.handleImport()}
+            />
           </div>
         </DialogContent>
       </Dialog>
       <BulkImportReviewDialog
-        open={reviewOpen}
-        onOpenChange={setReviewOpen}
-        items={reviewItems}
+        open={state.reviewOpen}
+        onOpenChange={state.setReviewOpen}
+        items={state.reviewItems}
       />
     </>
   )

--- a/app/dashboard/overview/bulk-import-dropzone.tsx
+++ b/app/dashboard/overview/bulk-import-dropzone.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import type { DragEvent, RefObject } from 'react'
+import { UploadIcon } from '@hugeicons/core-free-icons'
+
+import { AppIcon } from '@/lib/icons'
+import { BULK_IMPORT_MAX_FILES } from '@/lib/references/bulk-import-limits'
+import { cn } from '@/lib/utils'
+
+export function BulkImportDropzone({
+  compact,
+  loading,
+  dropRef,
+  onAddFiles,
+}: {
+  compact: boolean
+  loading: boolean
+  dropRef: RefObject<HTMLInputElement | null>
+  onAddFiles: (files: File[]) => void
+}) {
+  function handleFileDrop(event: DragEvent) {
+    event.preventDefault()
+    event.stopPropagation()
+    if (loading) return
+    const list = event.dataTransfer.files ? Array.from(event.dataTransfer.files) : []
+    onAddFiles(list)
+  }
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => !loading && dropRef.current?.click()}
+      onKeyDown={(e) => e.key === 'Enter' && !loading && dropRef.current?.click()}
+      onDragOver={(e) => {
+        e.preventDefault()
+        e.stopPropagation()
+      }}
+      onDrop={handleFileDrop}
+      className={cn(
+        'flex w-full min-w-0 cursor-pointer items-center justify-center rounded-lg border-2 border-dashed border-muted-foreground/30 bg-muted/20 text-muted-foreground transition-colors hover:border-muted-foreground/50 hover:bg-muted/30 disabled:pointer-events-none disabled:opacity-60',
+        compact
+          ? 'h-10 gap-2 px-3 text-left text-xs sm:text-sm'
+          : 'min-h-[160px] flex-col gap-2 p-6 text-center text-sm',
+      )}
+    >
+      <AppIcon icon={UploadIcon} size={compact ? 16 : 32} className="shrink-0" />
+      <span className={cn(compact && 'min-w-0 truncate')}>
+        {compact
+          ? `Weitere Dateien ablegen oder klicken (max. ${BULK_IMPORT_MAX_FILES})`
+          : `Dateien hier ablegen oder klicken (max. ${BULK_IMPORT_MAX_FILES})`}
+      </span>
+    </div>
+  )
+}

--- a/app/dashboard/overview/bulk-import-file-helpers.ts
+++ b/app/dashboard/overview/bulk-import-file-helpers.ts
@@ -1,7 +1,7 @@
 import { toast } from 'sonner'
 import { BULK_IMPORT_MAX_FILES } from '@/lib/references/bulk-import-limits'
 import { autoGroupBulkImportByFileName } from '@/lib/references/bulk-import-grouping'
-import type { BulkImportGroupItem } from './bulk-import-dialog'
+import type { BulkImportGroupItem } from './bulk-import-types'
 import type { Dispatch, SetStateAction } from 'react'
 
 export async function previewBulkImportFile(file: File) {

--- a/app/dashboard/overview/bulk-import-footer.tsx
+++ b/app/dashboard/overview/bulk-import-footer.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import type { RefObject } from 'react'
+import { Loader } from '@hugeicons/core-free-icons'
+
+import { AppIcon } from '@/lib/icons'
+import { Button } from '@/components/ui/button'
+
+import { BulkImportDropzone } from './bulk-import-dropzone'
+
+export function BulkImportFooter({
+  hasFiles,
+  totalFiles,
+  groupsCount,
+  loading,
+  canMergeSelected,
+  extractionProgress,
+  dropRef,
+  onAddFiles,
+  onMergeSelected,
+  onCancel,
+  onSubmit,
+}: {
+  hasFiles: boolean
+  totalFiles: number
+  groupsCount: number
+  loading: boolean
+  canMergeSelected: boolean
+  extractionProgress: { current: number; total: number } | null
+  dropRef: RefObject<HTMLInputElement | null>
+  onAddFiles: (files: File[]) => void
+  onMergeSelected: () => void
+  onCancel: () => void
+  onSubmit: () => void
+}) {
+  return (
+    <div className="shrink-0 border-t border-border py-3">
+      <div className="flex items-center gap-3">
+        {hasFiles ? (
+          <div className="min-w-0 flex-1">
+            <BulkImportDropzone
+              compact
+              loading={loading}
+              dropRef={dropRef}
+              onAddFiles={onAddFiles}
+            />
+          </div>
+        ) : (
+          <div className="flex-1" aria-hidden />
+        )}
+
+        <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="toolbar"
+            disabled={!canMergeSelected || loading}
+            onClick={onMergeSelected}
+          >
+            Ausgewählte gruppieren
+          </Button>
+          <Button
+            variant="outline"
+            size="toolbar"
+            disabled={loading}
+            onClick={onCancel}
+          >
+            Abbrechen
+          </Button>
+          <Button
+            size="toolbar"
+            disabled={totalFiles === 0 || loading}
+            onClick={onSubmit}
+          >
+            {loading ? (
+              <>
+                <AppIcon icon={Loader} size={16} className="mr-2 animate-spin" />
+                {extractionProgress
+                  ? `Extrahiere ${extractionProgress.current}/${extractionProgress.total}…`
+                  : 'Import läuft…'}
+              </>
+            ) : (
+              'Import starten'
+            )}
+          </Button>
+        </div>
+      </div>
+      {totalFiles > 0 ? (
+        <p className="mt-1.5 text-right text-xs text-muted-foreground">
+          {groupsCount} Gruppe{groupsCount !== 1 ? 'n' : ''} · {totalFiles} Datei
+          {totalFiles !== 1 ? 'en' : ''}
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/app/dashboard/overview/bulk-import-groups-panel.tsx
+++ b/app/dashboard/overview/bulk-import-groups-panel.tsx
@@ -1,0 +1,229 @@
+'use client'
+
+import type { DragEvent } from 'react'
+import { AlertTriangle, RefreshCw } from 'lucide-react'
+import { Cancel01Icon, FileText, PencilEdit01Icon } from '@hugeicons/core-free-icons'
+
+import { AccountsToolbarTooltip } from '@/app/dashboard/accounts/components/accounts-toolbar-tooltip'
+import { AppIcon } from '@/lib/icons'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Input } from '@/components/ui/input'
+import { isSuspiciousBulkImportProjectName } from '@/lib/references/bulk-import-preview-utils'
+import { cn } from '@/lib/utils'
+
+import {
+  BULK_IMPORT_HEADER_CLASS,
+  BULK_IMPORT_ROW_GRID_CLASS,
+  type BulkImportGroupItem,
+} from './bulk-import-types'
+
+export function BulkImportGroupsPanel({
+  groups,
+  loading,
+  selectedGroupIds,
+  editingCompanyId,
+  companyDraft,
+  setCompanyDraft,
+  dragOverGroupId,
+  setDragOverGroupId,
+  draggingFileKey,
+  setDraggingFileKey,
+  toggleGroupSelection,
+  startCompanyEdit,
+  commitCompanyEdit,
+  cancelCompanyEdit,
+  isGroupPreviewPending,
+  setGroupName,
+  removeFile,
+  fileChipKey,
+  handleFileChipDragStart,
+  handleDocumentsDragOver,
+  handleDocumentsDrop,
+}: {
+  groups: BulkImportGroupItem[]
+  loading: boolean
+  selectedGroupIds: Set<string>
+  editingCompanyId: string | null
+  companyDraft: string
+  setCompanyDraft: (value: string) => void
+  dragOverGroupId: string | null
+  setDragOverGroupId: (
+    value: string | null | ((prev: string | null) => string | null),
+  ) => void
+  draggingFileKey: string | null
+  setDraggingFileKey: (value: string | null) => void
+  toggleGroupSelection: (groupId: string, checked: boolean) => void
+  startCompanyEdit: (group: BulkImportGroupItem) => void
+  commitCompanyEdit: (groupId: string) => void
+  cancelCompanyEdit: () => void
+  isGroupPreviewPending: (group: BulkImportGroupItem) => boolean
+  setGroupName: (groupId: string, projectName: string) => void
+  removeFile: (groupId: string, fileIndex: number) => void
+  fileChipKey: (groupId: string, file: File) => string
+  handleFileChipDragStart: (
+    event: DragEvent<HTMLDivElement>,
+    groupId: string,
+    fileIndex: number,
+    chipKey: string,
+  ) => void
+  handleDocumentsDragOver: (event: DragEvent<HTMLDivElement>, groupId: string) => void
+  handleDocumentsDrop: (event: DragEvent<HTMLDivElement>, toGroupId: string) => void
+}) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-border bg-white">
+      <div className="flex shrink-0 gap-3 border-b border-border bg-white px-3 py-2">
+        <div className="size-4 shrink-0" aria-hidden />
+        <div className={cn(BULK_IMPORT_ROW_GRID_CLASS, BULK_IMPORT_HEADER_CLASS)}>
+          <span>Kunde</span>
+          <span>Referenztitel</span>
+          <span>Dokumente</span>
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto bg-white">
+        {groups.map((group) => {
+          const previewPending = isGroupPreviewPending(group)
+          const suspiciousTitle = isSuspiciousBulkImportProjectName(group.projectName)
+          const isEditingCompany = editingCompanyId === group.id
+
+          return (
+            <div
+              key={group.id}
+              className="flex items-center gap-3 border-b border-border bg-white px-3 py-2.5 last:border-b-0"
+            >
+              <Checkbox
+                className="self-center"
+                checked={selectedGroupIds.has(group.id)}
+                disabled={loading}
+                onCheckedChange={(checked) =>
+                  toggleGroupSelection(group.id, checked === true)
+                }
+                aria-label={`${group.projectName || 'Referenz'} auswählen`}
+              />
+
+              <div className={BULK_IMPORT_ROW_GRID_CLASS}>
+                <div className="flex min-w-0 items-center gap-1.5">
+                  {isEditingCompany ? (
+                    <Input
+                      value={companyDraft}
+                      onChange={(e) => setCompanyDraft(e.target.value)}
+                      onBlur={() => commitCompanyEdit(group.id)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') commitCompanyEdit(group.id)
+                        if (e.key === 'Escape') cancelCompanyEdit()
+                      }}
+                      disabled={loading}
+                      autoFocus
+                      className="h-7 min-w-0 flex-1 text-sm"
+                    />
+                  ) : (
+                    <>
+                      <span
+                        className={cn(
+                          'min-w-0 truncate text-sm font-medium',
+                          group.companyName ? 'text-foreground' : 'text-muted-foreground',
+                        )}
+                      >
+                        {group.companyName?.trim() || '—'}
+                      </span>
+                      <AccountsToolbarTooltip label="Kunde bearbeiten">
+                        <button
+                          type="button"
+                          disabled={loading}
+                          onClick={() => startCompanyEdit(group)}
+                          className="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                          aria-label="Kunde bearbeiten"
+                        >
+                          <AppIcon icon={PencilEdit01Icon} size={14} />
+                        </button>
+                      </AccountsToolbarTooltip>
+                    </>
+                  )}
+                </div>
+
+                <div className="flex min-w-0 flex-1 items-center gap-1.5">
+                  <Input
+                    value={group.projectName}
+                    onChange={(e) => setGroupName(group.id, e.target.value)}
+                    disabled={loading}
+                    className="h-8 min-w-0 flex-1 text-sm"
+                    placeholder="Referenztitel"
+                    aria-label="Referenztitel"
+                  />
+                  {previewPending ? (
+                    <RefreshCw
+                      className="size-4 shrink-0 animate-spin text-muted-foreground"
+                      aria-hidden
+                    />
+                  ) : null}
+                  {!previewPending && suspiciousTitle ? (
+                    <AccountsToolbarTooltip label="Projektname prüfen — evtl. Zeitraum statt Titel erkannt">
+                      <span className="inline-flex shrink-0 text-amber-600">
+                        <AlertTriangle className="size-4" aria-hidden />
+                      </span>
+                    </AccountsToolbarTooltip>
+                  ) : null}
+                </div>
+
+                <div
+                  className={cn(
+                    'flex min-h-9 min-w-0 flex-wrap gap-1.5 rounded-md transition-colors lg:justify-end',
+                    dragOverGroupId === group.id &&
+                      'bg-primary/10 ring-1 ring-inset ring-primary/40',
+                  )}
+                  onDragOver={(event) => handleDocumentsDragOver(event, group.id)}
+                  onDragLeave={(event) => {
+                    if (!event.currentTarget.contains(event.relatedTarget as Node)) {
+                      setDragOverGroupId((prev) => (prev === group.id ? null : prev))
+                    }
+                  }}
+                  onDrop={(event) => handleDocumentsDrop(event, group.id)}
+                >
+                  {group.files.map((file, fileIndex) => {
+                    const chipKey = fileChipKey(group.id, file)
+                    return (
+                      <div
+                        key={chipKey}
+                        draggable={!loading}
+                        onDragStart={(event) =>
+                          handleFileChipDragStart(event, group.id, fileIndex, chipKey)
+                        }
+                        onDragEnd={() => {
+                          setDraggingFileKey(null)
+                          setDragOverGroupId(null)
+                        }}
+                        className={cn(
+                          'flex max-w-full cursor-grab items-center gap-1 rounded-md border border-border bg-background px-2 py-1 text-xs shadow-sm active:cursor-grabbing',
+                          draggingFileKey === chipKey && 'opacity-50',
+                        )}
+                      >
+                        <AppIcon
+                          icon={FileText}
+                          size={12}
+                          className="shrink-0 text-muted-foreground"
+                        />
+                        <span className="max-w-[100px] truncate sm:max-w-[120px]">
+                          {file.name}
+                        </span>
+                        <button
+                          type="button"
+                          disabled={loading}
+                          onClick={() => removeFile(group.id, fileIndex)}
+                          onMouseDown={(event) => event.stopPropagation()}
+                          className="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                          aria-label={`${file.name} entfernen`}
+                        >
+                          <AppIcon icon={Cancel01Icon} size={12} />
+                        </button>
+                      </div>
+                    )
+                  })}
+                </div>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/overview/bulk-import-types.ts
+++ b/app/dashboard/overview/bulk-import-types.ts
@@ -1,0 +1,20 @@
+export type BulkImportGroupItem = {
+  id: string
+  projectName: string
+  companyName?: string
+  files: File[]
+}
+
+export const BULK_IMPORT_DIALOG_CLASS =
+  'flex max-h-[min(90vh,920px)] w-[calc(100vw-2rem)] max-w-[90vw] flex-col gap-0 overflow-hidden border-0 p-0 sm:max-w-[90vw] lg:max-w-7xl'
+
+export const BULK_IMPORT_ROW_GRID_CLASS =
+  'grid flex-1 grid-cols-1 gap-2 lg:grid-cols-[minmax(140px,220px)_minmax(0,1fr)_minmax(180px,34%)] lg:items-center lg:gap-4'
+
+export const BULK_IMPORT_HEADER_CLASS = 'text-xs font-medium text-muted-foreground'
+
+export const BULK_IMPORT_FILE_DRAG_MIME = 'application/x-refstack-bulk-import-file'
+
+export function bulkImportFileChipKey(groupId: string, file: File): string {
+  return `${groupId}:${file.name}:${file.size}:${file.lastModified}`
+}

--- a/app/dashboard/overview/use-bulk-import-dialog.ts
+++ b/app/dashboard/overview/use-bulk-import-dialog.ts
@@ -1,0 +1,345 @@
+'use client'
+
+import {
+  useEffect,
+  useState,
+  type Dispatch,
+  type DragEvent,
+  type SetStateAction,
+} from 'react'
+import { useRouter } from 'next/navigation'
+import { toast } from 'sonner'
+
+import { bulkCreateReferencesFromFiles } from '@/app/dashboard/actions'
+import { extractBulkImportReferenceFromFile } from '@/lib/references/bulk-import-extract-client'
+import { uploadBulkImportFilesForReference } from '@/lib/references/bulk-import-upload'
+import { runBulkImportExtractionForReference } from '@/lib/references/library/bulk-import-post-process'
+import type { BulkImportExtractionResult } from '@/lib/references/bulk-import-review-types'
+import { createClient } from '@/lib/supabase/client'
+
+import type { BulkImportReviewItem } from './bulk-import-review-dialog'
+import {
+  BULK_IMPORT_FILE_DRAG_MIME,
+  bulkImportFileChipKey,
+  type BulkImportGroupItem,
+} from './bulk-import-types'
+
+export function useBulkImportDialog({
+  open,
+  onOpenChange,
+  loading,
+  onLoadingChange,
+  groups,
+  setGroups,
+  moveFile,
+  setCompanyName,
+  mergeSelectedGroups,
+  previewPendingFiles,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  loading: boolean
+  onLoadingChange?: (loading: boolean) => void
+  groups: BulkImportGroupItem[]
+  setGroups: Dispatch<SetStateAction<BulkImportGroupItem[]>>
+  moveFile: (fromGroupId: string, fileIndex: number, toGroupId: string) => void
+  setCompanyName: (groupId: string, companyName: string) => void
+  mergeSelectedGroups: (groupIds: string[]) => void
+  previewPendingFiles: Set<File>
+}) {
+  const router = useRouter()
+  const totalFiles = groups.reduce((s, g) => s + g.files.length, 0)
+  const [reviewOpen, setReviewOpen] = useState(false)
+  const [reviewItems, setReviewItems] = useState<BulkImportReviewItem[]>([])
+  const [extractionProgress, setExtractionProgress] = useState<{
+    current: number
+    total: number
+  } | null>(null)
+  const [selectedGroupIds, setSelectedGroupIds] = useState<Set<string>>(() => new Set())
+  const [editingCompanyId, setEditingCompanyId] = useState<string | null>(null)
+  const [companyDraft, setCompanyDraft] = useState('')
+  const [dragOverGroupId, setDragOverGroupId] = useState<string | null>(null)
+  const [draggingFileKey, setDraggingFileKey] = useState<string | null>(null)
+
+  const hasFiles = groups.length > 0
+  const canMergeSelected = selectedGroupIds.size >= 2
+
+  useEffect(() => {
+    if (!open) {
+      setSelectedGroupIds(new Set())
+      setEditingCompanyId(null)
+      setCompanyDraft('')
+      setDragOverGroupId(null)
+      setDraggingFileKey(null)
+    }
+  }, [open])
+
+  useEffect(() => {
+    setSelectedGroupIds((prev) => {
+      const valid = new Set(groups.map((g) => g.id))
+      const next = new Set([...prev].filter((id) => valid.has(id)))
+      return next.size === prev.size ? prev : next
+    })
+  }, [groups])
+
+  function toggleGroupSelection(groupId: string, checked: boolean) {
+    setSelectedGroupIds((prev) => {
+      const next = new Set(prev)
+      if (checked) next.add(groupId)
+      else next.delete(groupId)
+      return next
+    })
+  }
+
+  function startCompanyEdit(group: BulkImportGroupItem) {
+    setEditingCompanyId(group.id)
+    setCompanyDraft(group.companyName ?? '')
+  }
+
+  function commitCompanyEdit(groupId: string) {
+    setCompanyName(groupId, companyDraft)
+    setEditingCompanyId(null)
+    setCompanyDraft('')
+  }
+
+  function cancelCompanyEdit() {
+    setEditingCompanyId(null)
+    setCompanyDraft('')
+  }
+
+  function isGroupPreviewPending(group: BulkImportGroupItem) {
+    return group.files.some((file) => previewPendingFiles.has(file))
+  }
+
+  function handleFileChipDragStart(
+    event: DragEvent<HTMLDivElement>,
+    groupId: string,
+    fileIndex: number,
+    chipKey: string,
+  ) {
+    if (loading) {
+      event.preventDefault()
+      return
+    }
+    event.dataTransfer.setData(
+      BULK_IMPORT_FILE_DRAG_MIME,
+      JSON.stringify({ fromGroupId: groupId, fileIndex }),
+    )
+    event.dataTransfer.effectAllowed = 'move'
+    setDraggingFileKey(chipKey)
+  }
+
+  function handleDocumentsDragOver(event: DragEvent<HTMLDivElement>, groupId: string) {
+    event.preventDefault()
+    event.stopPropagation()
+    event.dataTransfer.dropEffect = 'move'
+    setDragOverGroupId(groupId)
+  }
+
+  function handleDocumentsDrop(event: DragEvent<HTMLDivElement>, toGroupId: string) {
+    event.preventDefault()
+    event.stopPropagation()
+    setDragOverGroupId(null)
+    setDraggingFileKey(null)
+
+    try {
+      const raw = event.dataTransfer.getData(BULK_IMPORT_FILE_DRAG_MIME)
+      if (!raw) return
+      const payload = JSON.parse(raw) as { fromGroupId: string; fileIndex: number }
+      if (!payload.fromGroupId || typeof payload.fileIndex !== 'number') return
+      moveFile(payload.fromGroupId, payload.fileIndex, toGroupId)
+    } catch {
+      // Ungültige Drag-Daten ignorieren
+    }
+  }
+
+  const handleImport = async () => {
+    const formData = new FormData()
+    formData.append(
+      'groups',
+      JSON.stringify(
+        groups.map((g) => ({
+          projectName: g.projectName,
+          companyName: g.companyName ?? '',
+          fileCount: g.files.length,
+        })),
+      ),
+    )
+    groups.forEach((g) => {
+      g.files.forEach((f) => formData.append('files', f))
+    })
+
+    onLoadingChange?.(true)
+    setExtractionProgress(null)
+    try {
+      const result = await bulkCreateReferencesFromFiles(formData)
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+
+      const ids = result.referenceIds
+      let organizationId =
+        'organizationId' in result ? String(result.organizationId ?? '') : ''
+      if (!organizationId) {
+        const supabase = createClient()
+        const {
+          data: { user },
+        } = await supabase.auth.getUser()
+        if (user) {
+          const { data: profile } = await supabase
+            .from('profiles')
+            .select('organization_id')
+            .eq('id', user.id)
+            .single()
+          organizationId = String(profile?.organization_id ?? '')
+        }
+      }
+
+      let uploadFailed = false
+      if (ids.length > 0 && organizationId) {
+        let refIdx = 0
+        for (const group of groups) {
+          const refId = ids[refIdx]
+          if (refId && group.files.length > 0) {
+            const upload = await uploadBulkImportFilesForReference(
+              organizationId,
+              refId,
+              group.files,
+            )
+            if (!upload.success) {
+              uploadFailed = true
+              toast.error(
+                upload.error ??
+                  `Datei für „${group.projectName}“ konnte nicht gespeichert werden.`,
+                { duration: 8000 },
+              )
+            }
+          }
+          refIdx += 1
+        }
+      }
+      if (uploadFailed) {
+        onLoadingChange?.(false)
+        setExtractionProgress(null)
+        router.refresh()
+        return
+      }
+
+      if (ids.length === 0) {
+        toast.error(
+          result.created === 0
+            ? 'Es wurde keine Referenz angelegt. Bitte Dateien prüfen.'
+            : 'Nach dem Import fehlten Referenz-IDs für die Extraktion.',
+        )
+        onOpenChange(false)
+        setGroups([])
+        router.refresh()
+        return
+      }
+      let completeCount = 0
+      const pendingReview: BulkImportReviewItem[] = []
+
+      for (let i = 0; i < ids.length; i++) {
+        setExtractionProgress({ current: i + 1, total: ids.length })
+        const id = ids[i]!
+        const primaryFile = groups[i]?.files[0]
+        let r: BulkImportExtractionResult
+        if (primaryFile && primaryFile.size > 0) {
+          r = await extractBulkImportReferenceFromFile(id, primaryFile)
+        } else {
+          r = await runBulkImportExtractionForReference(id)
+        }
+        if (!r.success) {
+          pendingReview.push({
+            referenceId: id,
+            title: 'Referenz',
+            needsInput: true,
+            extractionOk: false,
+            extractionError: r.error,
+            suggestions: {},
+          })
+          continue
+        }
+        if (!r.needsInput) completeCount++
+        const showReview =
+          r.needsInput ||
+          !r.extractionOk ||
+          Boolean(String(r.extractionError ?? '').trim())
+        if (showReview) {
+          pendingReview.push({
+            referenceId: r.referenceId,
+            title: r.title,
+            needsInput: r.needsInput,
+            extractionOk: r.extractionOk,
+            extractionError: r.extractionError,
+            suggestions: r.suggestions,
+          })
+        }
+      }
+
+      const needsMoreCount = ids.length - completeCount
+      if (needsMoreCount > 0) {
+        toast.success(
+          `${completeCount} Referenzen erfolgreich importiert, ${needsMoreCount} Referenzen benötigen weiteren Input.`,
+          { duration: 6500 },
+        )
+      } else {
+        toast.success(
+          `${completeCount} Referenz${completeCount !== 1 ? 'en' : ''} erfolgreich importiert.`,
+          { duration: 5000 },
+        )
+      }
+
+      onOpenChange(false)
+      setGroups([])
+      router.refresh()
+      setExtractionProgress(null)
+
+      if (pendingReview.length > 0) {
+        setReviewItems(pendingReview)
+        window.setTimeout(() => setReviewOpen(true), 400)
+      } else {
+        setReviewItems([])
+      }
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Import fehlgeschlagen.')
+    } finally {
+      onLoadingChange?.(false)
+    }
+  }
+
+  function mergeSelectedAndClear() {
+    mergeSelectedGroups(Array.from(selectedGroupIds))
+    setSelectedGroupIds(new Set())
+  }
+
+  return {
+    totalFiles,
+    hasFiles,
+    canMergeSelected,
+    reviewOpen,
+    setReviewOpen,
+    reviewItems,
+    extractionProgress,
+    selectedGroupIds,
+    editingCompanyId,
+    companyDraft,
+    setCompanyDraft,
+    dragOverGroupId,
+    setDragOverGroupId,
+    draggingFileKey,
+    setDraggingFileKey,
+    toggleGroupSelection,
+    startCompanyEdit,
+    commitCompanyEdit,
+    cancelCompanyEdit,
+    isGroupPreviewPending,
+    fileChipKey: bulkImportFileChipKey,
+    handleFileChipDragStart,
+    handleDocumentsDragOver,
+    handleDocumentsDrop,
+    handleImport,
+    mergeSelectedAndClear,
+  }
+}

--- a/app/dashboard/overview/use-references-overview-dialogs-state.tsx
+++ b/app/dashboard/overview/use-references-overview-dialogs-state.tsx
@@ -11,7 +11,7 @@ import {
   setBulkImportCompanyName as setBulkImportCompanyNameHelper,
   setBulkImportGroupName as setBulkImportGroupNameHelper,
 } from '@/app/dashboard/overview/bulk-import-file-helpers'
-import type { BulkImportGroupItem } from '@/app/dashboard/overview/bulk-import-dialog'
+import type { BulkImportGroupItem } from '@/app/dashboard/overview/bulk-import-types'
 import {
   ReferencesOverviewDialogs,
   type ReferencesOverviewDialogsProps,

--- a/docs/tech-debt-offen-backlog.md
+++ b/docs/tech-debt-offen-backlog.md
@@ -28,7 +28,7 @@
 | **2** | E7 Schema-Sync | ✅ T1–T4 | Types bei Migrationen regenerieren (`db:types`) | XS ongoing | bei Schema-Change |
 | **3** | Typed-Supabase Cast-Abbau | ✅ T1–T4 | Rest-Casts nur Boundaries (HTTP/RPC/Json); Boy-Scout bei Touch | — | CI: `typecheck` vor Build |
 | **4** | P1-6 Accounts Naming | ✅ App/Lib | DB-Tabelle `companies` / `company_id` / Firmennamen-Helfer **bewusst offen** | — | nicht anfassen ohne Produktentscheid |
-| **5** | God-File-Nacharbeit | Slice 1–6 ✅ | Detail-Sheet, Readiness, sharing, overview-Hooks, watchlist, compliance-bulk-upload | M ongoing | nächster: bulk-import / deals-client / deal-documents |
+| **5** | God-File-Nacharbeit | Slice 1–7 ✅ | … + compliance-bulk-upload, bulk-import-dialog | M ongoing | nächster: deal-documents / deals-client / nda-popover |
 | **6** | `{ ok }` → `{ success }` | Lib ✅ | Slices 1–4; Rest nur Cron/Push-HTTP-Body | XS | Cron/Push separat wenn Monitoring-Clients ok |
 | **7** | P3-3 DE/EN-Dateinamen | ✅ Slice | `ai-draft-*`, `customer-control-link-email`; API `/api/ai-draft` + Redirect; UI-Copy „Sperrlink“/Event `ki_entwurf_generated` bleiben | — | Rest nur bei Touch |
 | **8** | `references`/`evidence` Pfade | ✅ | App = `references` (Routen/Ordner/`ROUTES`); Redirects `/dashboard/evidence` bleiben; `evidence_events` bleibt | — | Rest-`evidence` nur Domänenbegriff (RFP-Belege) |


### PR DESCRIPTION
## Summary
- Split `bulk-import-dialog.tsx` (~675 → ~159 orchestrator) into types, `useBulkImportDialog`, dropzone, groups panel, and footer
- Group file helpers now import types from `bulk-import-types` (dialog still re-exports `BulkImportGroupItem`)
- Behavior unchanged (preview pending, DnD, merge, create + upload + extract + review dialog)

## Test plan
- [ ] Overview: open bulk import, drop/add files, auto-group toast
- [ ] Edit company inline, edit title, suspicious-title warning
- [ ] Drag chips between groups; select + merge; remove chip
- [ ] Import starten → progress → success toast; review dialog if needed
- [ ] Max-files cap still enforced


Made with [Cursor](https://cursor.com)