### PR TITLE
refactor(#5): split workflow settings tab (slice 11)

### DIFF
--- a/app/dashboard/settings/tabs/use-workflow-settings.ts
+++ b/app/dashboard/settings/tabs/use-workflow-settings.ts
@@ -1,0 +1,79 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { toast } from 'sonner'
+
+import { updateWorkflowSettings } from '../settings-consolidation-actions'
+
+import type { WorkflowSettingsShape } from './workflow-types'
+
+export function useWorkflowSettings(initial: WorkflowSettingsShape) {
+  const [linkExpiryDays, setLinkExpiryDays] = useState(String(initial.linkExpiryDays))
+  const [requireInternalApproval, setRequireInternalApproval] = useState(
+    initial.requireInternalApproval,
+  )
+  const [reminder1Days, setReminder1Days] = useState(String(initial.reminder1Days))
+  const [reminder2Days, setReminder2Days] = useState(String(initial.reminder2Days))
+  const [escalationAfterDays, setEscalationAfterDays] = useState(
+    String(initial.escalationAfterDays),
+  )
+  const [autoNotifyRequesterOnEscalation, setAutoNotifyRequesterOnEscalation] = useState(
+    initial.autoNotifyRequesterOnEscalation,
+  )
+  const [autoAllowDelegation, setAutoAllowDelegation] = useState(
+    initial.autoAllowDelegation,
+  )
+  const [workflowPending, startWorkflowTransition] = useTransition()
+
+  const workflowDirty =
+    linkExpiryDays !== String(initial.linkExpiryDays) ||
+    requireInternalApproval !== initial.requireInternalApproval ||
+    reminder1Days !== String(initial.reminder1Days) ||
+    reminder2Days !== String(initial.reminder2Days) ||
+    escalationAfterDays !== String(initial.escalationAfterDays) ||
+    autoNotifyRequesterOnEscalation !== initial.autoNotifyRequesterOnEscalation ||
+    autoAllowDelegation !== initial.autoAllowDelegation
+
+  function saveWorkflow() {
+    startWorkflowTransition(async () => {
+      const parsed = Number(linkExpiryDays)
+      const rem1 = Number(reminder1Days)
+      const rem2 = Number(reminder2Days)
+      const escal = Number(escalationAfterDays)
+      const result = await updateWorkflowSettings({
+        linkExpiryDays: Number.isFinite(parsed) ? parsed : 14,
+        requireInternalApproval,
+        reminder1Days: Number.isFinite(rem1) ? rem1 : 3,
+        reminder2Days: Number.isFinite(rem2) ? rem2 : 7,
+        escalationAfterDays: Number.isFinite(escal) ? escal : 10,
+        autoNotifyRequesterOnEscalation,
+        autoAllowDelegation,
+      })
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success('Workflow-Einstellungen gespeichert')
+    })
+  }
+
+  return {
+    linkExpiryDays,
+    setLinkExpiryDays,
+    requireInternalApproval,
+    setRequireInternalApproval,
+    reminder1Days,
+    setReminder1Days,
+    reminder2Days,
+    setReminder2Days,
+    escalationAfterDays,
+    setEscalationAfterDays,
+    autoNotifyRequesterOnEscalation,
+    setAutoNotifyRequesterOnEscalation,
+    autoAllowDelegation,
+    setAutoAllowDelegation,
+    workflowPending,
+    workflowDirty,
+    saveWorkflow,
+  }
+}

--- a/app/dashboard/settings/tabs/use-workflow-simulation.ts
+++ b/app/dashboard/settings/tabs/use-workflow-simulation.ts
@@ -1,0 +1,176 @@
+'use client'
+
+import { useState } from 'react'
+import { toast } from 'sonner'
+
+import type {
+  WorkflowSettingsShape,
+  WorkflowSimulationItem,
+} from './workflow-types'
+
+type LiveSource = {
+  requireInternalApproval: boolean
+  reminder1Days: string
+  reminder2Days: string
+  escalationAfterDays: string
+  linkExpiryDays: string
+  autoNotifyRequesterOnEscalation: boolean
+  autoAllowDelegation: boolean
+}
+
+export function useWorkflowSimulation(
+  initial: WorkflowSettingsShape,
+  live: LiveSource,
+) {
+  const [workflowSimulation, setWorkflowSimulation] = useState<WorkflowSimulationItem[]>(
+    [],
+  )
+  const [simulationSandboxEnabled, setSimulationSandboxEnabled] = useState(false)
+  const [simRequireInternalApproval, setSimRequireInternalApproval] = useState(
+    initial.requireInternalApproval,
+  )
+  const [simReminder1Days, setSimReminder1Days] = useState(String(initial.reminder1Days))
+  const [simReminder2Days, setSimReminder2Days] = useState(String(initial.reminder2Days))
+  const [simEscalationAfterDays, setSimEscalationAfterDays] = useState(
+    String(initial.escalationAfterDays),
+  )
+  const [simLinkExpiryDays, setSimLinkExpiryDays] = useState(
+    String(initial.linkExpiryDays),
+  )
+  const [simAutoNotifyRequesterOnEscalation, setSimAutoNotifyRequesterOnEscalation] =
+    useState(initial.autoNotifyRequesterOnEscalation)
+  const [simAutoAllowDelegation, setSimAutoAllowDelegation] = useState(
+    initial.autoAllowDelegation,
+  )
+
+  function runWorkflowSimulation() {
+    const sourceRequireInternalApproval = simulationSandboxEnabled
+      ? simRequireInternalApproval
+      : live.requireInternalApproval
+    const sourceReminder1Days = simulationSandboxEnabled
+      ? simReminder1Days
+      : live.reminder1Days
+    const sourceReminder2Days = simulationSandboxEnabled
+      ? simReminder2Days
+      : live.reminder2Days
+    const sourceEscalationAfterDays = simulationSandboxEnabled
+      ? simEscalationAfterDays
+      : live.escalationAfterDays
+    const sourceLinkExpiryDays = simulationSandboxEnabled
+      ? simLinkExpiryDays
+      : live.linkExpiryDays
+    const sourceAutoNotifyRequesterOnEscalation = simulationSandboxEnabled
+      ? simAutoNotifyRequesterOnEscalation
+      : live.autoNotifyRequesterOnEscalation
+    const sourceAutoAllowDelegation = simulationSandboxEnabled
+      ? simAutoAllowDelegation
+      : live.autoAllowDelegation
+
+    const rem1 = Math.max(
+      1,
+      Number.isFinite(Number(sourceReminder1Days))
+        ? Math.trunc(Number(sourceReminder1Days))
+        : 3,
+    )
+    const rem2 = Math.max(
+      rem1,
+      Number.isFinite(Number(sourceReminder2Days))
+        ? Math.trunc(Number(sourceReminder2Days))
+        : 7,
+    )
+    const escal = Math.max(
+      rem2,
+      Number.isFinite(Number(sourceEscalationAfterDays))
+        ? Math.trunc(Number(sourceEscalationAfterDays))
+        : 10,
+    )
+    const ttl = Math.max(
+      1,
+      Number.isFinite(Number(sourceLinkExpiryDays))
+        ? Math.trunc(Number(sourceLinkExpiryDays))
+        : 14,
+    )
+
+    const items: WorkflowSimulationItem[] = [
+      {
+        day: 0,
+        label: 'Freigabe angefordert',
+        detail: sourceRequireInternalApproval
+          ? 'Referenz landet zuerst im internen Review (pending_internal).'
+          : 'Kundenfreigabe wird direkt versendet (pending).',
+        tone: 'info',
+      },
+      {
+        day: rem1,
+        label: 'Reminder #1',
+        detail: 'Automatischer Follow-up an den aktuellen Empfänger.',
+        tone: 'neutral',
+      },
+      {
+        day: rem2,
+        label: 'Reminder #2',
+        detail: 'Zweiter Reminder, falls weiterhin keine Entscheidung vorliegt.',
+        tone: 'neutral',
+      },
+      {
+        day: escal,
+        label: 'Eskalation',
+        detail: sourceAutoNotifyRequesterOnEscalation
+          ? 'Requester wird aktiv benachrichtigt.'
+          : 'Eskalation ohne automatische Requester-Benachrichtigung.',
+        tone: 'warning',
+      },
+      {
+        day: ttl,
+        label: 'Link läuft ab',
+        detail: 'Freigabelink erreicht das Ablaufdatum aus den Workflow-Regeln.',
+        tone: 'warning',
+      },
+    ]
+
+    if (sourceAutoAllowDelegation) {
+      items.splice(1, 0, {
+        day: 1,
+        label: 'Delegation möglich',
+        detail: 'Empfänger kann Anfrage an Kollegen delegieren.',
+        tone: 'info',
+      })
+    }
+
+    setWorkflowSimulation(items.sort((a, b) => a.day - b.day))
+    toast.success('Testlauf aktualisiert')
+  }
+
+  function resetWorkflowSandbox() {
+    setSimRequireInternalApproval(initial.requireInternalApproval)
+    setSimReminder1Days(String(initial.reminder1Days))
+    setSimReminder2Days(String(initial.reminder2Days))
+    setSimEscalationAfterDays(String(initial.escalationAfterDays))
+    setSimLinkExpiryDays(String(initial.linkExpiryDays))
+    setSimAutoNotifyRequesterOnEscalation(initial.autoNotifyRequesterOnEscalation)
+    setSimAutoAllowDelegation(initial.autoAllowDelegation)
+    toast.success('Sandbox auf Live-Werte zurückgesetzt')
+  }
+
+  return {
+    workflowSimulation,
+    simulationSandboxEnabled,
+    setSimulationSandboxEnabled,
+    simRequireInternalApproval,
+    setSimRequireInternalApproval,
+    simReminder1Days,
+    setSimReminder1Days,
+    simReminder2Days,
+    setSimReminder2Days,
+    simEscalationAfterDays,
+    setSimEscalationAfterDays,
+    simLinkExpiryDays,
+    setSimLinkExpiryDays,
+    simAutoNotifyRequesterOnEscalation,
+    setSimAutoNotifyRequesterOnEscalation,
+    simAutoAllowDelegation,
+    setSimAutoAllowDelegation,
+    runWorkflowSimulation,
+    resetWorkflowSandbox,
+  }
+}

--- a/app/dashboard/settings/tabs/workflow-freigabe-settings-card.tsx
+++ b/app/dashboard/settings/tabs/workflow-freigabe-settings-card.tsx
@@ -1,0 +1,175 @@
+'use client'
+
+import { CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Switch } from '@/components/ui/switch'
+
+import { SETTINGS_CARD_CLASS } from './settings-tab-shared'
+import { WorkflowSimulationPanel } from './workflow-simulation-panel'
+import type { WorkflowSettingsShape, WorkflowSimulationItem } from './workflow-types'
+
+export function WorkflowFreigabeSettingsCard({
+  linkExpiryDays,
+  onLinkExpiryDaysChange,
+  requireInternalApproval,
+  onRequireInternalApprovalChange,
+  autoAllowDelegation,
+  onAutoAllowDelegationChange,
+  reminder1Days,
+  onReminder1DaysChange,
+  reminder2Days,
+  onReminder2DaysChange,
+  escalationAfterDays,
+  onEscalationAfterDaysChange,
+  autoNotifyRequesterOnEscalation,
+  onAutoNotifyRequesterOnEscalationChange,
+  liveSettings,
+  simulation,
+}: {
+  linkExpiryDays: string
+  onLinkExpiryDaysChange: (value: string) => void
+  requireInternalApproval: boolean
+  onRequireInternalApprovalChange: (value: boolean) => void
+  autoAllowDelegation: boolean
+  onAutoAllowDelegationChange: (value: boolean) => void
+  reminder1Days: string
+  onReminder1DaysChange: (value: string) => void
+  reminder2Days: string
+  onReminder2DaysChange: (value: string) => void
+  escalationAfterDays: string
+  onEscalationAfterDaysChange: (value: string) => void
+  autoNotifyRequesterOnEscalation: boolean
+  onAutoNotifyRequesterOnEscalationChange: (value: boolean) => void
+  liveSettings: WorkflowSettingsShape
+  simulation: {
+    workflowSimulation: WorkflowSimulationItem[]
+    simulationSandboxEnabled: boolean
+    setSimulationSandboxEnabled: (value: boolean) => void
+    simRequireInternalApproval: boolean
+    setSimRequireInternalApproval: (value: boolean) => void
+    simReminder1Days: string
+    setSimReminder1Days: (value: string) => void
+    simReminder2Days: string
+    setSimReminder2Days: (value: string) => void
+    simEscalationAfterDays: string
+    setSimEscalationAfterDays: (value: string) => void
+    simLinkExpiryDays: string
+    setSimLinkExpiryDays: (value: string) => void
+    simAutoNotifyRequesterOnEscalation: boolean
+    setSimAutoNotifyRequesterOnEscalation: (value: boolean) => void
+    simAutoAllowDelegation: boolean
+    setSimAutoAllowDelegation: (value: boolean) => void
+    runWorkflowSimulation: () => void
+    resetWorkflowSandbox: () => void
+  }
+}) {
+  return (
+    <div className={SETTINGS_CARD_CLASS}>
+      <CardHeader className="space-y-2 px-0 pt-0">
+        <CardTitle className="text-base">Freigabe-Workflow</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4 px-0 pb-0 pt-2">
+        <div className="rounded-lg border border-slate-200 p-4">
+          <p className="text-sm font-semibold text-slate-900">1. Entry</p>
+          <div className="mt-3 max-w-sm space-y-2">
+            <Label htmlFor="link-expiry-days">Link Expiry (Tage)</Label>
+            <Input
+              id="link-expiry-days"
+              value={linkExpiryDays}
+              onChange={(e) => onLinkExpiryDaysChange(e.target.value)}
+              inputMode="numeric"
+            />
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-slate-200 p-4">
+          <p className="text-sm font-semibold text-slate-900">2. Interne Prüfung</p>
+          <div className="mt-3 flex items-center justify-between rounded-lg border border-slate-200 p-3">
+            <div>
+              <p className="text-sm font-medium">Vier-Augen-Prinzip aktiv</p>
+            </div>
+            <Switch
+              checked={requireInternalApproval}
+              onCheckedChange={onRequireInternalApprovalChange}
+            />
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-slate-200 p-4">
+          <p className="text-sm font-semibold text-slate-900">3. Externer Versand</p>
+          <div className="mt-3 flex items-center justify-between rounded-lg border border-slate-200 p-3">
+            <div>
+              <p className="text-sm font-medium">Delegation erlauben</p>
+            </div>
+            <Switch
+              checked={autoAllowDelegation}
+              onCheckedChange={onAutoAllowDelegationChange}
+            />
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-slate-200 p-4">
+          <p className="text-sm font-semibold text-slate-900">4. Follow-up Sequenz</p>
+          <div className="mt-3 grid gap-3 sm:grid-cols-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="approval-reminder-1">Reminder #1 (Tage)</Label>
+              <Input
+                id="approval-reminder-1"
+                value={reminder1Days}
+                onChange={(e) => onReminder1DaysChange(e.target.value)}
+                inputMode="numeric"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="approval-reminder-2">Reminder #2 (Tage)</Label>
+              <Input
+                id="approval-reminder-2"
+                value={reminder2Days}
+                onChange={(e) => onReminder2DaysChange(e.target.value)}
+                inputMode="numeric"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="approval-escalation-days">Eskalation ab Tag</Label>
+              <Input
+                id="approval-escalation-days"
+                value={escalationAfterDays}
+                onChange={(e) => onEscalationAfterDaysChange(e.target.value)}
+                inputMode="numeric"
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-slate-200 p-4">
+          <p className="text-sm font-semibold text-slate-900">5. Abschluss & Transparenz</p>
+          <div className="mt-3 flex items-center justify-between rounded-lg border border-slate-200 p-3">
+            <div>
+              <p className="text-sm font-medium">
+                Requester bei Eskalation benachrichtigen
+              </p>
+            </div>
+            <Switch
+              checked={autoNotifyRequesterOnEscalation}
+              onCheckedChange={onAutoNotifyRequesterOnEscalationChange}
+            />
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between rounded-lg border border-slate-200 bg-slate-50 p-3">
+          <div>
+            <p className="text-sm font-medium text-slate-900">Live-Ablaufvorschau</p>
+            <p className="mt-1 text-xs text-slate-500">
+              Tag 0 Anfrage · Tag {reminder1Days || '3'} Reminder 1 · Tag{' '}
+              {reminder2Days || '7'} Reminder 2 · Tag {escalationAfterDays || '10'}{' '}
+              Eskalation
+            </p>
+          </div>
+        </div>
+
+        <WorkflowSimulationPanel liveSettings={liveSettings} {...simulation} />
+      </CardContent>
+    </div>
+  )
+}

--- a/app/dashboard/settings/tabs/workflow-meddpicc-card.tsx
+++ b/app/dashboard/settings/tabs/workflow-meddpicc-card.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { useState } from 'react'
+
+import { CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Switch } from '@/components/ui/switch'
+
+import { SETTINGS_CARD_CLASS } from './settings-tab-shared'
+import {
+  DEFAULT_MEDDPICC_REQUIRED,
+  MEDDPICC_FIELDS,
+  type MeddpiccRequiredState,
+} from './workflow-types'
+
+export function WorkflowMeddpiccCard() {
+  const [meddpiccRequired, setMeddpiccRequired] = useState<MeddpiccRequiredState>(
+    DEFAULT_MEDDPICC_REQUIRED,
+  )
+
+  return (
+    <div className={SETTINGS_CARD_CLASS}>
+      <CardHeader className="px-0 pt-0">
+        <CardTitle className="text-base">MEDDPICC</CardTitle>
+      </CardHeader>
+      <CardContent className="grid gap-2 px-0 pb-0 sm:grid-cols-2">
+        {MEDDPICC_FIELDS.map(([key, label]) => (
+          <label
+            key={key}
+            className="flex items-center justify-between rounded-md border border-slate-200 px-3 py-2 text-sm"
+          >
+            {label}
+            <Switch
+              checked={meddpiccRequired[key]}
+              onCheckedChange={(checked) =>
+                setMeddpiccRequired((prev) => ({ ...prev, [key]: checked }))
+              }
+            />
+          </label>
+        ))}
+      </CardContent>
+    </div>
+  )
+}

--- a/app/dashboard/settings/tabs/workflow-simulation-panel.tsx
+++ b/app/dashboard/settings/tabs/workflow-simulation-panel.tsx
@@ -1,0 +1,207 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Switch } from '@/components/ui/switch'
+
+import type { WorkflowSettingsShape, WorkflowSimulationItem } from './workflow-types'
+
+export function WorkflowSimulationPanel({
+  liveSettings,
+  workflowSimulation,
+  simulationSandboxEnabled,
+  setSimulationSandboxEnabled,
+  simRequireInternalApproval,
+  setSimRequireInternalApproval,
+  simReminder1Days,
+  setSimReminder1Days,
+  simReminder2Days,
+  setSimReminder2Days,
+  simEscalationAfterDays,
+  setSimEscalationAfterDays,
+  simLinkExpiryDays,
+  setSimLinkExpiryDays,
+  simAutoNotifyRequesterOnEscalation,
+  setSimAutoNotifyRequesterOnEscalation,
+  simAutoAllowDelegation,
+  setSimAutoAllowDelegation,
+  runWorkflowSimulation,
+  resetWorkflowSandbox,
+}: {
+  liveSettings: WorkflowSettingsShape
+  workflowSimulation: WorkflowSimulationItem[]
+  simulationSandboxEnabled: boolean
+  setSimulationSandboxEnabled: (value: boolean) => void
+  simRequireInternalApproval: boolean
+  setSimRequireInternalApproval: (value: boolean) => void
+  simReminder1Days: string
+  setSimReminder1Days: (value: string) => void
+  simReminder2Days: string
+  setSimReminder2Days: (value: string) => void
+  simEscalationAfterDays: string
+  setSimEscalationAfterDays: (value: string) => void
+  simLinkExpiryDays: string
+  setSimLinkExpiryDays: (value: string) => void
+  simAutoNotifyRequesterOnEscalation: boolean
+  setSimAutoNotifyRequesterOnEscalation: (value: boolean) => void
+  simAutoAllowDelegation: boolean
+  setSimAutoAllowDelegation: (value: boolean) => void
+  runWorkflowSimulation: () => void
+  resetWorkflowSandbox: () => void
+}) {
+  return (
+    <div className="rounded-lg border border-slate-200 p-4">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold text-slate-900">Testlauf</p>
+        </div>
+        <Button type="button" size="sm" variant="outline" onClick={runWorkflowSimulation}>
+          Testlauf starten
+        </Button>
+      </div>
+      <div className="mt-3 rounded-md border border-slate-200 p-3">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm font-medium text-slate-900">What-if-Sandbox</p>
+          </div>
+          <Switch
+            checked={simulationSandboxEnabled}
+            onCheckedChange={setSimulationSandboxEnabled}
+          />
+        </div>
+        {simulationSandboxEnabled ? (
+          <div className="mt-3 grid gap-3 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <Label htmlFor="sim-reminder-1">Reminder #1</Label>
+              <Input
+                id="sim-reminder-1"
+                value={simReminder1Days}
+                onChange={(e) => setSimReminder1Days(e.target.value)}
+                inputMode="numeric"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="sim-reminder-2">Reminder #2</Label>
+              <Input
+                id="sim-reminder-2"
+                value={simReminder2Days}
+                onChange={(e) => setSimReminder2Days(e.target.value)}
+                inputMode="numeric"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="sim-escalation">Eskalation ab Tag</Label>
+              <Input
+                id="sim-escalation"
+                value={simEscalationAfterDays}
+                onChange={(e) => setSimEscalationAfterDays(e.target.value)}
+                inputMode="numeric"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="sim-ttl">Link Expiry (Tage)</Label>
+              <Input
+                id="sim-ttl"
+                value={simLinkExpiryDays}
+                onChange={(e) => setSimLinkExpiryDays(e.target.value)}
+                inputMode="numeric"
+              />
+            </div>
+            <div className="flex items-center justify-between rounded-md border border-slate-200 p-2.5 sm:col-span-2">
+              <span className="text-xs text-slate-600">Interne Freigabe aktiv</span>
+              <Switch
+                checked={simRequireInternalApproval}
+                onCheckedChange={setSimRequireInternalApproval}
+              />
+            </div>
+            <div className="flex items-center justify-between rounded-md border border-slate-200 p-2.5 sm:col-span-2">
+              <span className="text-xs text-slate-600">
+                Requester bei Eskalation benachrichtigen
+              </span>
+              <Switch
+                checked={simAutoNotifyRequesterOnEscalation}
+                onCheckedChange={setSimAutoNotifyRequesterOnEscalation}
+              />
+            </div>
+            <div className="flex items-center justify-between rounded-md border border-slate-200 p-2.5 sm:col-span-2">
+              <span className="text-xs text-slate-600">Delegation erlauben</span>
+              <Switch
+                checked={simAutoAllowDelegation}
+                onCheckedChange={setSimAutoAllowDelegation}
+              />
+            </div>
+            <div className="rounded-md border border-slate-200 bg-slate-50 p-2.5 sm:col-span-2">
+              <p className="text-xs font-medium text-slate-700">
+                Delta zur Live-Konfiguration
+              </p>
+              <ul className="mt-1.5 space-y-1 text-xs text-slate-600">
+                <li>
+                  Reminder #1: Live {liveSettings.reminder1Days}d → Sandbox{' '}
+                  {simReminder1Days || '—'}d
+                </li>
+                <li>
+                  Reminder #2: Live {liveSettings.reminder2Days}d → Sandbox{' '}
+                  {simReminder2Days || '—'}d
+                </li>
+                <li>
+                  Eskalation: Live {liveSettings.escalationAfterDays}d → Sandbox{' '}
+                  {simEscalationAfterDays || '—'}d
+                </li>
+                <li>
+                  TTL: Live {liveSettings.linkExpiryDays}d → Sandbox{' '}
+                  {simLinkExpiryDays || '—'}d
+                </li>
+                <li>
+                  Interne Freigabe: Live{' '}
+                  {liveSettings.requireInternalApproval ? 'an' : 'aus'} → Sandbox{' '}
+                  {simRequireInternalApproval ? 'an' : 'aus'}
+                </li>
+                <li>
+                  Eskalations-Notify: Live{' '}
+                  {liveSettings.autoNotifyRequesterOnEscalation ? 'an' : 'aus'} → Sandbox{' '}
+                  {simAutoNotifyRequesterOnEscalation ? 'an' : 'aus'}
+                </li>
+                <li>
+                  Delegation: Live {liveSettings.autoAllowDelegation ? 'an' : 'aus'} →
+                  Sandbox {simAutoAllowDelegation ? 'an' : 'aus'}
+                </li>
+              </ul>
+            </div>
+            <div className="sm:col-span-2 flex justify-end">
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                onClick={resetWorkflowSandbox}
+              >
+                Sandbox zurücksetzen
+              </Button>
+            </div>
+          </div>
+        ) : null}
+      </div>
+      {workflowSimulation.length > 0 ? (
+        <ul className="mt-4 space-y-2">
+          {workflowSimulation.map((item, idx) => (
+            <li
+              key={`${item.day}-${item.label}-${idx}`}
+              className={`rounded-md border px-3 py-2 ${
+                item.tone === 'warning'
+                  ? 'border-amber-200 bg-amber-50'
+                  : item.tone === 'info'
+                    ? 'border-blue-200 bg-blue-50'
+                    : 'border-slate-200 bg-slate-50'
+              }`}
+            >
+              <p className="text-sm font-medium text-slate-900">
+                Tag {item.day}: {item.label}
+              </p>
+              <p className="mt-0.5 text-xs text-slate-600">{item.detail}</p>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  )
+}

--- a/app/dashboard/settings/tabs/workflow-static-cards.tsx
+++ b/app/dashboard/settings/tabs/workflow-static-cards.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { ChevronRight, ClipboardList, ShieldCheck, Zap } from 'lucide-react'
+
+import { SETTINGS_CARD_CLASS } from './settings-tab-shared'
+
+export function WorkflowApprovalProcessCard() {
+  return (
+    <div className={SETTINGS_CARD_CLASS}>
+      <CardHeader className="px-0 pt-0">
+        <CardTitle className="text-base">Approval Process</CardTitle>
+      </CardHeader>
+      <CardContent className="px-0 pb-0">
+        <div className="flex flex-col items-start gap-2 rounded-lg border border-slate-200 p-4 text-sm sm:flex-row sm:items-center">
+          <span className="inline-flex items-center gap-2 rounded-md bg-slate-100 px-3 py-1.5 font-medium">
+            <ClipboardList className="h-4 w-4" /> Entwurf
+          </span>
+          <ChevronRight className="h-4 w-4 text-muted-foreground" />
+          <span className="inline-flex items-center gap-2 rounded-md bg-slate-100 px-3 py-1.5 font-medium">
+            <ShieldCheck className="h-4 w-4" /> Interner Review
+          </span>
+          <ChevronRight className="h-4 w-4 text-muted-foreground" />
+          <span className="inline-flex items-center gap-2 rounded-md bg-slate-100 px-3 py-1.5 font-medium">
+            <Zap className="h-4 w-4" /> Kundenfreigabe
+          </span>
+        </div>
+      </CardContent>
+    </div>
+  )
+}
+
+export function WorkflowAutomationCard() {
+  return (
+    <div className={SETTINGS_CARD_CLASS}>
+      <CardHeader className="px-0 pt-0">
+        <CardTitle className="text-base">Automation</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2 px-0 pb-0">
+        <div className="rounded-md border border-slate-200 p-3 text-sm">
+          Marktsignal Kategorie X → Push-Nachricht an Owner
+        </div>
+        <div className="rounded-md border border-slate-200 p-3 text-sm">
+          Approval überfällig → Eskalation an Requester
+        </div>
+      </CardContent>
+    </div>
+  )
+}

--- a/app/dashboard/settings/tabs/workflow-tab.tsx
+++ b/app/dashboard/settings/tabs/workflow-tab.tsx
@@ -1,251 +1,38 @@
 'use client'
 
-import { useState, useTransition } from 'react'
-import { toast } from 'sonner'
 import { TabsContent } from '@/components/ui/tabs'
-import { Button } from '@/components/ui/button'
-import { CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import { Switch } from '@/components/ui/switch'
-import { ChevronRight, ShieldCheck, Zap, ClipboardList } from 'lucide-react'
+
 import { SettingsExportTemplatesCard } from '../settings-export-templates-card'
-import type { ExportSettings } from '../settings-export-templates-actions'
-import { updateWorkflowSettings } from '../settings-consolidation-actions'
-import { SETTINGS_CARD_CLASS, type RegisterSettingsTab } from './settings-tab-shared'
+import { SETTINGS_CARD_CLASS } from './settings-tab-shared'
 import { useRegisterSettingsTab } from './use-register-settings-tab'
-
-type WorkflowSimulationItem = {
-  day: number
-  label: string
-  detail: string
-  tone: 'neutral' | 'info' | 'warning'
-}
-
-type WorkflowTabProps = {
-  org: {
-    id: string | null
-    exportSettings: ExportSettings
-    workflowSettings: {
-      linkExpiryDays: number
-      requireInternalApproval: boolean
-      reminder1Days: number
-      reminder2Days: number
-      escalationAfterDays: number
-      autoNotifyRequesterOnEscalation: boolean
-      autoAllowDelegation: boolean
-    }
-  }
-  register: RegisterSettingsTab
-}
+import { useWorkflowSettings } from './use-workflow-settings'
+import { useWorkflowSimulation } from './use-workflow-simulation'
+import { WorkflowFreigabeSettingsCard } from './workflow-freigabe-settings-card'
+import { WorkflowMeddpiccCard } from './workflow-meddpicc-card'
+import {
+  WorkflowApprovalProcessCard,
+  WorkflowAutomationCard,
+} from './workflow-static-cards'
+import type { WorkflowTabProps } from './workflow-types'
 
 export function WorkflowTab({ org, register }: WorkflowTabProps) {
-  const [linkExpiryDays, setLinkExpiryDays] = useState(
-    String(org.workflowSettings.linkExpiryDays),
-  )
-  const [requireInternalApproval, setRequireInternalApproval] = useState(
-    org.workflowSettings.requireInternalApproval,
-  )
-  const [reminder1Days, setReminder1Days] = useState(
-    String(org.workflowSettings.reminder1Days),
-  )
-  const [reminder2Days, setReminder2Days] = useState(
-    String(org.workflowSettings.reminder2Days),
-  )
-  const [escalationAfterDays, setEscalationAfterDays] = useState(
-    String(org.workflowSettings.escalationAfterDays),
-  )
-  const [autoNotifyRequesterOnEscalation, setAutoNotifyRequesterOnEscalation] = useState(
-    org.workflowSettings.autoNotifyRequesterOnEscalation,
-  )
-  const [autoAllowDelegation, setAutoAllowDelegation] = useState(
-    org.workflowSettings.autoAllowDelegation,
-  )
-  const [workflowPending, startWorkflowTransition] = useTransition()
-  const [workflowSimulation, setWorkflowSimulation] = useState<WorkflowSimulationItem[]>(
-    [],
-  )
-  const [simulationSandboxEnabled, setSimulationSandboxEnabled] = useState(false)
-  const [simRequireInternalApproval, setSimRequireInternalApproval] = useState(
-    org.workflowSettings.requireInternalApproval,
-  )
-  const [simReminder1Days, setSimReminder1Days] = useState(
-    String(org.workflowSettings.reminder1Days),
-  )
-  const [simReminder2Days, setSimReminder2Days] = useState(
-    String(org.workflowSettings.reminder2Days),
-  )
-  const [simEscalationAfterDays, setSimEscalationAfterDays] = useState(
-    String(org.workflowSettings.escalationAfterDays),
-  )
-  const [simLinkExpiryDays, setSimLinkExpiryDays] = useState(
-    String(org.workflowSettings.linkExpiryDays),
-  )
-  const [simAutoNotifyRequesterOnEscalation, setSimAutoNotifyRequesterOnEscalation] =
-    useState(org.workflowSettings.autoNotifyRequesterOnEscalation)
-  const [simAutoAllowDelegation, setSimAutoAllowDelegation] = useState(
-    org.workflowSettings.autoAllowDelegation,
-  )
-  const [meddpiccRequired, setMeddpiccRequired] = useState({
-    metricsPain: true,
-    economicBuyer: true,
-    decisionCriteria: false,
-    decisionProcess: false,
-    identifyPain: true,
-    champion: true,
-    competition: false,
+  const settings = useWorkflowSettings(org.workflowSettings)
+  const simulation = useWorkflowSimulation(org.workflowSettings, {
+    requireInternalApproval: settings.requireInternalApproval,
+    reminder1Days: settings.reminder1Days,
+    reminder2Days: settings.reminder2Days,
+    escalationAfterDays: settings.escalationAfterDays,
+    linkExpiryDays: settings.linkExpiryDays,
+    autoNotifyRequesterOnEscalation: settings.autoNotifyRequesterOnEscalation,
+    autoAllowDelegation: settings.autoAllowDelegation,
   })
-
-  const workflowDirty =
-    linkExpiryDays !== String(org.workflowSettings.linkExpiryDays) ||
-    requireInternalApproval !== org.workflowSettings.requireInternalApproval ||
-    reminder1Days !== String(org.workflowSettings.reminder1Days) ||
-    reminder2Days !== String(org.workflowSettings.reminder2Days) ||
-    escalationAfterDays !== String(org.workflowSettings.escalationAfterDays) ||
-    autoNotifyRequesterOnEscalation !==
-      org.workflowSettings.autoNotifyRequesterOnEscalation ||
-    autoAllowDelegation !== org.workflowSettings.autoAllowDelegation
-
-  function saveWorkflow() {
-    startWorkflowTransition(async () => {
-      const parsed = Number(linkExpiryDays)
-      const rem1 = Number(reminder1Days)
-      const rem2 = Number(reminder2Days)
-      const escal = Number(escalationAfterDays)
-      const result = await updateWorkflowSettings({
-        linkExpiryDays: Number.isFinite(parsed) ? parsed : 14,
-        requireInternalApproval,
-        reminder1Days: Number.isFinite(rem1) ? rem1 : 3,
-        reminder2Days: Number.isFinite(rem2) ? rem2 : 7,
-        escalationAfterDays: Number.isFinite(escal) ? escal : 10,
-        autoNotifyRequesterOnEscalation,
-        autoAllowDelegation,
-      })
-      if (!result.success) {
-        toast.error(result.error)
-        return
-      }
-      toast.success('Workflow-Einstellungen gespeichert')
-    })
-  }
-
-  function runWorkflowSimulation() {
-    const sourceRequireInternalApproval = simulationSandboxEnabled
-      ? simRequireInternalApproval
-      : requireInternalApproval
-    const sourceReminder1Days = simulationSandboxEnabled
-      ? simReminder1Days
-      : reminder1Days
-    const sourceReminder2Days = simulationSandboxEnabled
-      ? simReminder2Days
-      : reminder2Days
-    const sourceEscalationAfterDays = simulationSandboxEnabled
-      ? simEscalationAfterDays
-      : escalationAfterDays
-    const sourceLinkExpiryDays = simulationSandboxEnabled
-      ? simLinkExpiryDays
-      : linkExpiryDays
-    const sourceAutoNotifyRequesterOnEscalation = simulationSandboxEnabled
-      ? simAutoNotifyRequesterOnEscalation
-      : autoNotifyRequesterOnEscalation
-    const sourceAutoAllowDelegation = simulationSandboxEnabled
-      ? simAutoAllowDelegation
-      : autoAllowDelegation
-
-    const rem1 = Math.max(
-      1,
-      Number.isFinite(Number(sourceReminder1Days))
-        ? Math.trunc(Number(sourceReminder1Days))
-        : 3,
-    )
-    const rem2 = Math.max(
-      rem1,
-      Number.isFinite(Number(sourceReminder2Days))
-        ? Math.trunc(Number(sourceReminder2Days))
-        : 7,
-    )
-    const escal = Math.max(
-      rem2,
-      Number.isFinite(Number(sourceEscalationAfterDays))
-        ? Math.trunc(Number(sourceEscalationAfterDays))
-        : 10,
-    )
-    const ttl = Math.max(
-      1,
-      Number.isFinite(Number(sourceLinkExpiryDays))
-        ? Math.trunc(Number(sourceLinkExpiryDays))
-        : 14,
-    )
-
-    const items: WorkflowSimulationItem[] = [
-      {
-        day: 0,
-        label: 'Freigabe angefordert',
-        detail: sourceRequireInternalApproval
-          ? 'Referenz landet zuerst im internen Review (pending_internal).'
-          : 'Kundenfreigabe wird direkt versendet (pending).',
-        tone: 'info',
-      },
-      {
-        day: rem1,
-        label: 'Reminder #1',
-        detail: 'Automatischer Follow-up an den aktuellen Empfänger.',
-        tone: 'neutral',
-      },
-      {
-        day: rem2,
-        label: 'Reminder #2',
-        detail: 'Zweiter Reminder, falls weiterhin keine Entscheidung vorliegt.',
-        tone: 'neutral',
-      },
-      {
-        day: escal,
-        label: 'Eskalation',
-        detail: sourceAutoNotifyRequesterOnEscalation
-          ? 'Requester wird aktiv benachrichtigt.'
-          : 'Eskalation ohne automatische Requester-Benachrichtigung.',
-        tone: 'warning',
-      },
-      {
-        day: ttl,
-        label: 'Link läuft ab',
-        detail: 'Freigabelink erreicht das Ablaufdatum aus den Workflow-Regeln.',
-        tone: 'warning',
-      },
-    ]
-
-    if (sourceAutoAllowDelegation) {
-      items.splice(1, 0, {
-        day: 1,
-        label: 'Delegation möglich',
-        detail: 'Empfänger kann Anfrage an Kollegen delegieren.',
-        tone: 'info',
-      })
-    }
-
-    setWorkflowSimulation(items.sort((a, b) => a.day - b.day))
-    toast.success('Testlauf aktualisiert')
-  }
-
-  function resetWorkflowSandbox() {
-    setSimRequireInternalApproval(org.workflowSettings.requireInternalApproval)
-    setSimReminder1Days(String(org.workflowSettings.reminder1Days))
-    setSimReminder2Days(String(org.workflowSettings.reminder2Days))
-    setSimEscalationAfterDays(String(org.workflowSettings.escalationAfterDays))
-    setSimLinkExpiryDays(String(org.workflowSettings.linkExpiryDays))
-    setSimAutoNotifyRequesterOnEscalation(
-      org.workflowSettings.autoNotifyRequesterOnEscalation,
-    )
-    setSimAutoAllowDelegation(org.workflowSettings.autoAllowDelegation)
-    toast.success('Sandbox auf Live-Werte zurückgesetzt')
-  }
 
   useRegisterSettingsTab(
     'process',
     {
-      dirty: workflowDirty,
-      pending: workflowPending,
-      save: saveWorkflow,
+      dirty: settings.workflowDirty,
+      pending: settings.workflowPending,
+      save: settings.saveWorkflow,
     },
     register,
   )
@@ -253,344 +40,35 @@ export function WorkflowTab({ org, register }: WorkflowTabProps) {
   return (
     <TabsContent value="process">
       <div className="space-y-6">
-        <div className={SETTINGS_CARD_CLASS}>
-          <CardHeader className="px-0 pt-0">
-            <CardTitle className="text-base">Approval Process</CardTitle>
-          </CardHeader>
-          <CardContent className="px-0 pb-0">
-            <div className="flex flex-col items-start gap-2 rounded-lg border border-slate-200 p-4 text-sm sm:flex-row sm:items-center">
-              <span className="inline-flex items-center gap-2 rounded-md bg-slate-100 px-3 py-1.5 font-medium">
-                <ClipboardList className="h-4 w-4" /> Entwurf
-              </span>
-              <ChevronRight className="h-4 w-4 text-muted-foreground" />
-              <span className="inline-flex items-center gap-2 rounded-md bg-slate-100 px-3 py-1.5 font-medium">
-                <ShieldCheck className="h-4 w-4" /> Interner Review
-              </span>
-              <ChevronRight className="h-4 w-4 text-muted-foreground" />
-              <span className="inline-flex items-center gap-2 rounded-md bg-slate-100 px-3 py-1.5 font-medium">
-                <Zap className="h-4 w-4" /> Kundenfreigabe
-              </span>
-            </div>
-          </CardContent>
-        </div>
-        <div className={SETTINGS_CARD_CLASS}>
-          <CardHeader className="px-0 pt-0">
-            <CardTitle className="text-base">Automation</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-2 px-0 pb-0">
-            <div className="rounded-md border border-slate-200 p-3 text-sm">
-              Marktsignal Kategorie X → Push-Nachricht an Owner
-            </div>
-            <div className="rounded-md border border-slate-200 p-3 text-sm">
-              Approval überfällig → Eskalation an Requester
-            </div>
-          </CardContent>
-        </div>
-        <div className={SETTINGS_CARD_CLASS}>
-          <CardHeader className="px-0 pt-0">
-            <CardTitle className="text-base">MEDDPICC</CardTitle>
-          </CardHeader>
-          <CardContent className="grid gap-2 px-0 pb-0 sm:grid-cols-2">
-            {(
-              [
-                ['metricsPain', 'Metrics & Pain'],
-                ['economicBuyer', 'Economic Buyer'],
-                ['decisionCriteria', 'Decision Criteria'],
-                ['decisionProcess', 'Decision Process'],
-                ['identifyPain', 'Identify Pain'],
-                ['champion', 'Champion'],
-                ['competition', 'Competition'],
-              ] as const
-            ).map(([key, label]) => (
-              <label
-                key={key}
-                className="flex items-center justify-between rounded-md border border-slate-200 px-3 py-2 text-sm"
-              >
-                {label}
-                <Switch
-                  checked={meddpiccRequired[key]}
-                  onCheckedChange={(checked) =>
-                    setMeddpiccRequired((prev) => ({ ...prev, [key]: checked }))
-                  }
-                />
-              </label>
-            ))}
-          </CardContent>
-        </div>
+        <WorkflowApprovalProcessCard />
+        <WorkflowAutomationCard />
+        <WorkflowMeddpiccCard />
         <div className={SETTINGS_CARD_CLASS}>
           <SettingsExportTemplatesCard
             organizationId={org.id}
             initial={org.exportSettings}
           />
         </div>
-        <div className={SETTINGS_CARD_CLASS}>
-          <CardHeader className="space-y-2 px-0 pt-0">
-            <CardTitle className="text-base">Freigabe-Workflow</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4 px-0 pb-0 pt-2">
-            <div className="rounded-lg border border-slate-200 p-4">
-              <p className="text-sm font-semibold text-slate-900">1. Entry</p>
-              <div className="mt-3 max-w-sm space-y-2">
-                <Label htmlFor="link-expiry-days">Link Expiry (Tage)</Label>
-                <Input
-                  id="link-expiry-days"
-                  value={linkExpiryDays}
-                  onChange={(e) => setLinkExpiryDays(e.target.value)}
-                  inputMode="numeric"
-                />
-              </div>
-            </div>
-
-            <div className="rounded-lg border border-slate-200 p-4">
-              <p className="text-sm font-semibold text-slate-900">2. Interne Prüfung</p>
-              <div className="mt-3 flex items-center justify-between rounded-lg border border-slate-200 p-3">
-                <div>
-                  <p className="text-sm font-medium">Vier-Augen-Prinzip aktiv</p>
-                </div>
-                <Switch
-                  checked={requireInternalApproval}
-                  onCheckedChange={setRequireInternalApproval}
-                />
-              </div>
-            </div>
-
-            <div className="rounded-lg border border-slate-200 p-4">
-              <p className="text-sm font-semibold text-slate-900">3. Externer Versand</p>
-              <div className="mt-3 flex items-center justify-between rounded-lg border border-slate-200 p-3">
-                <div>
-                  <p className="text-sm font-medium">Delegation erlauben</p>
-                </div>
-                <Switch
-                  checked={autoAllowDelegation}
-                  onCheckedChange={setAutoAllowDelegation}
-                />
-              </div>
-            </div>
-
-            <div className="rounded-lg border border-slate-200 p-4">
-              <p className="text-sm font-semibold text-slate-900">4. Follow-up Sequenz</p>
-              <div className="mt-3 grid gap-3 sm:grid-cols-3">
-                <div className="space-y-1.5">
-                  <Label htmlFor="approval-reminder-1">Reminder #1 (Tage)</Label>
-                  <Input
-                    id="approval-reminder-1"
-                    value={reminder1Days}
-                    onChange={(e) => setReminder1Days(e.target.value)}
-                    inputMode="numeric"
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="approval-reminder-2">Reminder #2 (Tage)</Label>
-                  <Input
-                    id="approval-reminder-2"
-                    value={reminder2Days}
-                    onChange={(e) => setReminder2Days(e.target.value)}
-                    inputMode="numeric"
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="approval-escalation-days">Eskalation ab Tag</Label>
-                  <Input
-                    id="approval-escalation-days"
-                    value={escalationAfterDays}
-                    onChange={(e) => setEscalationAfterDays(e.target.value)}
-                    inputMode="numeric"
-                  />
-                </div>
-              </div>
-            </div>
-
-            <div className="rounded-lg border border-slate-200 p-4">
-              <p className="text-sm font-semibold text-slate-900">
-                5. Abschluss & Transparenz
-              </p>
-              <div className="mt-3 flex items-center justify-between rounded-lg border border-slate-200 p-3">
-                <div>
-                  <p className="text-sm font-medium">
-                    Requester bei Eskalation benachrichtigen
-                  </p>
-                </div>
-                <Switch
-                  checked={autoNotifyRequesterOnEscalation}
-                  onCheckedChange={setAutoNotifyRequesterOnEscalation}
-                />
-              </div>
-            </div>
-
-            <div className="flex items-center justify-between rounded-lg border border-slate-200 bg-slate-50 p-3">
-              <div>
-                <p className="text-sm font-medium text-slate-900">Live-Ablaufvorschau</p>
-                <p className="mt-1 text-xs text-slate-500">
-                  Tag 0 Anfrage · Tag {reminder1Days || '3'} Reminder 1 · Tag{' '}
-                  {reminder2Days || '7'} Reminder 2 · Tag {escalationAfterDays || '10'}{' '}
-                  Eskalation
-                </p>
-              </div>
-            </div>
-            <div className="rounded-lg border border-slate-200 p-4">
-              <div className="flex items-center justify-between gap-3">
-                <div>
-                  <p className="text-sm font-semibold text-slate-900">Testlauf</p>
-                </div>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  onClick={runWorkflowSimulation}
-                >
-                  Testlauf starten
-                </Button>
-              </div>
-              <div className="mt-3 rounded-md border border-slate-200 p-3">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <p className="text-sm font-medium text-slate-900">What-if-Sandbox</p>
-                  </div>
-                  <Switch
-                    checked={simulationSandboxEnabled}
-                    onCheckedChange={setSimulationSandboxEnabled}
-                  />
-                </div>
-                {simulationSandboxEnabled ? (
-                  <div className="mt-3 grid gap-3 sm:grid-cols-2">
-                    <div className="space-y-1.5">
-                      <Label htmlFor="sim-reminder-1">Reminder #1</Label>
-                      <Input
-                        id="sim-reminder-1"
-                        value={simReminder1Days}
-                        onChange={(e) => setSimReminder1Days(e.target.value)}
-                        inputMode="numeric"
-                      />
-                    </div>
-                    <div className="space-y-1.5">
-                      <Label htmlFor="sim-reminder-2">Reminder #2</Label>
-                      <Input
-                        id="sim-reminder-2"
-                        value={simReminder2Days}
-                        onChange={(e) => setSimReminder2Days(e.target.value)}
-                        inputMode="numeric"
-                      />
-                    </div>
-                    <div className="space-y-1.5">
-                      <Label htmlFor="sim-escalation">Eskalation ab Tag</Label>
-                      <Input
-                        id="sim-escalation"
-                        value={simEscalationAfterDays}
-                        onChange={(e) => setSimEscalationAfterDays(e.target.value)}
-                        inputMode="numeric"
-                      />
-                    </div>
-                    <div className="space-y-1.5">
-                      <Label htmlFor="sim-ttl">Link Expiry (Tage)</Label>
-                      <Input
-                        id="sim-ttl"
-                        value={simLinkExpiryDays}
-                        onChange={(e) => setSimLinkExpiryDays(e.target.value)}
-                        inputMode="numeric"
-                      />
-                    </div>
-                    <div className="flex items-center justify-between rounded-md border border-slate-200 p-2.5 sm:col-span-2">
-                      <span className="text-xs text-slate-600">
-                        Interne Freigabe aktiv
-                      </span>
-                      <Switch
-                        checked={simRequireInternalApproval}
-                        onCheckedChange={setSimRequireInternalApproval}
-                      />
-                    </div>
-                    <div className="flex items-center justify-between rounded-md border border-slate-200 p-2.5 sm:col-span-2">
-                      <span className="text-xs text-slate-600">
-                        Requester bei Eskalation benachrichtigen
-                      </span>
-                      <Switch
-                        checked={simAutoNotifyRequesterOnEscalation}
-                        onCheckedChange={setSimAutoNotifyRequesterOnEscalation}
-                      />
-                    </div>
-                    <div className="flex items-center justify-between rounded-md border border-slate-200 p-2.5 sm:col-span-2">
-                      <span className="text-xs text-slate-600">Delegation erlauben</span>
-                      <Switch
-                        checked={simAutoAllowDelegation}
-                        onCheckedChange={setSimAutoAllowDelegation}
-                      />
-                    </div>
-                    <div className="rounded-md border border-slate-200 bg-slate-50 p-2.5 sm:col-span-2">
-                      <p className="text-xs font-medium text-slate-700">
-                        Delta zur Live-Konfiguration
-                      </p>
-                      <ul className="mt-1.5 space-y-1 text-xs text-slate-600">
-                        <li>
-                          Reminder #1: Live {org.workflowSettings.reminder1Days}d →
-                          Sandbox {simReminder1Days || '—'}d
-                        </li>
-                        <li>
-                          Reminder #2: Live {org.workflowSettings.reminder2Days}d →
-                          Sandbox {simReminder2Days || '—'}d
-                        </li>
-                        <li>
-                          Eskalation: Live {org.workflowSettings.escalationAfterDays}d →
-                          Sandbox {simEscalationAfterDays || '—'}d
-                        </li>
-                        <li>
-                          TTL: Live {org.workflowSettings.linkExpiryDays}d → Sandbox{' '}
-                          {simLinkExpiryDays || '—'}d
-                        </li>
-                        <li>
-                          Interne Freigabe: Live{' '}
-                          {org.workflowSettings.requireInternalApproval ? 'an' : 'aus'} →
-                          Sandbox {simRequireInternalApproval ? 'an' : 'aus'}
-                        </li>
-                        <li>
-                          Eskalations-Notify: Live{' '}
-                          {org.workflowSettings.autoNotifyRequesterOnEscalation
-                            ? 'an'
-                            : 'aus'}{' '}
-                          → Sandbox {simAutoNotifyRequesterOnEscalation ? 'an' : 'aus'}
-                        </li>
-                        <li>
-                          Delegation: Live{' '}
-                          {org.workflowSettings.autoAllowDelegation ? 'an' : 'aus'} →
-                          Sandbox {simAutoAllowDelegation ? 'an' : 'aus'}
-                        </li>
-                      </ul>
-                    </div>
-                    <div className="sm:col-span-2 flex justify-end">
-                      <Button
-                        type="button"
-                        size="sm"
-                        variant="ghost"
-                        onClick={resetWorkflowSandbox}
-                      >
-                        Sandbox zurücksetzen
-                      </Button>
-                    </div>
-                  </div>
-                ) : null}
-              </div>
-              {workflowSimulation.length > 0 ? (
-                <ul className="mt-4 space-y-2">
-                  {workflowSimulation.map((item, idx) => (
-                    <li
-                      key={`${item.day}-${item.label}-${idx}`}
-                      className={`rounded-md border px-3 py-2 ${
-                        item.tone === 'warning'
-                          ? 'border-amber-200 bg-amber-50'
-                          : item.tone === 'info'
-                            ? 'border-blue-200 bg-blue-50'
-                            : 'border-slate-200 bg-slate-50'
-                      }`}
-                    >
-                      <p className="text-sm font-medium text-slate-900">
-                        Tag {item.day}: {item.label}
-                      </p>
-                      <p className="mt-0.5 text-xs text-slate-600">{item.detail}</p>
-                    </li>
-                  ))}
-                </ul>
-              ) : null}
-            </div>
-          </CardContent>
-        </div>
+        <WorkflowFreigabeSettingsCard
+          linkExpiryDays={settings.linkExpiryDays}
+          onLinkExpiryDaysChange={settings.setLinkExpiryDays}
+          requireInternalApproval={settings.requireInternalApproval}
+          onRequireInternalApprovalChange={settings.setRequireInternalApproval}
+          autoAllowDelegation={settings.autoAllowDelegation}
+          onAutoAllowDelegationChange={settings.setAutoAllowDelegation}
+          reminder1Days={settings.reminder1Days}
+          onReminder1DaysChange={settings.setReminder1Days}
+          reminder2Days={settings.reminder2Days}
+          onReminder2DaysChange={settings.setReminder2Days}
+          escalationAfterDays={settings.escalationAfterDays}
+          onEscalationAfterDaysChange={settings.setEscalationAfterDays}
+          autoNotifyRequesterOnEscalation={settings.autoNotifyRequesterOnEscalation}
+          onAutoNotifyRequesterOnEscalationChange={
+            settings.setAutoNotifyRequesterOnEscalation
+          }
+          liveSettings={org.workflowSettings}
+          simulation={simulation}
+        />
       </div>
     </TabsContent>
   )

--- a/app/dashboard/settings/tabs/workflow-types.ts
+++ b/app/dashboard/settings/tabs/workflow-types.ts
@@ -1,0 +1,58 @@
+import type { ExportSettings } from '../settings-export-templates-actions'
+import type { RegisterSettingsTab } from './settings-tab-shared'
+
+export type WorkflowSimulationItem = {
+  day: number
+  label: string
+  detail: string
+  tone: 'neutral' | 'info' | 'warning'
+}
+
+export type WorkflowSettingsShape = {
+  linkExpiryDays: number
+  requireInternalApproval: boolean
+  reminder1Days: number
+  reminder2Days: number
+  escalationAfterDays: number
+  autoNotifyRequesterOnEscalation: boolean
+  autoAllowDelegation: boolean
+}
+
+export type WorkflowTabProps = {
+  org: {
+    id: string | null
+    exportSettings: ExportSettings
+    workflowSettings: WorkflowSettingsShape
+  }
+  register: RegisterSettingsTab
+}
+
+export type MeddpiccRequiredState = {
+  metricsPain: boolean
+  economicBuyer: boolean
+  decisionCriteria: boolean
+  decisionProcess: boolean
+  identifyPain: boolean
+  champion: boolean
+  competition: boolean
+}
+
+export const MEDDPICC_FIELDS = [
+  ['metricsPain', 'Metrics & Pain'],
+  ['economicBuyer', 'Economic Buyer'],
+  ['decisionCriteria', 'Decision Criteria'],
+  ['decisionProcess', 'Decision Process'],
+  ['identifyPain', 'Identify Pain'],
+  ['champion', 'Champion'],
+  ['competition', 'Competition'],
+] as const satisfies ReadonlyArray<readonly [keyof MeddpiccRequiredState, string]>
+
+export const DEFAULT_MEDDPICC_REQUIRED: MeddpiccRequiredState = {
+  metricsPain: true,
+  economicBuyer: true,
+  decisionCriteria: false,
+  decisionProcess: false,
+  identifyPain: true,
+  champion: true,
+  competition: false,
+}

--- a/docs/tech-debt-offen-backlog.md
+++ b/docs/tech-debt-offen-backlog.md
@@ -28,7 +28,7 @@
 | **2** | E7 Schema-Sync | ✅ T1–T4 | Types bei Migrationen regenerieren (`db:types`) | XS ongoing | bei Schema-Change |
 | **3** | Typed-Supabase Cast-Abbau | ✅ T1–T4 | Rest-Casts nur Boundaries (HTTP/RPC/Json); Boy-Scout bei Touch | — | CI: `typecheck` vor Build |
 | **4** | P1-6 Accounts Naming | ✅ App/Lib | DB-Tabelle `companies` / `company_id` / Firmennamen-Helfer **bewusst offen** | — | nicht anfassen ohne Produktentscheid |
-| **5** | God-File-Nacharbeit | Slice 1–10 ✅ | … + deals-client, nda-popover | M ongoing | nächster: Boy-Scout bei Touch / nächste Top-Dateien |
+| **5** | God-File-Nacharbeit | Slice 1–11 ✅ | … + nda-popover, workflow-tab | M ongoing | nächster: account-detail-client Hooks / Boy-Scout |
 | **6** | `{ ok }` → `{ success }` | Lib ✅ | Slices 1–4; Rest nur Cron/Push-HTTP-Body | XS | Cron/Push separat wenn Monitoring-Clients ok |
 | **7** | P3-3 DE/EN-Dateinamen | ✅ Slice | `ai-draft-*`, `customer-control-link-email`; API `/api/ai-draft` + Redirect; UI-Copy „Sperrlink“/Event `ki_entwurf_generated` bleiben | — | Rest nur bei Touch |
 | **8** | `references`/`evidence` Pfade | ✅ | App = `references` (Routen/Ordner/`ROUTES`); Redirects `/dashboard/evidence` bleiben; `evidence_events` bleibt | — | Rest-`evidence` nur Domänenbegriff (RFP-Belege) |


### PR DESCRIPTION
## Summary
- Split `workflow-tab.tsx` (~597 → ~75) into types, static cards, MEDDPICC card, freigabe settings card, simulation panel, and settings/simulation hooks
- Settings dirty/save registration unchanged
- Behavior unchanged (live preview, sandbox what-if, testlauf timeline)

## Test plan
- [ ] Settings → Prozess: edit freigabe fields, dirty save bar works
- [ ] MEDDPICC toggles local only
- [ ] Testlauf starten with live values
- [ ] Enable sandbox, change sim values, see delta, reset sandbox, re-run
- [ ] Export templates card still renders


Made with [Cursor](https://cursor.com)