### PR TITLE
refactor(#5): split deals client (slice 9)

### DIFF
--- a/app/dashboard/deals/deals-client.tsx
+++ b/app/dashboard/deals/deals-client.tsx
@@ -1,35 +1,17 @@
 'use client'
 
-import { useEffect, useMemo, useRef, useState, useCallback } from 'react'
+import { useMemo, useRef, useState, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
-import { Button } from '@/components/ui/button'
-import { ToolbarSearchField } from '@/components/ui/toolbar-search-field'
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
-import type { DealRow, DealStatus } from './types'
-import { DealForm } from './new/deal-form'
-import { importDealsFromXlsx } from './actions'
 import { CirclePlus, Loader, UploadIcon } from '@hugeicons/core-free-icons'
+import { ExternalLink, FolderOpen } from 'lucide-react'
 import { toast } from 'sonner'
+
+import { CrmImportPreviewDialog } from '@/app/dashboard/accounts/components/crm-import-preview-dialog'
+import { AccountsToolbarTooltip } from '@/app/dashboard/accounts/components/accounts-toolbar-tooltip'
+import { CrmOnboardingEmptyState } from '@/app/dashboard/components/crm-onboarding-empty-state'
+import { TableBulkActionsBar } from '@/components/table/table-bulk-actions-bar'
 import { AppDataTable } from '@/components/ui/app-data-table'
-import type { ColumnDef } from '@tanstack/react-table'
-import { TableRowCheckbox } from '@/components/table/table-row-checkbox'
-import { AppIcon } from '@/lib/icons'
-import { DealStatusBadge } from '@/components/deal-status-badge'
-import { MatchScoreCircle } from '@/components/match/match-score-circle'
-import { getMatchStrength } from '@/lib/match/match-strength'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
-import { COPY } from '@/lib/copy'
-import { formatDealVolume } from '@/lib/format'
-import { ROUTES } from '@/lib/routes'
-import { TableAccountLinkContent } from '@/components/table/table-account-link-content'
-import { TableRowAlign } from '@/components/table/table-row-align'
-import { TableSortableHeader } from '@/components/table/table-sortable-header'
-import { TableTitleHoverContent } from '@/components/table/table-title-hover-content'
+import { Button } from '@/components/ui/button'
 import {
   Select,
   SelectContent,
@@ -37,50 +19,28 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { ExternalLink, FolderOpen } from 'lucide-react'
-import { TableBulkActionsBar } from '@/components/table/table-bulk-actions-bar'
-import { CrmOnboardingEmptyState } from '@/app/dashboard/components/crm-onboarding-empty-state'
-import { CrmImportPreviewDialog } from '@/app/dashboard/accounts/components/crm-import-preview-dialog'
-import { AccountsToolbarTooltip } from '@/app/dashboard/accounts/components/accounts-toolbar-tooltip'
-import { useRole } from '@/hooks/useRole'
-import { useCrmOAuthCallback } from '@/hooks/use-crm-oauth-callback'
-import { getHubSpotConnectHref } from '@/lib/crm/hubspot/oauth-return'
+import { ToolbarSearchField } from '@/components/ui/toolbar-search-field'
 import {
-  loadColumnWidthsFromStorage,
-  saveColumnWidthsToStorage,
-} from '@/lib/table-column-sizing'
-import type { ColumnSizingState } from '@tanstack/react-table'
+  TooltipProvider,
+} from '@/components/ui/tooltip'
+import { useCrmOAuthCallback } from '@/hooks/use-crm-oauth-callback'
+import { useRole } from '@/hooks/useRole'
+import { COPY } from '@/lib/copy'
+import { getHubSpotConnectHref } from '@/lib/crm/hubspot/oauth-return'
+import { AppIcon } from '@/lib/icons'
 
-type StatusFilterValue = 'all' | DealStatus
-const DEAL_COLUMNS_STORAGE_KEY = 'refstack:deals:column-order-v2'
-const DEAL_COLUMN_SIZING_STORAGE_KEY = 'refstack:deals:column-sizing-v1'
-const DEAL_COL_LABELS = COPY.deals.columnViewLabels
-const DEAL_RESIZABLE_COLUMN_IDS = [
-  'status',
-  'title',
-  'company_name',
-  'volume',
-  'reference_count',
-  'match',
-  'expiry_date',
-  'account_manager_name',
-  'sales_manager_name',
-] as const
-const STATUS_FILTER_OPTIONS: { value: StatusFilterValue; label: string }[] = [
-  { value: 'all', label: COPY.deals.filterStatusAll },
-  { value: 'negotiation', label: COPY.deals.filterStatusNegotiation },
-  { value: 'rfp', label: COPY.deals.filterStatusRfp },
-  { value: 'won', label: COPY.deals.filterStatusWon },
-  { value: 'lost', label: COPY.deals.filterStatusLost },
-]
-
-function formatDate(iso: string) {
-  const d = new Date(iso)
-  const day = d.getUTCDate().toString().padStart(2, '0')
-  const month = (d.getUTCMonth() + 1).toString().padStart(2, '0')
-  const year = d.getUTCFullYear()
-  return `${day}.${month}.${year}`
-}
+import { importDealsFromXlsx } from './actions'
+import { DealsCreateDialog } from './deals-create-dialog'
+import { buildDealsTableColumns } from './deals-table-columns'
+import {
+  DEAL_DEFAULT_COLUMN_ORDER,
+  DEAL_INITIAL_COLUMN_VISIBILITY,
+  STATUS_FILTER_OPTIONS,
+  type StatusFilterValue,
+} from './deals-table-constants'
+import { filterDealsTableRows } from './deals-table-format'
+import type { DealRow } from './types'
+import { useDealsTableColumnsState } from './use-deals-table-columns-state'
 
 type Props = {
   deals: DealRow[]
@@ -89,17 +49,6 @@ type Props = {
   hubspotConfigured?: boolean
   hubspotConnected?: boolean
   canConnectCrm?: boolean
-}
-
-function isExpiringIn30Days(dateStr: string | null): boolean {
-  if (!dateStr) return false
-  const end = new Date(dateStr)
-  if (Number.isNaN(end.getTime())) return false
-  const now = new Date()
-  now.setHours(0, 0, 0, 0)
-  end.setHours(0, 0, 0, 0)
-  const days = Math.ceil((end.getTime() - now.getTime()) / (1000 * 60 * 60 * 24))
-  return days <= 30
 }
 
 export function DealsClientContent({
@@ -119,19 +68,8 @@ export function DealsClientContent({
   const [query, setQuery] = useState('')
   const [statusFilter, setStatusFilter] = useState<StatusFilterValue>('all')
   const [selectedDealIds, setSelectedDealIds] = useState<string[]>([])
-  const [columnOrder, setColumnOrder] = useState<string[]>([
-    'select',
-    'company_name',
-    'title',
-    'volume',
-    'status',
-    'reference_count',
-    'match',
-    'expiry_date',
-    'account_manager_name',
-    'sales_manager_name',
-  ])
-  const [columnSizing, setColumnSizing] = useState<ColumnSizingState>({})
+  const { columnOrder, setColumnOrder, columnSizing, setColumnSizing } =
+    useDealsTableColumnsState()
 
   const openCrmImport = useCallback(() => setCrmImportOpen(true), [])
 
@@ -140,39 +78,6 @@ export function DealsClientContent({
     hubspotConnected,
     onOpenImport: openCrmImport,
   })
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return
-    try {
-      const raw = window.localStorage.getItem(DEAL_COLUMNS_STORAGE_KEY)
-      if (!raw) return
-      const parsed = JSON.parse(raw)
-      if (!Array.isArray(parsed)) return
-      const normalized = parsed.filter((id): id is string => typeof id === 'string')
-      if (normalized.length > 0) setColumnOrder(normalized)
-    } catch {
-      // ignore invalid local storage payload
-    }
-  }, [])
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return
-    window.localStorage.setItem(DEAL_COLUMNS_STORAGE_KEY, JSON.stringify(columnOrder))
-  }, [columnOrder])
-
-  useEffect(() => {
-    setColumnSizing(
-      loadColumnWidthsFromStorage(
-        DEAL_COLUMN_SIZING_STORAGE_KEY,
-        DEAL_RESIZABLE_COLUMN_IDS,
-      ),
-    )
-  }, [])
-
-  useEffect(() => {
-    if (Object.keys(columnSizing).length === 0) return
-    saveColumnWidthsToStorage(DEAL_COLUMN_SIZING_STORAGE_KEY, columnSizing)
-  }, [columnSizing])
 
   async function handleXlsxImport(file: File) {
     const formData = new FormData()
@@ -197,264 +102,23 @@ export function DealsClientContent({
     }
   }
 
-  const filtered = useMemo(() => {
-    let list = deals
-    if (statusFilter !== 'all') {
-      list = list.filter((d) => d.status === statusFilter)
-    }
-    const q = query.trim().toLowerCase()
-    if (!q) return list
-    return list.filter((d) => {
-      const hay =
-        `${d.title} ${d.company_name ?? ''} ${d.account_manager_name ?? ''}`.toLowerCase()
-      return hay.includes(q)
-    })
-  }, [deals, query, statusFilter])
+  const filtered = useMemo(
+    () => filterDealsTableRows({ deals, query, statusFilter }),
+    [deals, query, statusFilter],
+  )
 
   const filtersActive = statusFilter !== 'all'
   const showDealsOnboarding = deals.length === 0 && !query.trim() && !filtersActive
 
-  const columns = useMemo<ColumnDef<DealRow>[]>(() => {
-    return [
-      {
-        id: 'select',
-        header: ({ table }) => (
-          <TableRowCheckbox
-            rowHeight={10}
-            checked={
-              table.getIsAllPageRowsSelected()
-                ? true
-                : table.getIsSomePageRowsSelected()
-                  ? 'indeterminate'
-                  : false
-            }
-            onCheckedChange={(checked) => table.toggleAllPageRowsSelected(checked)}
-            aria-label="Alle auswählen"
-          />
-        ),
-        cell: ({ row }) => (
-          <TableRowCheckbox
-            checked={row.getIsSelected()}
-            onCheckedChange={(checked) => row.toggleSelected(checked)}
-            onClick={(e) => e.stopPropagation()}
-            aria-label="Zeile auswählen"
-          />
-        ),
-        enableSorting: false,
-        enableHiding: false,
-        enableResizing: false,
-        size: 32,
-        minSize: 32,
-        maxSize: 32,
-      },
-      {
-        accessorKey: 'status',
-        meta: { viewLabel: DEAL_COL_LABELS.status },
-        size: 120,
-        minSize: 88,
-        header: ({ column }) => <TableSortableHeader label="Status" column={column} />,
-        cell: ({ row }) => <DealStatusBadge status={row.original.status} />,
-      },
-      {
-        accessorKey: 'title',
-        meta: { viewLabel: DEAL_COL_LABELS.title },
-        size: 280,
-        minSize: 140,
-        header: ({ column }) => <TableSortableHeader label="Titel" column={column} />,
-        cell: ({ row }) => (
-          <TableRowAlign className="min-w-0">
-            <TableTitleHoverContent
-              title={row.original.title}
-              href={ROUTES.deals.detail(row.original.id)}
-              previewLabel="Anforderungen"
-              previewText={row.original.requirements_text}
-              emptyPreviewText="Keine Anforderungen hinterlegt."
-            />
-          </TableRowAlign>
-        ),
-      },
-      {
-        accessorKey: 'company_name',
-        meta: { viewLabel: DEAL_COL_LABELS.company_name },
-        size: 220,
-        minSize: 140,
-        header: ({ column }) => <TableSortableHeader label="Account" column={column} />,
-        cell: ({ row }) => (
-          <TableRowAlign>
-            <TableAccountLinkContent
-              companyId={row.original.company_id}
-              companyName={row.original.company_name}
-              companyLogoUrl={row.original.company_logo_url}
-            />
-          </TableRowAlign>
-        ),
-      },
-      {
-        accessorKey: 'volume',
-        meta: { viewLabel: DEAL_COL_LABELS.volume },
-        size: 120,
-        minSize: 88,
-        header: ({ column }) => <TableSortableHeader label="Volumen" column={column} />,
-        cell: ({ row }) => (
-          <span className="text-muted-foreground tabular-nums">
-            {formatDealVolume(row.original.volume)}
-          </span>
-        ),
-      },
-      {
-        id: 'reference_count',
-        accessorFn: (row) => row.linked_refs?.length ?? 0,
-        meta: {
-          viewLabel: DEAL_COL_LABELS.reference_count,
-          headerAlign: 'center' as const,
-        },
-        size: 96,
-        minSize: 80,
-        header: ({ column }) => (
-          <TableSortableHeader label={COPY.deals.referenceCountColumn} column={column} />
-        ),
-        cell: ({ row }) => (
-          <div className="text-center tabular-nums text-muted-foreground">
-            {row.original.linked_refs?.length ?? 0}
-          </div>
-        ),
-      },
-      {
-        id: 'match',
-        accessorFn: (row) => row.best_match_score,
-        meta: { viewLabel: DEAL_COL_LABELS.match, headerAlign: 'center' as const },
-        sortingFn: (rowA, rowB) => {
-          const a = rowA.original.best_match_score
-          const b = rowB.original.best_match_score
-          if (a == null && b == null) return 0
-          if (a == null) return 1
-          if (b == null) return -1
-          return a - b
-        },
-        size: 88,
-        minSize: 72,
-        header: ({ column }) => (
-          <TableSortableHeader label={COPY.deals.matchColumn} column={column} />
-        ),
-        cell: ({ row }) => {
-          const refCount = row.original.linked_refs?.length ?? 0
-          const score = row.original.best_match_score
-
-          if (refCount === 0) {
-            return (
-              <div
-                className="flex justify-center text-muted-foreground"
-                aria-label="Keine Referenzen"
-              >
-                —
-              </div>
-            )
-          }
-
-          if (score == null || Number.isNaN(score)) {
-            return (
-              <div className="flex justify-center">
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span
-                      tabIndex={0}
-                      className="cursor-default text-muted-foreground"
-                      aria-label="Manuell verknüpft, kein Match-Score"
-                    >
-                      —
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent side="top" className="max-w-xs text-xs">
-                    Manuell verknüpft — kein Match-Score aus Smart Match
-                  </TooltipContent>
-                </Tooltip>
-              </div>
-            )
-          }
-
-          const percent = Math.round(score * 100)
-          const strength = getMatchStrength(score)
-
-          return (
-            <div className="flex justify-center">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span
-                    tabIndex={0}
-                    className="inline-flex cursor-default rounded-full outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  >
-                    <MatchScoreCircle size="sm" strength={strength} percent={percent} />
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent side="top" className="text-xs">
-                  {strength.ariaLabel} · {percent}%
-                </TooltipContent>
-              </Tooltip>
-            </div>
-          )
-        },
-      },
-      {
-        accessorKey: 'account_manager_name',
-        meta: { viewLabel: DEAL_COL_LABELS.account_manager_name },
-        size: 160,
-        minSize: 100,
-        header: ({ column }) => (
-          <TableSortableHeader label={COPY.roles.accountManager} column={column} />
-        ),
-        cell: ({ row }) => (
-          <span className="text-muted-foreground">
-            {row.original.account_manager_name ?? '—'}
-          </span>
-        ),
-      },
-      {
-        accessorKey: 'expiry_date',
-        meta: { viewLabel: DEAL_COL_LABELS.expiry_date },
-        size: 120,
-        minSize: 88,
-        header: ({ column }) => <TableSortableHeader label="Deadline" column={column} />,
-        cell: ({ row }) => {
-          const isHot = isExpiringIn30Days(row.original.expiry_date)
-          return (
-            <span
-              className={isHot ? 'text-destructive font-medium' : 'text-muted-foreground'}
-            >
-              {row.original.expiry_date ? formatDate(row.original.expiry_date) : '—'}
-            </span>
-          )
-        },
-      },
-      {
-        accessorKey: 'sales_manager_name',
-        meta: { viewLabel: DEAL_COL_LABELS.sales_manager_name },
-        size: 160,
-        minSize: 100,
-        header: ({ column }) => (
-          <TableSortableHeader label={COPY.roles.salesManager} column={column} />
-        ),
-        cell: ({ row }) => (
-          <span className="text-muted-foreground">
-            {row.original.sales_manager_name ?? '—'}
-          </span>
-        ),
-      },
-    ]
-  }, [])
+  const columns = useMemo(() => buildDealsTableColumns(), [])
 
   const createDealDialog = (
-    <Dialog open={createOpen} onOpenChange={setCreateOpen}>
-      <DialogContent className="max-h-[90vh] min-h-[60vh] overflow-y-auto w-[calc(100vw-2rem)] max-w-[90vw] lg:max-w-7xl gap-0 border-0 px-6 py-6 md:px-12 md:py-10 lg:px-16 lg:py-12">
-        <div className="flex flex-col items-center w-full max-w-full">
-          <DialogHeader className="w-full max-w-4xl mx-auto px-0 pb-4">
-            <DialogTitle>Deal anlegen</DialogTitle>
-          </DialogHeader>
-          <div className="w-full max-w-4xl">
-            <DealForm companies={companies} orgProfiles={orgProfiles} />
-          </div>
-        </div>
-      </DialogContent>
-    </Dialog>
+    <DealsCreateDialog
+      open={createOpen}
+      onOpenChange={setCreateOpen}
+      companies={companies}
+      orgProfiles={orgProfiles}
+    />
   )
 
   if (showDealsOnboarding) {
@@ -520,29 +184,8 @@ export function DealsClientContent({
           initialPageSize={30}
           getRowId={(row) => row.id}
           onSelectedRowIdsChange={setSelectedDealIds}
-          initialColumnVisibility={{
-            account_manager_name: false,
-            sales_manager_name: false,
-            status: true,
-            company_name: true,
-            title: true,
-            volume: true,
-            reference_count: true,
-            match: true,
-            expiry_date: true,
-          }}
-          initialColumnOrder={[
-            'select',
-            'company_name',
-            'title',
-            'volume',
-            'status',
-            'reference_count',
-            'match',
-            'expiry_date',
-            'account_manager_name',
-            'sales_manager_name',
-          ]}
+          initialColumnVisibility={{ ...DEAL_INITIAL_COLUMN_VISIBILITY }}
+          initialColumnOrder={[...DEAL_DEFAULT_COLUMN_ORDER]}
           columnOrder={columnOrder}
           onColumnOrderChange={setColumnOrder}
           enableColumnDrag

--- a/app/dashboard/deals/deals-create-dialog.tsx
+++ b/app/dashboard/deals/deals-create-dialog.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+
+import { DealForm } from './new/deal-form'
+
+export function DealsCreateDialog({
+  open,
+  onOpenChange,
+  companies,
+  orgProfiles,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  companies: { id: string; name: string }[]
+  orgProfiles: { id: string; full_name: string | null }[]
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] min-h-[60vh] overflow-y-auto w-[calc(100vw-2rem)] max-w-[90vw] lg:max-w-7xl gap-0 border-0 px-6 py-6 md:px-12 md:py-10 lg:px-16 lg:py-12">
+        <div className="flex flex-col items-center w-full max-w-full">
+          <DialogHeader className="w-full max-w-4xl mx-auto px-0 pb-4">
+            <DialogTitle>Deal anlegen</DialogTitle>
+          </DialogHeader>
+          <div className="w-full max-w-4xl">
+            <DealForm companies={companies} orgProfiles={orgProfiles} />
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/app/dashboard/deals/deals-table-columns.tsx
+++ b/app/dashboard/deals/deals-table-columns.tsx
@@ -1,0 +1,255 @@
+'use client'
+
+import type { ColumnDef } from '@tanstack/react-table'
+
+import { DealStatusBadge } from '@/components/deal-status-badge'
+import { MatchScoreCircle } from '@/components/match/match-score-circle'
+import { TableAccountLinkContent } from '@/components/table/table-account-link-content'
+import { TableRowAlign } from '@/components/table/table-row-align'
+import { TableRowCheckbox } from '@/components/table/table-row-checkbox'
+import { TableSortableHeader } from '@/components/table/table-sortable-header'
+import { TableTitleHoverContent } from '@/components/table/table-title-hover-content'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { COPY } from '@/lib/copy'
+import { formatDealVolume } from '@/lib/format'
+import { getMatchStrength } from '@/lib/match/match-strength'
+import { ROUTES } from '@/lib/routes'
+
+import { DEAL_COL_LABELS } from './deals-table-constants'
+import {
+  formatDealTableDate,
+  isDealExpiringIn30Days,
+} from './deals-table-format'
+import type { DealRow } from './types'
+
+export function buildDealsTableColumns(): ColumnDef<DealRow>[] {
+  return [
+    {
+      id: 'select',
+      header: ({ table }) => (
+        <TableRowCheckbox
+          rowHeight={10}
+          checked={
+            table.getIsAllPageRowsSelected()
+              ? true
+              : table.getIsSomePageRowsSelected()
+                ? 'indeterminate'
+                : false
+          }
+          onCheckedChange={(checked) => table.toggleAllPageRowsSelected(checked)}
+          aria-label="Alle auswählen"
+        />
+      ),
+      cell: ({ row }) => (
+        <TableRowCheckbox
+          checked={row.getIsSelected()}
+          onCheckedChange={(checked) => row.toggleSelected(checked)}
+          onClick={(e) => e.stopPropagation()}
+          aria-label="Zeile auswählen"
+        />
+      ),
+      enableSorting: false,
+      enableHiding: false,
+      enableResizing: false,
+      size: 32,
+      minSize: 32,
+      maxSize: 32,
+    },
+    {
+      accessorKey: 'status',
+      meta: { viewLabel: DEAL_COL_LABELS.status },
+      size: 120,
+      minSize: 88,
+      header: ({ column }) => <TableSortableHeader label="Status" column={column} />,
+      cell: ({ row }) => <DealStatusBadge status={row.original.status} />,
+    },
+    {
+      accessorKey: 'title',
+      meta: { viewLabel: DEAL_COL_LABELS.title },
+      size: 280,
+      minSize: 140,
+      header: ({ column }) => <TableSortableHeader label="Titel" column={column} />,
+      cell: ({ row }) => (
+        <TableRowAlign className="min-w-0">
+          <TableTitleHoverContent
+            title={row.original.title}
+            href={ROUTES.deals.detail(row.original.id)}
+            previewLabel="Anforderungen"
+            previewText={row.original.requirements_text}
+            emptyPreviewText="Keine Anforderungen hinterlegt."
+          />
+        </TableRowAlign>
+      ),
+    },
+    {
+      accessorKey: 'company_name',
+      meta: { viewLabel: DEAL_COL_LABELS.company_name },
+      size: 220,
+      minSize: 140,
+      header: ({ column }) => <TableSortableHeader label="Account" column={column} />,
+      cell: ({ row }) => (
+        <TableRowAlign>
+          <TableAccountLinkContent
+            companyId={row.original.company_id}
+            companyName={row.original.company_name}
+            companyLogoUrl={row.original.company_logo_url}
+          />
+        </TableRowAlign>
+      ),
+    },
+    {
+      accessorKey: 'volume',
+      meta: { viewLabel: DEAL_COL_LABELS.volume },
+      size: 120,
+      minSize: 88,
+      header: ({ column }) => <TableSortableHeader label="Volumen" column={column} />,
+      cell: ({ row }) => (
+        <span className="text-muted-foreground tabular-nums">
+          {formatDealVolume(row.original.volume)}
+        </span>
+      ),
+    },
+    {
+      id: 'reference_count',
+      accessorFn: (row) => row.linked_refs?.length ?? 0,
+      meta: {
+        viewLabel: DEAL_COL_LABELS.reference_count,
+        headerAlign: 'center' as const,
+      },
+      size: 96,
+      minSize: 80,
+      header: ({ column }) => (
+        <TableSortableHeader label={COPY.deals.referenceCountColumn} column={column} />
+      ),
+      cell: ({ row }) => (
+        <div className="text-center tabular-nums text-muted-foreground">
+          {row.original.linked_refs?.length ?? 0}
+        </div>
+      ),
+    },
+    {
+      id: 'match',
+      accessorFn: (row) => row.best_match_score,
+      meta: { viewLabel: DEAL_COL_LABELS.match, headerAlign: 'center' as const },
+      sortingFn: (rowA, rowB) => {
+        const a = rowA.original.best_match_score
+        const b = rowB.original.best_match_score
+        if (a == null && b == null) return 0
+        if (a == null) return 1
+        if (b == null) return -1
+        return a - b
+      },
+      size: 88,
+      minSize: 72,
+      header: ({ column }) => (
+        <TableSortableHeader label={COPY.deals.matchColumn} column={column} />
+      ),
+      cell: ({ row }) => {
+        const refCount = row.original.linked_refs?.length ?? 0
+        const score = row.original.best_match_score
+
+        if (refCount === 0) {
+          return (
+            <div
+              className="flex justify-center text-muted-foreground"
+              aria-label="Keine Referenzen"
+            >
+              —
+            </div>
+          )
+        }
+
+        if (score == null || Number.isNaN(score)) {
+          return (
+            <div className="flex justify-center">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span
+                    tabIndex={0}
+                    className="cursor-default text-muted-foreground"
+                    aria-label="Manuell verknüpft, kein Match-Score"
+                  >
+                    —
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="top" className="max-w-xs text-xs">
+                  Manuell verknüpft — kein Match-Score aus Smart Match
+                </TooltipContent>
+              </Tooltip>
+            </div>
+          )
+        }
+
+        const percent = Math.round(score * 100)
+        const strength = getMatchStrength(score)
+
+        return (
+          <div className="flex justify-center">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span
+                  tabIndex={0}
+                  className="inline-flex cursor-default rounded-full outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  <MatchScoreCircle size="sm" strength={strength} percent={percent} />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="top" className="text-xs">
+                {strength.ariaLabel} · {percent}%
+              </TooltipContent>
+            </Tooltip>
+          </div>
+        )
+      },
+    },
+    {
+      accessorKey: 'account_manager_name',
+      meta: { viewLabel: DEAL_COL_LABELS.account_manager_name },
+      size: 160,
+      minSize: 100,
+      header: ({ column }) => (
+        <TableSortableHeader label={COPY.roles.accountManager} column={column} />
+      ),
+      cell: ({ row }) => (
+        <span className="text-muted-foreground">
+          {row.original.account_manager_name ?? '—'}
+        </span>
+      ),
+    },
+    {
+      accessorKey: 'expiry_date',
+      meta: { viewLabel: DEAL_COL_LABELS.expiry_date },
+      size: 120,
+      minSize: 88,
+      header: ({ column }) => <TableSortableHeader label="Deadline" column={column} />,
+      cell: ({ row }) => {
+        const isHot = isDealExpiringIn30Days(row.original.expiry_date)
+        return (
+          <span
+            className={isHot ? 'text-destructive font-medium' : 'text-muted-foreground'}
+          >
+            {row.original.expiry_date ? formatDealTableDate(row.original.expiry_date) : '—'}
+          </span>
+        )
+      },
+    },
+    {
+      accessorKey: 'sales_manager_name',
+      meta: { viewLabel: DEAL_COL_LABELS.sales_manager_name },
+      size: 160,
+      minSize: 100,
+      header: ({ column }) => (
+        <TableSortableHeader label={COPY.roles.salesManager} column={column} />
+      ),
+      cell: ({ row }) => (
+        <span className="text-muted-foreground">
+          {row.original.sales_manager_name ?? '—'}
+        </span>
+      ),
+    },
+  ]
+}

--- a/app/dashboard/deals/deals-table-constants.ts
+++ b/app/dashboard/deals/deals-table-constants.ts
@@ -1,0 +1,55 @@
+import { COPY } from '@/lib/copy'
+
+import type { DealStatus } from './types'
+
+export type StatusFilterValue = 'all' | DealStatus
+
+export const DEAL_COLUMNS_STORAGE_KEY = 'refstack:deals:column-order-v2'
+export const DEAL_COLUMN_SIZING_STORAGE_KEY = 'refstack:deals:column-sizing-v1'
+
+export const DEAL_COL_LABELS = COPY.deals.columnViewLabels
+
+export const DEAL_RESIZABLE_COLUMN_IDS = [
+  'status',
+  'title',
+  'company_name',
+  'volume',
+  'reference_count',
+  'match',
+  'expiry_date',
+  'account_manager_name',
+  'sales_manager_name',
+] as const
+
+export const DEAL_DEFAULT_COLUMN_ORDER = [
+  'select',
+  'company_name',
+  'title',
+  'volume',
+  'status',
+  'reference_count',
+  'match',
+  'expiry_date',
+  'account_manager_name',
+  'sales_manager_name',
+] as const
+
+export const STATUS_FILTER_OPTIONS: { value: StatusFilterValue; label: string }[] = [
+  { value: 'all', label: COPY.deals.filterStatusAll },
+  { value: 'negotiation', label: COPY.deals.filterStatusNegotiation },
+  { value: 'rfp', label: COPY.deals.filterStatusRfp },
+  { value: 'won', label: COPY.deals.filterStatusWon },
+  { value: 'lost', label: COPY.deals.filterStatusLost },
+]
+
+export const DEAL_INITIAL_COLUMN_VISIBILITY = {
+  account_manager_name: false,
+  sales_manager_name: false,
+  status: true,
+  company_name: true,
+  title: true,
+  volume: true,
+  reference_count: true,
+  match: true,
+  expiry_date: true,
+} as const

--- a/app/dashboard/deals/deals-table-format.ts
+++ b/app/dashboard/deals/deals-table-format.ts
@@ -1,0 +1,43 @@
+import type { DealRow } from './types'
+import type { StatusFilterValue } from './deals-table-constants'
+
+export function formatDealTableDate(iso: string): string {
+  const d = new Date(iso)
+  const day = d.getUTCDate().toString().padStart(2, '0')
+  const month = (d.getUTCMonth() + 1).toString().padStart(2, '0')
+  const year = d.getUTCFullYear()
+  return `${day}.${month}.${year}`
+}
+
+export function isDealExpiringIn30Days(dateStr: string | null): boolean {
+  if (!dateStr) return false
+  const end = new Date(dateStr)
+  if (Number.isNaN(end.getTime())) return false
+  const now = new Date()
+  now.setHours(0, 0, 0, 0)
+  end.setHours(0, 0, 0, 0)
+  const days = Math.ceil((end.getTime() - now.getTime()) / (1000 * 60 * 60 * 24))
+  return days <= 30
+}
+
+export function filterDealsTableRows({
+  deals,
+  query,
+  statusFilter,
+}: {
+  deals: DealRow[]
+  query: string
+  statusFilter: StatusFilterValue
+}): DealRow[] {
+  let list = deals
+  if (statusFilter !== 'all') {
+    list = list.filter((d) => d.status === statusFilter)
+  }
+  const q = query.trim().toLowerCase()
+  if (!q) return list
+  return list.filter((d) => {
+    const hay =
+      `${d.title} ${d.company_name ?? ''} ${d.account_manager_name ?? ''}`.toLowerCase()
+    return hay.includes(q)
+  })
+}

--- a/app/dashboard/deals/use-deals-table-columns-state.ts
+++ b/app/dashboard/deals/use-deals-table-columns-state.ts
@@ -1,0 +1,61 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { ColumnSizingState } from '@tanstack/react-table'
+
+import {
+  loadColumnWidthsFromStorage,
+  saveColumnWidthsToStorage,
+} from '@/lib/table-column-sizing'
+
+import {
+  DEAL_COLUMN_SIZING_STORAGE_KEY,
+  DEAL_COLUMNS_STORAGE_KEY,
+  DEAL_DEFAULT_COLUMN_ORDER,
+  DEAL_RESIZABLE_COLUMN_IDS,
+} from './deals-table-constants'
+
+export function useDealsTableColumnsState() {
+  const [columnOrder, setColumnOrder] = useState<string[]>([...DEAL_DEFAULT_COLUMN_ORDER])
+  const [columnSizing, setColumnSizing] = useState<ColumnSizingState>({})
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    try {
+      const raw = window.localStorage.getItem(DEAL_COLUMNS_STORAGE_KEY)
+      if (!raw) return
+      const parsed = JSON.parse(raw)
+      if (!Array.isArray(parsed)) return
+      const normalized = parsed.filter((id): id is string => typeof id === 'string')
+      if (normalized.length > 0) setColumnOrder(normalized)
+    } catch {
+      // ignore invalid local storage payload
+    }
+  }, [])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    window.localStorage.setItem(DEAL_COLUMNS_STORAGE_KEY, JSON.stringify(columnOrder))
+  }, [columnOrder])
+
+  useEffect(() => {
+    setColumnSizing(
+      loadColumnWidthsFromStorage(
+        DEAL_COLUMN_SIZING_STORAGE_KEY,
+        DEAL_RESIZABLE_COLUMN_IDS,
+      ),
+    )
+  }, [])
+
+  useEffect(() => {
+    if (Object.keys(columnSizing).length === 0) return
+    saveColumnWidthsToStorage(DEAL_COLUMN_SIZING_STORAGE_KEY, columnSizing)
+  }, [columnSizing])
+
+  return {
+    columnOrder,
+    setColumnOrder,
+    columnSizing,
+    setColumnSizing,
+  }
+}

--- a/docs/tech-debt-offen-backlog.md
+++ b/docs/tech-debt-offen-backlog.md
@@ -28,7 +28,7 @@
 | **2** | E7 Schema-Sync | ✅ T1–T4 | Types bei Migrationen regenerieren (`db:types`) | XS ongoing | bei Schema-Change |
 | **3** | Typed-Supabase Cast-Abbau | ✅ T1–T4 | Rest-Casts nur Boundaries (HTTP/RPC/Json); Boy-Scout bei Touch | — | CI: `typecheck` vor Build |
 | **4** | P1-6 Accounts Naming | ✅ App/Lib | DB-Tabelle `companies` / `company_id` / Firmennamen-Helfer **bewusst offen** | — | nicht anfassen ohne Produktentscheid |
-| **5** | God-File-Nacharbeit | Slice 1–8 ✅ | … + bulk-import, deal-documents-section | M ongoing | nächster: deals-client / nda-popover |
+| **5** | God-File-Nacharbeit | Slice 1–9 ✅ | … + deal-documents, deals-client | M ongoing | nächster: nda-popover / account-detail |
 | **6** | `{ ok }` → `{ success }` | Lib ✅ | Slices 1–4; Rest nur Cron/Push-HTTP-Body | XS | Cron/Push separat wenn Monitoring-Clients ok |
 | **7** | P3-3 DE/EN-Dateinamen | ✅ Slice | `ai-draft-*`, `customer-control-link-email`; API `/api/ai-draft` + Redirect; UI-Copy „Sperrlink“/Event `ki_entwurf_generated` bleiben | — | Rest nur bei Touch |
 | **8** | `references`/`evidence` Pfade | ✅ | App = `references` (Routen/Ordner/`ROUTES`); Redirects `/dashboard/evidence` bleiben; `evidence_events` bleibt | — | Rest-`evidence` nur Domänenbegriff (RFP-Belege) |


### PR DESCRIPTION
## Summary
- Split `deals-client.tsx` (~635 → ~278) into constants, format/filter helpers, `buildDealsTableColumns`, column persistence hook, and create dialog
- Behavior unchanged (filters, column drag/resize + localStorage, xlsx import, CRM onboarding, bulk open)

## Test plan
- [ ] Deals table: search + status filter
- [ ] Column reorder/resize persist after reload; view options
- [ ] Create deal dialog; xlsx import button
- [ ] Row select + bulk open / new tab
- [ ] Empty onboarding + HubSpot/CRM import path


Made with [Cursor](https://cursor.com)