### PR TITLE
refactor(#5): split deal documents section (slice 8)

### DIFF
--- a/app/dashboard/deals/cockpit/deal-document-delete-dialog.tsx
+++ b/app/dashboard/deals/cockpit/deal-document-delete-dialog.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { COPY } from '@/lib/copy'
+
+export function DealDocumentDeleteDialog({
+  open,
+  fileName,
+  pending,
+  onClose,
+  onConfirm,
+}: {
+  open: boolean
+  fileName: string
+  pending: boolean
+  onClose: () => void
+  onConfirm: () => void
+}) {
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onClose()
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{COPY.deals.cockpit.documentsDeleteConfirm}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {fileName} wird aus dem Deal und dem Speicher entfernt.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={pending}>Abbrechen</AlertDialogCancel>
+          <AlertDialogAction
+            disabled={pending}
+            onClick={(e) => {
+              e.preventDefault()
+              onConfirm()
+            }}
+          >
+            {pending ? 'Löschen …' : 'Löschen'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/app/dashboard/deals/cockpit/deal-document-dropzone.tsx
+++ b/app/dashboard/deals/cockpit/deal-document-dropzone.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import { useRef, useState } from 'react'
+import { UploadIcon } from '@hugeicons/core-free-icons'
+import { toast } from 'sonner'
+
+import { AppIcon } from '@/lib/icons'
+import { COPY } from '@/lib/copy'
+import { cn } from '@/lib/utils'
+import type { DealDocumentKind } from '@/lib/deals/deal-document-kinds'
+import { validateDealDocumentUpload } from '@/lib/deals/deal-document-upload'
+
+import { formatDealDocumentFileSize } from './deal-document-format'
+
+export function DealDocumentDropzone({
+  file,
+  kind,
+  onFileChange,
+  disabled,
+}: {
+  file: File | null
+  kind: DealDocumentKind
+  onFileChange: (file: File | null) => void
+  disabled?: boolean
+}) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [dragOver, setDragOver] = useState(false)
+
+  function acceptFile(next: File | undefined) {
+    if (!next) return
+    const validation = validateDealDocumentUpload(next, kind)
+    if (!validation.success) {
+      toast.error(validation.error)
+      return
+    }
+    onFileChange(next)
+  }
+
+  return (
+    <div
+      role="button"
+      tabIndex={disabled ? -1 : 0}
+      aria-disabled={disabled}
+      className={cn(
+        'w-full rounded-lg border-2 border-dashed px-4 py-6 text-center transition-colors',
+        dragOver && !disabled
+          ? 'border-primary/50 bg-muted/60'
+          : 'border-border bg-muted/30',
+        disabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer hover:bg-muted/50',
+      )}
+      onClick={() => !disabled && inputRef.current?.click()}
+      onKeyDown={(e) => {
+        if (disabled) return
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          inputRef.current?.click()
+        }
+      }}
+      onDragEnter={(e) => {
+        e.preventDefault()
+        if (!disabled) setDragOver(true)
+      }}
+      onDragOver={(e) => {
+        e.preventDefault()
+        if (!disabled) setDragOver(true)
+      }}
+      onDragLeave={(e) => {
+        e.preventDefault()
+        setDragOver(false)
+      }}
+      onDrop={(e) => {
+        e.preventDefault()
+        setDragOver(false)
+        if (disabled) return
+        acceptFile(e.dataTransfer.files?.[0])
+      }}
+    >
+      {file ? (
+        <div className="space-y-1">
+          <p className="text-sm font-medium">{file.name}</p>
+          <p className="text-xs text-muted-foreground">
+            {formatDealDocumentFileSize(file.size)} ·{' '}
+            {COPY.deals.cockpit.documentsDropzoneReplace}
+          </p>
+        </div>
+      ) : (
+        <div className="flex flex-col items-center gap-2 text-sm text-muted-foreground">
+          <AppIcon icon={UploadIcon} size={20} />
+          {COPY.deals.cockpit.documentsDropzoneHint}
+        </div>
+      )}
+      <input
+        ref={inputRef}
+        type="file"
+        className="sr-only"
+        disabled={disabled}
+        onChange={(e) => {
+          acceptFile(e.target.files?.[0])
+          e.target.value = ''
+        }}
+      />
+    </div>
+  )
+}

--- a/app/dashboard/deals/cockpit/deal-document-format.ts
+++ b/app/dashboard/deals/cockpit/deal-document-format.ts
@@ -1,0 +1,18 @@
+export function formatDealDocumentFileSize(bytes: number | null): string {
+  if (bytes == null || bytes <= 0) return '—'
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`
+}
+
+export function formatDealDocumentUploadedAt(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return '—'
+  return d.toLocaleString('de-DE', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}

--- a/app/dashboard/deals/cockpit/deal-document-kind-select.tsx
+++ b/app/dashboard/deals/cockpit/deal-document-kind-select.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  DEAL_DOCUMENT_KINDS,
+  DEAL_DOCUMENT_KIND_LABELS,
+  type DealDocumentKind,
+} from '@/lib/deals/deal-document-kinds'
+
+export function DealDocumentKindSelect({
+  value,
+  onValueChange,
+  id,
+}: {
+  value: DealDocumentKind
+  onValueChange: (v: DealDocumentKind) => void
+  id?: string
+}) {
+  return (
+    <Select value={value} onValueChange={(v) => onValueChange(v as DealDocumentKind)}>
+      <SelectTrigger id={id}>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {DEAL_DOCUMENT_KINDS.map((kind) => (
+          <SelectItem key={kind} value={kind}>
+            {DEAL_DOCUMENT_KIND_LABELS[kind]}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}

--- a/app/dashboard/deals/cockpit/deal-document-rename-dialog.tsx
+++ b/app/dashboard/deals/cockpit/deal-document-rename-dialog.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { COPY } from '@/lib/copy'
+
+export function DealDocumentRenameDialog({
+  open,
+  value,
+  pending,
+  onValueChange,
+  onClose,
+  onSubmit,
+}: {
+  open: boolean
+  value: string
+  pending: boolean
+  onValueChange: (value: string) => void
+  onClose: () => void
+  onSubmit: () => void
+}) {
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onClose()
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{COPY.deals.cockpit.documentsRenameTitle}</DialogTitle>
+        </DialogHeader>
+        <Input value={value} onChange={(e) => onValueChange(e.target.value)} autoFocus />
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={onClose}>
+            Abbrechen
+          </Button>
+          <Button
+            type="button"
+            onClick={onSubmit}
+            disabled={pending || !value.trim()}
+          >
+            {pending ? 'Speichern …' : 'Speichern'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/app/dashboard/deals/cockpit/deal-document-row.tsx
+++ b/app/dashboard/deals/cockpit/deal-document-row.tsx
@@ -1,0 +1,143 @@
+'use client'
+
+import { Loader, MoreHorizontal } from '@hugeicons/core-free-icons'
+import { Download, Trash2 } from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { AppIcon } from '@/lib/icons'
+import { COPY } from '@/lib/copy'
+import {
+  DEAL_DOCUMENT_KINDS,
+  DEAL_DOCUMENT_KIND_LABELS,
+  type DealDocumentKind,
+} from '@/lib/deals/deal-document-kinds'
+
+import type { DealDocumentRow as DealDocumentRowType } from '../document-actions'
+import {
+  formatDealDocumentFileSize,
+  formatDealDocumentUploadedAt,
+} from './deal-document-format'
+
+export function DealDocumentRow({
+  doc,
+  canManage,
+  isRfpMode,
+  analyzingId,
+  downloadPendingId,
+  onAnalyze,
+  onDownload,
+  onRenameRequest,
+  onKindChange,
+  onDeleteRequest,
+}: {
+  doc: DealDocumentRowType
+  canManage: boolean
+  isRfpMode: boolean
+  analyzingId: string | null
+  downloadPendingId: string | null
+  onAnalyze: (doc: DealDocumentRowType) => void
+  onDownload: (doc: DealDocumentRowType) => void
+  onRenameRequest: (doc: DealDocumentRowType) => void
+  onKindChange: (doc: DealDocumentRowType, kind: DealDocumentKind) => void
+  onDeleteRequest: (doc: DealDocumentRowType) => void
+}) {
+  return (
+    <li className="flex flex-wrap items-center gap-3 py-3 first:pt-0 last:pb-0">
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="truncate text-sm font-medium">{doc.file_name}</span>
+          <Badge variant="secondary">{DEAL_DOCUMENT_KIND_LABELS[doc.kind]}</Badge>
+        </div>
+        <p className="mt-0.5 text-xs text-muted-foreground">
+          {formatDealDocumentFileSize(doc.size_bytes)}
+          {doc.uploaded_by_name ? ` · ${doc.uploaded_by_name}` : ''}
+          {` · ${formatDealDocumentUploadedAt(doc.created_at)}`}
+        </p>
+      </div>
+      <div className="flex flex-wrap items-center gap-1">
+        {canManage && !isRfpMode && doc.kind === 'ausschreibung' ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={analyzingId === doc.id}
+            onClick={() => onAnalyze(doc)}
+          >
+            {analyzingId === doc.id ? (
+              <>
+                <AppIcon icon={Loader} size={14} className="mr-1 animate-spin" />
+                {COPY.deals.cockpit.documentsAnalyzePending}
+              </>
+            ) : (
+              COPY.deals.cockpit.documentsAnalyze
+            )}
+          </Button>
+        ) : null}
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          disabled={downloadPendingId === doc.id}
+          onClick={() => onDownload(doc)}
+        >
+          {downloadPendingId === doc.id ? (
+            <AppIcon icon={Loader} size={16} className="animate-spin" />
+          ) : (
+            <Download className="size-4" />
+          )}
+          <span className="sr-only">{COPY.deals.cockpit.documentsDownload}</span>
+        </Button>
+        {canManage ? (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button type="button" variant="ghost" size="icon" className="size-8">
+                <AppIcon icon={MoreHorizontal} size={16} />
+                <span className="sr-only">Aktionen</span>
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onSelect={() => onRenameRequest(doc)}>
+                {COPY.deals.cockpit.documentsRename}
+              </DropdownMenuItem>
+              <DropdownMenuSub>
+                <DropdownMenuSubTrigger>
+                  {COPY.deals.cockpit.documentsChangeKind}
+                </DropdownMenuSubTrigger>
+                <DropdownMenuSubContent>
+                  {DEAL_DOCUMENT_KINDS.map((kind) => (
+                    <DropdownMenuItem
+                      key={kind}
+                      disabled={kind === doc.kind}
+                      onSelect={() => onKindChange(doc, kind)}
+                    >
+                      {DEAL_DOCUMENT_KIND_LABELS[kind]}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                className="text-destructive focus:text-destructive"
+                onSelect={() => onDeleteRequest(doc)}
+              >
+                <Trash2 className="mr-2 size-4" />
+                {COPY.deals.cockpit.documentsDelete}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ) : null}
+      </div>
+    </li>
+  )
+}

--- a/app/dashboard/deals/cockpit/deal-document-upload-dialog.tsx
+++ b/app/dashboard/deals/cockpit/deal-document-upload-dialog.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { Loader } from '@hugeicons/core-free-icons'
+import { toast } from 'sonner'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Label } from '@/components/ui/label'
+import { AppIcon } from '@/lib/icons'
+import { COPY } from '@/lib/copy'
+import type { DealDocumentKind } from '@/lib/deals/deal-document-kinds'
+import { validateDealDocumentUpload } from '@/lib/deals/deal-document-upload'
+
+import { DealDocumentDropzone } from './deal-document-dropzone'
+import { DealDocumentKindSelect } from './deal-document-kind-select'
+
+export function DealDocumentUploadDialog({
+  open,
+  onOpenChange,
+  kind,
+  onKindChange,
+  file,
+  onFileChange,
+  uploading,
+  onSubmit,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  kind: DealDocumentKind
+  onKindChange: (kind: DealDocumentKind) => void
+  file: File | null
+  onFileChange: (file: File | null) => void
+  uploading: boolean
+  onSubmit: () => void
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{COPY.deals.cockpit.documentsUploadTitle}</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="deal-doc-kind">{COPY.deals.cockpit.documentsKindLabel}</Label>
+            <DealDocumentKindSelect
+              id="deal-doc-kind"
+              value={kind}
+              onValueChange={(nextKind) => {
+                onKindChange(nextKind)
+                if (file) {
+                  const validation = validateDealDocumentUpload(file, nextKind)
+                  if (!validation.success) {
+                    toast.error(validation.error)
+                    onFileChange(null)
+                  }
+                }
+              }}
+            />
+          </div>
+          <DealDocumentDropzone
+            file={file}
+            kind={kind}
+            disabled={uploading}
+            onFileChange={onFileChange}
+          />
+        </div>
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Abbrechen
+          </Button>
+          <Button type="button" onClick={onSubmit} disabled={uploading || !file}>
+            {uploading ? (
+              <>
+                <AppIcon icon={Loader} size={16} className="mr-1 animate-spin" />
+                Wird hochgeladen …
+              </>
+            ) : (
+              COPY.deals.cockpit.documentsUpload
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/app/dashboard/deals/cockpit/deal-documents-list.tsx
+++ b/app/dashboard/deals/cockpit/deal-documents-list.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import { COPY } from '@/lib/copy'
+import type { DealDocumentKind } from '@/lib/deals/deal-document-kinds'
+
+import type { DealDocumentRow as DealDocumentRowType } from '../document-actions'
+import { DealDocumentRow } from './deal-document-row'
+import { DealRfpAnalyzeButton } from './deal-rfp-analyze-button'
+
+export function DealDocumentsList({
+  dealId,
+  documents,
+  canManage,
+  isRfpMode,
+  rfpHasAnalysis,
+  rfpAnalysisStale,
+  analyzingId,
+  downloadPendingId,
+  onAnalyze,
+  onDownload,
+  onRenameRequest,
+  onKindChange,
+  onDeleteRequest,
+  onAnalyzed,
+}: {
+  dealId: string
+  documents: DealDocumentRowType[]
+  canManage: boolean
+  isRfpMode: boolean
+  rfpHasAnalysis: boolean
+  rfpAnalysisStale: boolean
+  analyzingId: string | null
+  downloadPendingId: string | null
+  onAnalyze: (doc: DealDocumentRowType) => void
+  onDownload: (doc: DealDocumentRowType) => void
+  onRenameRequest: (doc: DealDocumentRowType) => void
+  onKindChange: (doc: DealDocumentRowType, kind: DealDocumentKind) => void
+  onDeleteRequest: (doc: DealDocumentRowType) => void
+  onAnalyzed: () => void
+}) {
+  return (
+    <>
+      <ul className="divide-y divide-border pl-7">
+        {documents.map((doc) => (
+          <DealDocumentRow
+            key={doc.id}
+            doc={doc}
+            canManage={canManage}
+            isRfpMode={isRfpMode}
+            analyzingId={analyzingId}
+            downloadPendingId={downloadPendingId}
+            onAnalyze={onAnalyze}
+            onDownload={onDownload}
+            onRenameRequest={onRenameRequest}
+            onKindChange={onKindChange}
+            onDeleteRequest={onDeleteRequest}
+          />
+        ))}
+      </ul>
+      {isRfpMode && canManage ? (
+        <div className="mt-4 flex flex-col gap-2 border-t border-border pt-4 pl-7 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-xs text-muted-foreground">
+            {COPY.deals.cockpit.documentsAnalyzeReadyHint}
+          </p>
+          <DealRfpAnalyzeButton
+            dealId={dealId}
+            documents={documents}
+            canManage={canManage}
+            hasAnalysis={rfpHasAnalysis}
+            isStale={rfpAnalysisStale}
+            variant="default"
+            className="shrink-0"
+            onAnalyzed={onAnalyzed}
+          />
+        </div>
+      ) : null}
+    </>
+  )
+}

--- a/app/dashboard/deals/cockpit/deal-documents-section.tsx
+++ b/app/dashboard/deals/cockpit/deal-documents-section.tsx
@@ -1,28 +1,10 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import {
-  ArrowRight01Icon,
-  CirclePlus,
-  Loader,
-  MoreHorizontal,
-  UploadIcon,
-} from '@hugeicons/core-free-icons'
-import { Download, Trash2 } from 'lucide-react'
+import { ArrowRight01Icon, CirclePlus } from '@hugeicons/core-free-icons'
 import { toast } from 'sonner'
 
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog'
-import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import {
@@ -30,41 +12,10 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from '@/components/ui/collapsible'
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
 import { AppIcon } from '@/lib/icons'
 import { COPY } from '@/lib/copy'
 import { cn } from '@/lib/utils'
-import {
-  DEAL_DOCUMENT_KINDS,
-  DEAL_DOCUMENT_KIND_LABELS,
-  type DealDocumentKind,
-} from '@/lib/deals/deal-document-kinds'
-import { validateDealDocumentUpload } from '@/lib/deals/deal-document-upload'
+import type { DealDocumentKind } from '@/lib/deals/deal-document-kinds'
 
 import type { DealDocumentRow } from '../document-actions'
 import {
@@ -74,142 +25,12 @@ import {
   setDealDocumentKind,
   uploadDealDocument,
 } from '../document-actions'
-import { DealRfpAnalyzeButton, runDealRfpAnalyze } from './deal-rfp-analyze-button'
+import { DealDocumentDeleteDialog } from './deal-document-delete-dialog'
+import { DealDocumentRenameDialog } from './deal-document-rename-dialog'
+import { DealDocumentUploadDialog } from './deal-document-upload-dialog'
+import { DealDocumentsList } from './deal-documents-list'
+import { runDealRfpAnalyze } from './deal-rfp-analyze-button'
 import { useDealReferenceSuggestionsRefresh } from './deal-reference-suggestions-refresh'
-
-function formatFileSize(bytes: number | null): string {
-  if (bytes == null || bytes <= 0) return '—'
-  if (bytes < 1024) return `${bytes} B`
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
-  return `${(bytes / 1024 / 1024).toFixed(1)} MB`
-}
-
-function formatUploadedAt(iso: string): string {
-  const d = new Date(iso)
-  if (Number.isNaN(d.getTime())) return '—'
-  return d.toLocaleString('de-DE', {
-    day: '2-digit',
-    month: '2-digit',
-    year: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  })
-}
-
-function KindSelect({
-  value,
-  onValueChange,
-  id,
-}: {
-  value: DealDocumentKind
-  onValueChange: (v: DealDocumentKind) => void
-  id?: string
-}) {
-  return (
-    <Select value={value} onValueChange={(v) => onValueChange(v as DealDocumentKind)}>
-      <SelectTrigger id={id}>
-        <SelectValue />
-      </SelectTrigger>
-      <SelectContent>
-        {DEAL_DOCUMENT_KINDS.map((kind) => (
-          <SelectItem key={kind} value={kind}>
-            {DEAL_DOCUMENT_KIND_LABELS[kind]}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
-  )
-}
-
-function DocumentDropzone({
-  file,
-  kind,
-  onFileChange,
-  disabled,
-}: {
-  file: File | null
-  kind: DealDocumentKind
-  onFileChange: (file: File | null) => void
-  disabled?: boolean
-}) {
-  const inputRef = useRef<HTMLInputElement>(null)
-  const [dragOver, setDragOver] = useState(false)
-
-  function acceptFile(next: File | undefined) {
-    if (!next) return
-    const validation = validateDealDocumentUpload(next, kind)
-    if (!validation.success) {
-      toast.error(validation.error)
-      return
-    }
-    onFileChange(next)
-  }
-
-  return (
-    <div
-      role="button"
-      tabIndex={disabled ? -1 : 0}
-      aria-disabled={disabled}
-      className={cn(
-        'w-full rounded-lg border-2 border-dashed px-4 py-6 text-center transition-colors',
-        dragOver && !disabled
-          ? 'border-primary/50 bg-muted/60'
-          : 'border-border bg-muted/30',
-        disabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer hover:bg-muted/50',
-      )}
-      onClick={() => !disabled && inputRef.current?.click()}
-      onKeyDown={(e) => {
-        if (disabled) return
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault()
-          inputRef.current?.click()
-        }
-      }}
-      onDragEnter={(e) => {
-        e.preventDefault()
-        if (!disabled) setDragOver(true)
-      }}
-      onDragOver={(e) => {
-        e.preventDefault()
-        if (!disabled) setDragOver(true)
-      }}
-      onDragLeave={(e) => {
-        e.preventDefault()
-        setDragOver(false)
-      }}
-      onDrop={(e) => {
-        e.preventDefault()
-        setDragOver(false)
-        if (disabled) return
-        acceptFile(e.dataTransfer.files?.[0])
-      }}
-    >
-      {file ? (
-        <div className="space-y-1">
-          <p className="text-sm font-medium">{file.name}</p>
-          <p className="text-xs text-muted-foreground">
-            {formatFileSize(file.size)} · {COPY.deals.cockpit.documentsDropzoneReplace}
-          </p>
-        </div>
-      ) : (
-        <div className="flex flex-col items-center gap-2 text-sm text-muted-foreground">
-          <AppIcon icon={UploadIcon} size={20} />
-          {COPY.deals.cockpit.documentsDropzoneHint}
-        </div>
-      )}
-      <input
-        ref={inputRef}
-        type="file"
-        className="sr-only"
-        disabled={disabled}
-        onChange={(e) => {
-          acceptFile(e.target.files?.[0])
-          e.target.value = ''
-        }}
-      />
-    </div>
-  )
-}
 
 export function DealDocumentsSection({
   dealId,
@@ -405,255 +226,58 @@ export function DealDocumentsSection({
           ) : (
             <CollapsibleContent>
               <CardContent className="pt-0">
-                <ul className="divide-y divide-border pl-7">
-                  {documents.map((doc) => (
-                    <li
-                      key={doc.id}
-                      className="flex flex-wrap items-center gap-3 py-3 first:pt-0 last:pb-0"
-                    >
-                      <div className="min-w-0 flex-1">
-                        <div className="flex flex-wrap items-center gap-2">
-                          <span className="truncate text-sm font-medium">
-                            {doc.file_name}
-                          </span>
-                          <Badge variant="secondary">
-                            {DEAL_DOCUMENT_KIND_LABELS[doc.kind]}
-                          </Badge>
-                        </div>
-                        <p className="mt-0.5 text-xs text-muted-foreground">
-                          {formatFileSize(doc.size_bytes)}
-                          {doc.uploaded_by_name ? ` · ${doc.uploaded_by_name}` : ''}
-                          {` · ${formatUploadedAt(doc.created_at)}`}
-                        </p>
-                      </div>
-                      <div className="flex flex-wrap items-center gap-1">
-                        {canManage && !isRfpMode && doc.kind === 'ausschreibung' ? (
-                          <Button
-                            type="button"
-                            variant="outline"
-                            size="sm"
-                            disabled={analyzingId === doc.id}
-                            onClick={() => void handleAnalyze(doc)}
-                          >
-                            {analyzingId === doc.id ? (
-                              <>
-                                <AppIcon
-                                  icon={Loader}
-                                  size={14}
-                                  className="mr-1 animate-spin"
-                                />
-                                {COPY.deals.cockpit.documentsAnalyzePending}
-                              </>
-                            ) : (
-                              COPY.deals.cockpit.documentsAnalyze
-                            )}
-                          </Button>
-                        ) : null}
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          disabled={downloadPendingId === doc.id}
-                          onClick={() => handleDownload(doc)}
-                        >
-                          {downloadPendingId === doc.id ? (
-                            <AppIcon icon={Loader} size={16} className="animate-spin" />
-                          ) : (
-                            <Download className="size-4" />
-                          )}
-                          <span className="sr-only">
-                            {COPY.deals.cockpit.documentsDownload}
-                          </span>
-                        </Button>
-                        {canManage ? (
-                          <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                              <Button
-                                type="button"
-                                variant="ghost"
-                                size="icon"
-                                className="size-8"
-                              >
-                                <AppIcon icon={MoreHorizontal} size={16} />
-                                <span className="sr-only">Aktionen</span>
-                              </Button>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end">
-                              <DropdownMenuItem
-                                onSelect={() => {
-                                  setRenameTarget(doc)
-                                  setRenameValue(doc.file_name)
-                                }}
-                              >
-                                {COPY.deals.cockpit.documentsRename}
-                              </DropdownMenuItem>
-                              <DropdownMenuSub>
-                                <DropdownMenuSubTrigger>
-                                  {COPY.deals.cockpit.documentsChangeKind}
-                                </DropdownMenuSubTrigger>
-                                <DropdownMenuSubContent>
-                                  {DEAL_DOCUMENT_KINDS.map((kind) => (
-                                    <DropdownMenuItem
-                                      key={kind}
-                                      disabled={kind === doc.kind}
-                                      onSelect={() => handleKindChange(doc, kind)}
-                                    >
-                                      {DEAL_DOCUMENT_KIND_LABELS[kind]}
-                                    </DropdownMenuItem>
-                                  ))}
-                                </DropdownMenuSubContent>
-                              </DropdownMenuSub>
-                              <DropdownMenuSeparator />
-                              <DropdownMenuItem
-                                className="text-destructive focus:text-destructive"
-                                onSelect={() => setDeleteTarget(doc)}
-                              >
-                                <Trash2 className="mr-2 size-4" />
-                                {COPY.deals.cockpit.documentsDelete}
-                              </DropdownMenuItem>
-                            </DropdownMenuContent>
-                          </DropdownMenu>
-                        ) : null}
-                      </div>
-                    </li>
-                  ))}
-                </ul>
-                {isRfpMode && canManage ? (
-                  <div className="mt-4 flex flex-col gap-2 border-t border-border pt-4 pl-7 sm:flex-row sm:items-center sm:justify-between">
-                    <p className="text-xs text-muted-foreground">
-                      {COPY.deals.cockpit.documentsAnalyzeReadyHint}
-                    </p>
-                    <DealRfpAnalyzeButton
-                      dealId={dealId}
-                      documents={documents}
-                      canManage={canManage}
-                      hasAnalysis={rfpHasAnalysis}
-                      isStale={rfpAnalysisStale}
-                      variant="default"
-                      className="shrink-0"
-                      onAnalyzed={() => void refreshReferenceSuggestions?.()}
-                    />
-                  </div>
-                ) : null}
+                <DealDocumentsList
+                  dealId={dealId}
+                  documents={documents}
+                  canManage={canManage}
+                  isRfpMode={isRfpMode}
+                  rfpHasAnalysis={rfpHasAnalysis}
+                  rfpAnalysisStale={rfpAnalysisStale}
+                  analyzingId={analyzingId}
+                  downloadPendingId={downloadPendingId}
+                  onAnalyze={(doc) => void handleAnalyze(doc)}
+                  onDownload={(doc) => void handleDownload(doc)}
+                  onRenameRequest={(doc) => {
+                    setRenameTarget(doc)
+                    setRenameValue(doc.file_name)
+                  }}
+                  onKindChange={(doc, kind) => void handleKindChange(doc, kind)}
+                  onDeleteRequest={setDeleteTarget}
+                  onAnalyzed={() => void refreshReferenceSuggestions?.()}
+                />
               </CardContent>
             </CollapsibleContent>
           )}
         </Collapsible>
       </Card>
 
-      <Dialog open={uploadOpen} onOpenChange={setUploadOpen}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>{COPY.deals.cockpit.documentsUploadTitle}</DialogTitle>
-          </DialogHeader>
-          <div className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="deal-doc-kind">
-                {COPY.deals.cockpit.documentsKindLabel}
-              </Label>
-              <KindSelect
-                id="deal-doc-kind"
-                value={uploadKind}
-                onValueChange={(kind) => {
-                  setUploadKind(kind)
-                  if (uploadFile) {
-                    const validation = validateDealDocumentUpload(uploadFile, kind)
-                    if (!validation.success) {
-                      toast.error(validation.error)
-                      setUploadFile(null)
-                    }
-                  }
-                }}
-              />
-            </div>
-            <DocumentDropzone
-              file={uploadFile}
-              kind={uploadKind}
-              disabled={uploading}
-              onFileChange={setUploadFile}
-            />
-          </div>
-          <DialogFooter>
-            <Button type="button" variant="outline" onClick={() => setUploadOpen(false)}>
-              Abbrechen
-            </Button>
-            <Button
-              type="button"
-              onClick={handleUpload}
-              disabled={uploading || !uploadFile}
-            >
-              {uploading ? (
-                <>
-                  <AppIcon icon={Loader} size={16} className="mr-1 animate-spin" />
-                  Wird hochgeladen …
-                </>
-              ) : (
-                COPY.deals.cockpit.documentsUpload
-              )}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <DealDocumentUploadDialog
+        open={uploadOpen}
+        onOpenChange={setUploadOpen}
+        kind={uploadKind}
+        onKindChange={setUploadKind}
+        file={uploadFile}
+        onFileChange={setUploadFile}
+        uploading={uploading}
+        onSubmit={() => void handleUpload()}
+      />
 
-      <Dialog
+      <DealDocumentRenameDialog
         open={renameTarget != null}
-        onOpenChange={(open) => {
-          if (!open) setRenameTarget(null)
-        }}
-      >
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>{COPY.deals.cockpit.documentsRenameTitle}</DialogTitle>
-          </DialogHeader>
-          <Input
-            value={renameValue}
-            onChange={(e) => setRenameValue(e.target.value)}
-            autoFocus
-          />
-          <DialogFooter>
-            <Button type="button" variant="outline" onClick={() => setRenameTarget(null)}>
-              Abbrechen
-            </Button>
-            <Button
-              type="button"
-              onClick={handleRename}
-              disabled={renamePending || !renameValue.trim()}
-            >
-              {renamePending ? 'Speichern …' : 'Speichern'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+        value={renameValue}
+        pending={renamePending}
+        onValueChange={setRenameValue}
+        onClose={() => setRenameTarget(null)}
+        onSubmit={() => void handleRename()}
+      />
 
-      <AlertDialog
+      <DealDocumentDeleteDialog
         open={deleteTarget != null}
-        onOpenChange={(open) => {
-          if (!open) setDeleteTarget(null)
-        }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>
-              {COPY.deals.cockpit.documentsDeleteConfirm}
-            </AlertDialogTitle>
-            <AlertDialogDescription>
-              {deleteTarget?.file_name ?? ''} wird aus dem Deal und dem Speicher entfernt.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={deletePending}>Abbrechen</AlertDialogCancel>
-            <AlertDialogAction
-              disabled={deletePending}
-              onClick={(e) => {
-                e.preventDefault()
-                void handleDelete()
-              }}
-            >
-              {deletePending ? 'Löschen …' : 'Löschen'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        fileName={deleteTarget?.file_name ?? ''}
+        pending={deletePending}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={() => void handleDelete()}
+      />
     </>
   )
 }

--- a/docs/tech-debt-offen-backlog.md
+++ b/docs/tech-debt-offen-backlog.md
@@ -28,7 +28,7 @@
 | **2** | E7 Schema-Sync | ✅ T1–T4 | Types bei Migrationen regenerieren (`db:types`) | XS ongoing | bei Schema-Change |
 | **3** | Typed-Supabase Cast-Abbau | ✅ T1–T4 | Rest-Casts nur Boundaries (HTTP/RPC/Json); Boy-Scout bei Touch | — | CI: `typecheck` vor Build |
 | **4** | P1-6 Accounts Naming | ✅ App/Lib | DB-Tabelle `companies` / `company_id` / Firmennamen-Helfer **bewusst offen** | — | nicht anfassen ohne Produktentscheid |
-| **5** | God-File-Nacharbeit | Slice 1–7 ✅ | … + compliance-bulk-upload, bulk-import-dialog | M ongoing | nächster: deal-documents / deals-client / nda-popover |
+| **5** | God-File-Nacharbeit | Slice 1–8 ✅ | … + bulk-import, deal-documents-section | M ongoing | nächster: deals-client / nda-popover |
 | **6** | `{ ok }` → `{ success }` | Lib ✅ | Slices 1–4; Rest nur Cron/Push-HTTP-Body | XS | Cron/Push separat wenn Monitoring-Clients ok |
 | **7** | P3-3 DE/EN-Dateinamen | ✅ Slice | `ai-draft-*`, `customer-control-link-email`; API `/api/ai-draft` + Redirect; UI-Copy „Sperrlink“/Event `ki_entwurf_generated` bleiben | — | Rest nur bei Touch |
 | **8** | `references`/`evidence` Pfade | ✅ | App = `references` (Routen/Ordner/`ROUTES`); Redirects `/dashboard/evidence` bleiben; `evidence_events` bleibt | — | Rest-`evidence` nur Domänenbegriff (RFP-Belege) |


### PR DESCRIPTION
## Summary
- Split `deal-documents-section.tsx` (~659 → ~283 orchestrator) into format helpers, kind select, dropzone, upload/rename/delete dialogs, row, and list
- Public API `DealDocumentsSection` unchanged
- Behavior unchanged (upload/validate, analyze, download, rename, kind change, delete, RFP footer)

## Test plan
- [ ] Deal cockpit: expand documents, download, open ⋯ menu
- [ ] Upload dialog: kind + dropzone validation, upload success
- [ ] Rename / change kind / delete confirm
- [ ] Non-RFP: analyze button on ausschreibung docs
- [ ] RFP mode: analyze footer with DealRfpAnalyzeButton


Made with [Cursor](https://cursor.com)