### PR TITLE
refactor(#5): extract account detail hooks (slice 12)

### DIFF
--- a/app/dashboard/accounts/account-detail-client.tsx
+++ b/app/dashboard/accounts/account-detail-client.tsx
@@ -1,36 +1,29 @@
 'use client'
 
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useState } from 'react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { Award, Compass, Kanban, Users } from 'lucide-react'
-import { toast } from 'sonner'
+
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { useRole } from '@/hooks/useRole'
 import { COPY } from '@/lib/copy'
-import type { ContactPersonRow, StakeholderRole, StakeholderRow } from './actions'
-import {
-  createContactPerson,
-  createStakeholder,
-  deleteContactPerson,
-  deleteStakeholder,
-  setCompanyInternalReferenceApprovalContact,
-  updateContactPerson,
-  updateExternalContactBuyingCenterRole,
-  updateStakeholder,
-  upsertCompanyStrategy,
-} from './actions'
+
 import { AccountContactDialog } from './account-contact-dialog'
-import type { AccountDetailClientProps } from './account-detail-types'
+import {
+  ACCOUNT_DETAIL_TAB_TRIGGER_CLASS,
+  parseAccountDetailTab,
+  type AccountDetailTab,
+} from './account-detail-constants'
 import { AccountDetailHeader } from './account-detail-header'
+import { AccountDetailPipelineTab } from './account-detail-pipeline-tab'
+import { AccountDetailPowerMapTab } from './account-detail-power-map-tab'
+import { AccountDetailProofPointsTab } from './account-detail-proof-points-tab'
 import { AccountDetailStrategyTab } from './account-detail-strategy-tab'
+import type { AccountDetailClientProps } from './account-detail-types'
 import { AccountStakeholderDialog } from './account-stakeholder-dialog'
 import { EditAccountDialog } from './edit-account-dialog'
-import { AccountDetailPipelineTab } from './account-detail-pipeline-tab'
-import { AccountDetailProofPointsTab } from './account-detail-proof-points-tab'
-import { AccountDetailPowerMapTab } from './account-detail-power-map-tab'
-
-const ACCOUNT_DETAIL_TAB_TRIGGER_CLASS =
-  'h-auto min-w-0 flex-1 justify-center gap-1.5 rounded-md px-3.5 py-1.5 text-sm font-medium text-slate-500 shadow-none transition-all after:hidden hover:bg-slate-50 hover:text-slate-800 data-[state=active]:border-transparent data-[state=active]:bg-slate-100 data-[state=active]:font-medium data-[state=active]:text-slate-900 data-[state=active]:shadow-none dark:data-[state=active]:bg-slate-100 dark:data-[state=active]:text-slate-900'
+import { useAccountDetailBuyingCenter } from './use-account-detail-buying-center'
+import { useAccountDetailStrategy } from './use-account-detail-strategy'
 
 export function AccountDetailClient({
   company,
@@ -53,335 +46,27 @@ export function AccountDetailClient({
   const canEditAccount = isAdmin || isAccountManager
   const canEditStrategy = isAdmin || isAccountManager || isSales
   const canEditBuyingCenter = isAdmin || isAccountManager || isSales
-  const initialTabParam = searchParams.get('tab')
-  const initialTab =
-    initialTabParam === 'mission_control' ||
-    initialTabParam === 'buying_center' ||
-    initialTabParam === 'pipeline' ||
-    initialTabParam === 'proof_points'
-      ? initialTabParam
-      : 'mission_control'
-  const [activeTab, setActiveTab] = useState<
-    'mission_control' | 'buying_center' | 'pipeline' | 'proof_points'
-  >(initialTab)
 
-  const [goals, setGoals] = useState(initialStrategy?.company_goals ?? '')
-  const [valueProposition, setValueProposition] = useState(
-    initialStrategy?.value_proposition ?? '',
+  const [activeTab, setActiveTab] = useState<AccountDetailTab>(
+    parseAccountDetailTab(searchParams.get('tab')),
   )
-  const [redFlags, setRedFlags] = useState(initialStrategy?.red_flags ?? '')
-  const [competition, setCompetition] = useState(initialStrategy?.competition ?? '')
-  const [nextSteps, setNextSteps] = useState(initialStrategy?.next_steps ?? '')
-  const [metricsPain, setMetricsPain] = useState(initialStrategy?.metrics_pain ?? '')
-  const [mhAssessment] = useState<Record<string, unknown>>(
-    initialStrategy?.mh_assessment ?? {},
-  )
-  const [strategySaving, setStrategySaving] = useState(false)
+  const [editAccountOpen, setEditAccountOpen] = useState(Boolean(initialEditOpen))
 
-  const lastSavedRef = useRef({
-    goals: initialStrategy?.company_goals ?? '',
-    valueProposition: initialStrategy?.value_proposition ?? '',
-    redFlags: initialStrategy?.red_flags ?? '',
-    competition: initialStrategy?.competition ?? '',
-    nextSteps: initialStrategy?.next_steps ?? '',
-    metricsPain: initialStrategy?.metrics_pain ?? '',
-    mhAssessment: initialStrategy?.mh_assessment ?? {},
+  const strategy = useAccountDetailStrategy({
+    companyId: company.id,
+    initialStrategy,
+    canEdit: canEditStrategy,
   })
 
-  const [stakeholders, setStakeholders] = useState(initialStakeholders)
-  const [externalContacts, setExternalContacts] = useState(initialExternalContacts)
-  const [internalContacts, setInternalContacts] = useState(initialInternalContacts)
-  const [internalRefApprovalContactId, setInternalRefApprovalContactId] = useState<
-    string | null
-  >(company.internal_reference_approval_contact_id ?? null)
-
-  useEffect(() => {
-    setInternalRefApprovalContactId(
+  const buyingCenter = useAccountDetailBuyingCenter({
+    companyId: company.id,
+    initialStakeholders,
+    initialExternalContacts,
+    initialInternalContacts,
+    initialInternalRefApprovalContactId:
       company.internal_reference_approval_contact_id ?? null,
-    )
-  }, [company.internal_reference_approval_contact_id])
-
-  const [stakeholderOpen, setStakeholderOpen] = useState(false)
-  const [editingStakeholder, setEditingStakeholder] = useState<StakeholderRow | null>(
-    null,
-  )
-  const [shName, setShName] = useState('')
-  const [shTitle, setShTitle] = useState('')
-  const [shRole, setShRole] = useState<StakeholderRole>('champion')
-  const [shInfluence, setShInfluence] = useState('')
-  const [shAttitude, setShAttitude] = useState('')
-  const [shNotes, setShNotes] = useState('')
-  const [shLinkedIn, setShLinkedIn] = useState('')
-  const [shPriorities, setShPriorities] = useState('')
-  const [shLastContact, setShLastContact] = useState('')
-  const [shSentiment, setShSentiment] = useState('')
-  const [stakeholderSaving, setStakeholderSaving] = useState(false)
-
-  const [editAccountOpen, setEditAccountOpen] = useState(Boolean(initialEditOpen))
-  const [contactOpen, setContactOpen] = useState(false)
-  const [editingContact, setEditingContact] = useState<ContactPersonRow | null>(null)
-  const [cFirst, setCFirst] = useState('')
-  const [cLast, setCLast] = useState('')
-  const [cEmail, setCEmail] = useState('')
-  const [cPhone, setCPhone] = useState('')
-  const [cRole, setCRole] = useState('')
-  const [contactSaving, setContactSaving] = useState(false)
-  const [cLinkedIn, setCLinkedIn] = useState('')
-  const [cIsRefApprovalContact, setCIsRefApprovalContact] = useState(false)
-
-  const saveStrategy = async (opts?: { silent?: boolean }) => {
-    if (!canEditStrategy) return
-    const snapshot = {
-      goals,
-      valueProposition,
-      redFlags,
-      competition,
-      nextSteps,
-      metricsPain,
-      mhAssessment,
-    }
-    const last = lastSavedRef.current
-    const changed =
-      snapshot.goals !== last.goals ||
-      snapshot.valueProposition !== last.valueProposition ||
-      snapshot.redFlags !== last.redFlags ||
-      snapshot.competition !== last.competition ||
-      snapshot.nextSteps !== last.nextSteps ||
-      snapshot.metricsPain !== last.metricsPain ||
-      JSON.stringify(snapshot.mhAssessment) !== JSON.stringify(last.mhAssessment)
-    if (!changed) return
-
-    setStrategySaving(true)
-    try {
-      const res = await upsertCompanyStrategy(company.id, {
-        metrics_pain: snapshot.metricsPain || null,
-        company_goals: snapshot.goals || null,
-        red_flags: snapshot.redFlags || null,
-        competition: snapshot.competition || null,
-        next_steps: snapshot.nextSteps || null,
-        value_proposition: snapshot.valueProposition || null,
-        mh_assessment: snapshot.mhAssessment,
-      })
-      if (!res.success) {
-        toast.error(res.error ?? 'Speichern fehlgeschlagen.')
-        return
-      }
-      lastSavedRef.current = snapshot
-      if (!opts?.silent) toast.success('Gespeichert.')
-    } finally {
-      setStrategySaving(false)
-    }
-  }
-
-  const strategyFields = useMemo(
-    () => [
-      {
-        key: 'metrics_pain',
-        label: 'Metrics & Pain',
-        value: metricsPain,
-        set: setMetricsPain,
-      },
-      { key: 'company_goals', label: 'Geschäftsziele', value: goals, set: setGoals },
-      {
-        key: 'value_proposition',
-        label: 'Value Proposition',
-        value: valueProposition,
-        set: setValueProposition,
-      },
-      {
-        key: 'red_flags',
-        label: 'Risiken / Red Flags',
-        value: redFlags,
-        set: setRedFlags,
-      },
-      {
-        key: 'competition',
-        label: 'Wettbewerb / Incumbent',
-        value: competition,
-        set: setCompetition,
-      },
-      {
-        key: 'next_steps',
-        label: 'Nächste Schritte',
-        value: nextSteps,
-        set: setNextSteps,
-      },
-    ],
-    [metricsPain, goals, valueProposition, redFlags, competition, nextSteps],
-  )
-
-  const openStakeholderDialog = (s?: StakeholderRow) => {
-    setEditingStakeholder(s ?? null)
-    setShName(s?.name ?? '')
-    setShTitle(s?.title ?? '')
-    setShRole(s?.role ?? 'champion')
-    setShInfluence(s?.influence_level ?? '')
-    setShAttitude(s?.attitude ?? '')
-    setShNotes(s?.notes ?? '')
-    setShLinkedIn(s?.linkedin_url ?? '')
-    setShPriorities(s?.priorities_topics ?? '')
-    const lastI = s?.last_interaction_at ?? s?.last_contact_at ?? ''
-    setShLastContact(lastI.slice(0, 10))
-    setShSentiment(s?.sentiment ?? '')
-    setStakeholderOpen(true)
-  }
-
-  const saveStakeholder = async () => {
-    if (!canEditBuyingCenter) return
-    if (!shName.trim()) return toast.error('Name ist erforderlich.')
-    setStakeholderSaving(true)
-    try {
-      const payload = {
-        name: shName.trim(),
-        title: shTitle.trim() || null,
-        role: shRole,
-        influence_level: shInfluence.trim() || null,
-        attitude: shAttitude.trim() || null,
-        notes: shNotes.trim() || null,
-        linkedin_url: shLinkedIn.trim() || null,
-        priorities_topics: shPriorities.trim() || null,
-        last_interaction_at: shLastContact || null,
-        last_contact_at: shLastContact || null,
-        sentiment: shSentiment.trim() || null,
-      }
-      if (editingStakeholder) {
-        const res = await updateStakeholder(editingStakeholder.id, payload)
-        if (!res.success) return toast.error(res.error ?? 'Speichern fehlgeschlagen.')
-        toast.success('Stakeholder aktualisiert.')
-        setStakeholderOpen(false)
-        setStakeholders((prev) =>
-          prev.map((p) =>
-            p.id === editingStakeholder.id
-              ? {
-                  ...p,
-                  ...payload,
-                  role: payload.role,
-                }
-              : p,
-          ),
-        )
-      } else {
-        const res = await createStakeholder(company.id, payload)
-        if (!res.success) return toast.error(res.error ?? 'Speichern fehlgeschlagen.')
-        toast.success('Stakeholder hinzugefügt.')
-        setStakeholderOpen(false)
-        const created = res.stakeholder
-        if (created) setStakeholders((prev) => [...prev, created])
-      }
-    } finally {
-      setStakeholderSaving(false)
-    }
-  }
-
-  const removeStakeholder = async (id: string) => {
-    if (!canEditBuyingCenter) return
-    const res = await deleteStakeholder(id)
-    if (!res.success) return toast.error(res.error ?? 'Löschen fehlgeschlagen.')
-    setStakeholders((prev) => prev.filter((s) => s.id !== id))
-    toast.success('Stakeholder gelöscht.')
-  }
-
-  const openContactDialog = (c?: ContactPersonRow) => {
-    setEditingContact(c ?? null)
-    setCIsRefApprovalContact(Boolean(c?.id && c.id === internalRefApprovalContactId))
-    setCFirst(c?.first_name ?? '')
-    setCLast(c?.last_name ?? '')
-    setCEmail(c?.email ?? '')
-    setCPhone(c?.phone ?? '')
-    const legacyPosition = c?.position?.trim()
-    setCRole(c?.role?.trim() || legacyPosition || '')
-    setCLinkedIn(c?.linkedin_url ?? '')
-    setContactOpen(true)
-  }
-
-  const saveContact = async () => {
-    if (!canEditBuyingCenter) return
-    setContactSaving(true)
-    try {
-      if (editingContact) {
-        const res = await updateContactPerson(editingContact.id, {
-          first_name: cFirst.trim() || null,
-          last_name: cLast.trim() || null,
-          email: cEmail.trim() || null,
-          phone: cPhone.trim() || null,
-          linkedin_url: cLinkedIn.trim() || null,
-          role: cRole.trim() || null,
-        })
-        if (!res.success) return toast.error(res.error ?? 'Speichern fehlgeschlagen.')
-        if (cIsRefApprovalContact) {
-          const ar = await setCompanyInternalReferenceApprovalContact(
-            company.id,
-            editingContact.id,
-          )
-          if (!ar.success) {
-            toast.error(ar.error ?? 'Referenzfreigabe-Zuordnung fehlgeschlagen.')
-            return
-          }
-          setInternalRefApprovalContactId(editingContact.id)
-        } else if (internalRefApprovalContactId === editingContact.id) {
-          const ar = await setCompanyInternalReferenceApprovalContact(company.id, null)
-          if (!ar.success) {
-            toast.error(ar.error ?? 'Zuordnung konnte nicht entfernt werden.')
-            return
-          }
-          setInternalRefApprovalContactId(null)
-        }
-        toast.success('Kontakt aktualisiert.')
-        setContactOpen(false)
-        setInternalContacts((prev) =>
-          prev.map((p) =>
-            p.id === editingContact.id
-              ? ({
-                  ...p,
-                  first_name: cFirst.trim() || null,
-                  last_name: cLast.trim() || null,
-                  email: cEmail.trim() || null,
-                  phone: cPhone.trim() || null,
-                  linkedin_url: cLinkedIn.trim() || null,
-                  role: cRole.trim() || null,
-                } as ContactPersonRow)
-              : p,
-          ),
-        )
-      } else {
-        const res = await createContactPerson(company.id, {
-          first_name: cFirst.trim() || null,
-          last_name: cLast.trim() || null,
-          email: cEmail.trim() || null,
-          phone: cPhone.trim() || null,
-          linkedin_url: cLinkedIn.trim() || null,
-          role: cRole.trim() || null,
-        })
-        if (!res.success) return toast.error(res.error ?? 'Speichern fehlgeschlagen.')
-        const created = res.contact
-        if (created && cIsRefApprovalContact) {
-          const ar = await setCompanyInternalReferenceApprovalContact(
-            company.id,
-            created.id,
-          )
-          if (!ar.success) {
-            toast.error(ar.error ?? 'Referenzfreigabe-Zuordnung fehlgeschlagen.')
-            return
-          }
-          setInternalRefApprovalContactId(created.id)
-        }
-        toast.success('Kontakt hinzugefügt.')
-        setContactOpen(false)
-        if (created) setInternalContacts((prev) => [...prev, created])
-      }
-    } finally {
-      setContactSaving(false)
-    }
-  }
-
-  const removeContact = async (id: string) => {
-    if (!canEditBuyingCenter) return
-    const res = await deleteContactPerson(id)
-    if (!res.success) return toast.error(res.error ?? 'Löschen fehlgeschlagen.')
-    if (internalRefApprovalContactId === id) setInternalRefApprovalContactId(null)
-    setInternalContacts((prev) => prev.filter((c) => c.id !== id))
-    toast.success('Kontakt gelöscht.')
-  }
+    canEdit: canEditBuyingCenter,
+  })
 
   return (
     <div className="space-y-6">
@@ -402,13 +87,7 @@ export function AccountDetailClient({
       <Tabs
         value={activeTab}
         onValueChange={(value) => {
-          const next =
-            value === 'mission_control' ||
-            value === 'buying_center' ||
-            value === 'pipeline' ||
-            value === 'proof_points'
-              ? value
-              : 'mission_control'
+          const next = parseAccountDetailTab(value)
           setActiveTab(next)
           const params = new URLSearchParams(searchParams.toString())
           params.set('tab', next)
@@ -441,71 +120,35 @@ export function AccountDetailClient({
         <TabsContent value="mission_control" className="mt-2">
           <AccountDetailStrategyTab
             canEdit={canEditStrategy}
-            strategySaving={strategySaving}
-            strategyFields={strategyFields}
-            saveStrategy={saveStrategy}
-            stakeholders={stakeholders}
-            externalContacts={externalContacts}
+            strategySaving={strategy.strategySaving}
+            strategyFields={strategy.strategyFields}
+            saveStrategy={strategy.saveStrategy}
+            stakeholders={buyingCenter.stakeholders}
+            externalContacts={buyingCenter.externalContacts}
             marketSignals={marketSignals}
-            onSetStakeholderRole={async (id, role) => {
-              const res = await updateStakeholder(id, { role })
-              if (!res.success) {
-                toast.error(res.error ?? 'Speichern fehlgeschlagen.')
-                return
-              }
-              setStakeholders((prev) =>
-                prev.map((s) => (s.id === id ? ({ ...s, role } as StakeholderRow) : s)),
-              )
-              if (role !== 'unknown') {
-                setExternalContacts((prev) =>
-                  prev.map((c) =>
-                    c.buying_center_role === role
-                      ? { ...c, buying_center_role: 'unknown' as const }
-                      : c,
-                  ),
-                )
-              }
-              toast.success('Rolle aktualisiert.')
-            }}
-            onSetExternalBuyingCenterRole={async (id, role) => {
-              const res = await updateExternalContactBuyingCenterRole(id, role)
-              if (!res.success) {
-                toast.error(res.error ?? 'Speichern fehlgeschlagen.')
-                return
-              }
-              setExternalContacts((prev) =>
-                prev.map((c) => (c.id === id ? { ...c, buying_center_role: role } : c)),
-              )
-              if (role !== 'unknown') {
-                setStakeholders((prev) =>
-                  prev.map((s) =>
-                    s.role === role
-                      ? ({ ...s, role: 'unknown' as const } as StakeholderRow)
-                      : s,
-                  ),
-                )
-              }
-              toast.success('Rolle aktualisiert.')
-            }}
+            onSetStakeholderRole={buyingCenter.setStakeholderRole}
+            onSetExternalBuyingCenterRole={buyingCenter.setExternalBuyingCenterRole}
           />
         </TabsContent>
 
         <TabsContent value="buying_center" className="mt-2">
           <AccountDetailPowerMapTab
-            stakeholders={stakeholders}
+            stakeholders={buyingCenter.stakeholders}
             marketSignals={marketSignals}
-            internalContacts={internalContacts}
-            externalContacts={externalContacts}
+            internalContacts={buyingCenter.internalContacts}
+            externalContacts={buyingCenter.externalContacts}
             companyName={company.name}
             organizationName={organizationName}
-            internalReferenceApprovalContactId={internalRefApprovalContactId}
+            internalReferenceApprovalContactId={
+              buyingCenter.internalRefApprovalContactId
+            }
             canEdit={canEditBuyingCenter}
-            onAddStakeholder={() => openStakeholderDialog()}
-            onEditStakeholder={openStakeholderDialog}
-            onRemoveStakeholder={removeStakeholder}
-            onAddInternalContact={() => openContactDialog()}
-            onEditInternalContact={openContactDialog}
-            onRemoveInternalContact={removeContact}
+            onAddStakeholder={() => buyingCenter.openStakeholderDialog()}
+            onEditStakeholder={buyingCenter.openStakeholderDialog}
+            onRemoveStakeholder={buyingCenter.removeStakeholder}
+            onAddInternalContact={() => buyingCenter.openContactDialog()}
+            onEditInternalContact={buyingCenter.openContactDialog}
+            onRemoveInternalContact={buyingCenter.removeContact}
           />
         </TabsContent>
 
@@ -522,54 +165,54 @@ export function AccountDetailClient({
       </Tabs>
 
       <AccountStakeholderDialog
-        open={stakeholderOpen}
-        onOpenChange={setStakeholderOpen}
-        editing={!!editingStakeholder}
-        saving={stakeholderSaving}
-        shName={shName}
-        setShName={setShName}
-        shTitle={shTitle}
-        setShTitle={setShTitle}
-        shRole={shRole}
-        setShRole={setShRole}
-        shInfluence={shInfluence}
-        setShInfluence={setShInfluence}
-        shAttitude={shAttitude}
-        setShAttitude={setShAttitude}
-        shLinkedIn={shLinkedIn}
-        setShLinkedIn={setShLinkedIn}
-        shPriorities={shPriorities}
-        setShPriorities={setShPriorities}
-        shLastContact={shLastContact}
-        setShLastContact={setShLastContact}
-        shSentiment={shSentiment}
-        setShSentiment={setShSentiment}
-        shNotes={shNotes}
-        setShNotes={setShNotes}
-        onSave={saveStakeholder}
+        open={buyingCenter.stakeholderOpen}
+        onOpenChange={buyingCenter.setStakeholderOpen}
+        editing={!!buyingCenter.editingStakeholder}
+        saving={buyingCenter.stakeholderSaving}
+        shName={buyingCenter.shName}
+        setShName={buyingCenter.setShName}
+        shTitle={buyingCenter.shTitle}
+        setShTitle={buyingCenter.setShTitle}
+        shRole={buyingCenter.shRole}
+        setShRole={buyingCenter.setShRole}
+        shInfluence={buyingCenter.shInfluence}
+        setShInfluence={buyingCenter.setShInfluence}
+        shAttitude={buyingCenter.shAttitude}
+        setShAttitude={buyingCenter.setShAttitude}
+        shLinkedIn={buyingCenter.shLinkedIn}
+        setShLinkedIn={buyingCenter.setShLinkedIn}
+        shPriorities={buyingCenter.shPriorities}
+        setShPriorities={buyingCenter.setShPriorities}
+        shLastContact={buyingCenter.shLastContact}
+        setShLastContact={buyingCenter.setShLastContact}
+        shSentiment={buyingCenter.shSentiment}
+        setShSentiment={buyingCenter.setShSentiment}
+        shNotes={buyingCenter.shNotes}
+        setShNotes={buyingCenter.setShNotes}
+        onSave={buyingCenter.saveStakeholder}
       />
 
       <AccountContactDialog
-        open={contactOpen}
-        onOpenChange={setContactOpen}
-        editing={!!editingContact}
-        saving={contactSaving}
+        open={buyingCenter.contactOpen}
+        onOpenChange={buyingCenter.setContactOpen}
+        editing={!!buyingCenter.editingContact}
+        saving={buyingCenter.contactSaving}
         companyName={company.name}
-        cFirst={cFirst}
-        setCFirst={setCFirst}
-        cLast={cLast}
-        setCLast={setCLast}
-        cEmail={cEmail}
-        setCEmail={setCEmail}
-        cPhone={cPhone}
-        setCPhone={setCPhone}
-        cLinkedIn={cLinkedIn}
-        setCLinkedIn={setCLinkedIn}
-        cRole={cRole}
-        setCRole={setCRole}
-        cIsRefApprovalContact={cIsRefApprovalContact}
-        setCIsRefApprovalContact={setCIsRefApprovalContact}
-        onSave={saveContact}
+        cFirst={buyingCenter.cFirst}
+        setCFirst={buyingCenter.setCFirst}
+        cLast={buyingCenter.cLast}
+        setCLast={buyingCenter.setCLast}
+        cEmail={buyingCenter.cEmail}
+        setCEmail={buyingCenter.setCEmail}
+        cPhone={buyingCenter.cPhone}
+        setCPhone={buyingCenter.setCPhone}
+        cLinkedIn={buyingCenter.cLinkedIn}
+        setCLinkedIn={buyingCenter.setCLinkedIn}
+        cRole={buyingCenter.cRole}
+        setCRole={buyingCenter.setCRole}
+        cIsRefApprovalContact={buyingCenter.cIsRefApprovalContact}
+        setCIsRefApprovalContact={buyingCenter.setCIsRefApprovalContact}
+        onSave={buyingCenter.saveContact}
       />
     </div>
   )

--- a/app/dashboard/accounts/account-detail-constants.ts
+++ b/app/dashboard/accounts/account-detail-constants.ts
@@ -1,5 +1,26 @@
 import type { StakeholderRole } from './actions'
 
+export const ACCOUNT_DETAIL_TAB_TRIGGER_CLASS =
+  'h-auto min-w-0 flex-1 justify-center gap-1.5 rounded-md px-3.5 py-1.5 text-sm font-medium text-slate-500 shadow-none transition-all after:hidden hover:bg-slate-50 hover:text-slate-800 data-[state=active]:border-transparent data-[state=active]:bg-slate-100 data-[state=active]:font-medium data-[state=active]:text-slate-900 data-[state=active]:shadow-none dark:data-[state=active]:bg-slate-100 dark:data-[state=active]:text-slate-900'
+
+export type AccountDetailTab =
+  | 'mission_control'
+  | 'buying_center'
+  | 'pipeline'
+  | 'proof_points'
+
+export function parseAccountDetailTab(value: string | null): AccountDetailTab {
+  if (
+    value === 'mission_control' ||
+    value === 'buying_center' ||
+    value === 'pipeline' ||
+    value === 'proof_points'
+  ) {
+    return value
+  }
+  return 'mission_control'
+}
+
 export const STAKEHOLDER_ROLE_BADGES: Record<
   StakeholderRole,
   { label: string; className: string }

--- a/app/dashboard/accounts/use-account-detail-buying-center.ts
+++ b/app/dashboard/accounts/use-account-detail-buying-center.ts
@@ -1,0 +1,345 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { toast } from 'sonner'
+
+import type {
+  ContactPersonRow,
+  ExternalContactRow,
+  StakeholderRole,
+  StakeholderRow,
+} from './actions'
+import {
+  createContactPerson,
+  createStakeholder,
+  deleteContactPerson,
+  deleteStakeholder,
+  setCompanyInternalReferenceApprovalContact,
+  updateContactPerson,
+  updateExternalContactBuyingCenterRole,
+  updateStakeholder,
+} from './actions'
+
+export function useAccountDetailBuyingCenter({
+  companyId,
+  initialStakeholders,
+  initialExternalContacts,
+  initialInternalContacts,
+  initialInternalRefApprovalContactId,
+  canEdit,
+}: {
+  companyId: string
+  initialStakeholders: StakeholderRow[]
+  initialExternalContacts: ExternalContactRow[]
+  initialInternalContacts: ContactPersonRow[]
+  initialInternalRefApprovalContactId: string | null
+  canEdit: boolean
+}) {
+  const [stakeholders, setStakeholders] = useState(initialStakeholders)
+  const [externalContacts, setExternalContacts] = useState(initialExternalContacts)
+  const [internalContacts, setInternalContacts] = useState(initialInternalContacts)
+  const [internalRefApprovalContactId, setInternalRefApprovalContactId] = useState<
+    string | null
+  >(initialInternalRefApprovalContactId)
+
+  useEffect(() => {
+    setInternalRefApprovalContactId(initialInternalRefApprovalContactId)
+  }, [initialInternalRefApprovalContactId])
+
+  const [stakeholderOpen, setStakeholderOpen] = useState(false)
+  const [editingStakeholder, setEditingStakeholder] = useState<StakeholderRow | null>(
+    null,
+  )
+  const [shName, setShName] = useState('')
+  const [shTitle, setShTitle] = useState('')
+  const [shRole, setShRole] = useState<StakeholderRole>('champion')
+  const [shInfluence, setShInfluence] = useState('')
+  const [shAttitude, setShAttitude] = useState('')
+  const [shNotes, setShNotes] = useState('')
+  const [shLinkedIn, setShLinkedIn] = useState('')
+  const [shPriorities, setShPriorities] = useState('')
+  const [shLastContact, setShLastContact] = useState('')
+  const [shSentiment, setShSentiment] = useState('')
+  const [stakeholderSaving, setStakeholderSaving] = useState(false)
+
+  const [contactOpen, setContactOpen] = useState(false)
+  const [editingContact, setEditingContact] = useState<ContactPersonRow | null>(null)
+  const [cFirst, setCFirst] = useState('')
+  const [cLast, setCLast] = useState('')
+  const [cEmail, setCEmail] = useState('')
+  const [cPhone, setCPhone] = useState('')
+  const [cRole, setCRole] = useState('')
+  const [contactSaving, setContactSaving] = useState(false)
+  const [cLinkedIn, setCLinkedIn] = useState('')
+  const [cIsRefApprovalContact, setCIsRefApprovalContact] = useState(false)
+
+  const openStakeholderDialog = (s?: StakeholderRow) => {
+    setEditingStakeholder(s ?? null)
+    setShName(s?.name ?? '')
+    setShTitle(s?.title ?? '')
+    setShRole(s?.role ?? 'champion')
+    setShInfluence(s?.influence_level ?? '')
+    setShAttitude(s?.attitude ?? '')
+    setShNotes(s?.notes ?? '')
+    setShLinkedIn(s?.linkedin_url ?? '')
+    setShPriorities(s?.priorities_topics ?? '')
+    const lastI = s?.last_interaction_at ?? s?.last_contact_at ?? ''
+    setShLastContact(lastI.slice(0, 10))
+    setShSentiment(s?.sentiment ?? '')
+    setStakeholderOpen(true)
+  }
+
+  const saveStakeholder = async () => {
+    if (!canEdit) return
+    if (!shName.trim()) return toast.error('Name ist erforderlich.')
+    setStakeholderSaving(true)
+    try {
+      const payload = {
+        name: shName.trim(),
+        title: shTitle.trim() || null,
+        role: shRole,
+        influence_level: shInfluence.trim() || null,
+        attitude: shAttitude.trim() || null,
+        notes: shNotes.trim() || null,
+        linkedin_url: shLinkedIn.trim() || null,
+        priorities_topics: shPriorities.trim() || null,
+        last_interaction_at: shLastContact || null,
+        last_contact_at: shLastContact || null,
+        sentiment: shSentiment.trim() || null,
+      }
+      if (editingStakeholder) {
+        const res = await updateStakeholder(editingStakeholder.id, payload)
+        if (!res.success) return toast.error(res.error ?? 'Speichern fehlgeschlagen.')
+        toast.success('Stakeholder aktualisiert.')
+        setStakeholderOpen(false)
+        setStakeholders((prev) =>
+          prev.map((p) =>
+            p.id === editingStakeholder.id
+              ? {
+                  ...p,
+                  ...payload,
+                  role: payload.role,
+                }
+              : p,
+          ),
+        )
+      } else {
+        const res = await createStakeholder(companyId, payload)
+        if (!res.success) return toast.error(res.error ?? 'Speichern fehlgeschlagen.')
+        toast.success('Stakeholder hinzugefügt.')
+        setStakeholderOpen(false)
+        const created = res.stakeholder
+        if (created) setStakeholders((prev) => [...prev, created])
+      }
+    } finally {
+      setStakeholderSaving(false)
+    }
+  }
+
+  const removeStakeholder = async (id: string) => {
+    if (!canEdit) return
+    const res = await deleteStakeholder(id)
+    if (!res.success) return toast.error(res.error ?? 'Löschen fehlgeschlagen.')
+    setStakeholders((prev) => prev.filter((s) => s.id !== id))
+    toast.success('Stakeholder gelöscht.')
+  }
+
+  const openContactDialog = (c?: ContactPersonRow) => {
+    setEditingContact(c ?? null)
+    setCIsRefApprovalContact(Boolean(c?.id && c.id === internalRefApprovalContactId))
+    setCFirst(c?.first_name ?? '')
+    setCLast(c?.last_name ?? '')
+    setCEmail(c?.email ?? '')
+    setCPhone(c?.phone ?? '')
+    const legacyPosition = c?.position?.trim()
+    setCRole(c?.role?.trim() || legacyPosition || '')
+    setCLinkedIn(c?.linkedin_url ?? '')
+    setContactOpen(true)
+  }
+
+  const saveContact = async () => {
+    if (!canEdit) return
+    setContactSaving(true)
+    try {
+      if (editingContact) {
+        const res = await updateContactPerson(editingContact.id, {
+          first_name: cFirst.trim() || null,
+          last_name: cLast.trim() || null,
+          email: cEmail.trim() || null,
+          phone: cPhone.trim() || null,
+          linkedin_url: cLinkedIn.trim() || null,
+          role: cRole.trim() || null,
+        })
+        if (!res.success) return toast.error(res.error ?? 'Speichern fehlgeschlagen.')
+        if (cIsRefApprovalContact) {
+          const ar = await setCompanyInternalReferenceApprovalContact(
+            companyId,
+            editingContact.id,
+          )
+          if (!ar.success) {
+            toast.error(ar.error ?? 'Referenzfreigabe-Zuordnung fehlgeschlagen.')
+            return
+          }
+          setInternalRefApprovalContactId(editingContact.id)
+        } else if (internalRefApprovalContactId === editingContact.id) {
+          const ar = await setCompanyInternalReferenceApprovalContact(companyId, null)
+          if (!ar.success) {
+            toast.error(ar.error ?? 'Zuordnung konnte nicht entfernt werden.')
+            return
+          }
+          setInternalRefApprovalContactId(null)
+        }
+        toast.success('Kontakt aktualisiert.')
+        setContactOpen(false)
+        setInternalContacts((prev) =>
+          prev.map((p) =>
+            p.id === editingContact.id
+              ? ({
+                  ...p,
+                  first_name: cFirst.trim() || null,
+                  last_name: cLast.trim() || null,
+                  email: cEmail.trim() || null,
+                  phone: cPhone.trim() || null,
+                  linkedin_url: cLinkedIn.trim() || null,
+                  role: cRole.trim() || null,
+                } as ContactPersonRow)
+              : p,
+          ),
+        )
+      } else {
+        const res = await createContactPerson(companyId, {
+          first_name: cFirst.trim() || null,
+          last_name: cLast.trim() || null,
+          email: cEmail.trim() || null,
+          phone: cPhone.trim() || null,
+          linkedin_url: cLinkedIn.trim() || null,
+          role: cRole.trim() || null,
+        })
+        if (!res.success) return toast.error(res.error ?? 'Speichern fehlgeschlagen.')
+        const created = res.contact
+        if (created && cIsRefApprovalContact) {
+          const ar = await setCompanyInternalReferenceApprovalContact(
+            companyId,
+            created.id,
+          )
+          if (!ar.success) {
+            toast.error(ar.error ?? 'Referenzfreigabe-Zuordnung fehlgeschlagen.')
+            return
+          }
+          setInternalRefApprovalContactId(created.id)
+        }
+        toast.success('Kontakt hinzugefügt.')
+        setContactOpen(false)
+        if (created) setInternalContacts((prev) => [...prev, created])
+      }
+    } finally {
+      setContactSaving(false)
+    }
+  }
+
+  const removeContact = async (id: string) => {
+    if (!canEdit) return
+    const res = await deleteContactPerson(id)
+    if (!res.success) return toast.error(res.error ?? 'Löschen fehlgeschlagen.')
+    if (internalRefApprovalContactId === id) setInternalRefApprovalContactId(null)
+    setInternalContacts((prev) => prev.filter((c) => c.id !== id))
+    toast.success('Kontakt gelöscht.')
+  }
+
+  const setStakeholderRole = async (id: string, role: StakeholderRole) => {
+    const res = await updateStakeholder(id, { role })
+    if (!res.success) {
+      toast.error(res.error ?? 'Speichern fehlgeschlagen.')
+      return
+    }
+    setStakeholders((prev) =>
+      prev.map((s) => (s.id === id ? ({ ...s, role } as StakeholderRow) : s)),
+    )
+    if (role !== 'unknown') {
+      setExternalContacts((prev) =>
+        prev.map((c) =>
+          c.buying_center_role === role
+            ? { ...c, buying_center_role: 'unknown' as const }
+            : c,
+        ),
+      )
+    }
+    toast.success('Rolle aktualisiert.')
+  }
+
+  const setExternalBuyingCenterRole = async (id: string, role: StakeholderRole) => {
+    const res = await updateExternalContactBuyingCenterRole(id, role)
+    if (!res.success) {
+      toast.error(res.error ?? 'Speichern fehlgeschlagen.')
+      return
+    }
+    setExternalContacts((prev) =>
+      prev.map((c) => (c.id === id ? { ...c, buying_center_role: role } : c)),
+    )
+    if (role !== 'unknown') {
+      setStakeholders((prev) =>
+        prev.map((s) =>
+          s.role === role ? ({ ...s, role: 'unknown' as const } as StakeholderRow) : s,
+        ),
+      )
+    }
+    toast.success('Rolle aktualisiert.')
+  }
+
+  return {
+    stakeholders,
+    externalContacts,
+    internalContacts,
+    internalRefApprovalContactId,
+    stakeholderOpen,
+    setStakeholderOpen,
+    editingStakeholder,
+    shName,
+    setShName,
+    shTitle,
+    setShTitle,
+    shRole,
+    setShRole,
+    shInfluence,
+    setShInfluence,
+    shAttitude,
+    setShAttitude,
+    shNotes,
+    setShNotes,
+    shLinkedIn,
+    setShLinkedIn,
+    shPriorities,
+    setShPriorities,
+    shLastContact,
+    setShLastContact,
+    shSentiment,
+    setShSentiment,
+    stakeholderSaving,
+    openStakeholderDialog,
+    saveStakeholder,
+    removeStakeholder,
+    contactOpen,
+    setContactOpen,
+    editingContact,
+    cFirst,
+    setCFirst,
+    cLast,
+    setCLast,
+    cEmail,
+    setCEmail,
+    cPhone,
+    setCPhone,
+    cRole,
+    setCRole,
+    contactSaving,
+    cLinkedIn,
+    setCLinkedIn,
+    cIsRefApprovalContact,
+    setCIsRefApprovalContact,
+    openContactDialog,
+    saveContact,
+    removeContact,
+    setStakeholderRole,
+    setExternalBuyingCenterRole,
+  }
+}

--- a/app/dashboard/accounts/use-account-detail-strategy.ts
+++ b/app/dashboard/accounts/use-account-detail-strategy.ts
@@ -1,0 +1,127 @@
+'use client'
+
+import { useMemo, useRef, useState } from 'react'
+import { toast } from 'sonner'
+
+import type { CompanyStrategyRow } from './actions'
+import { upsertCompanyStrategy } from './actions'
+
+export function useAccountDetailStrategy({
+  companyId,
+  initialStrategy,
+  canEdit,
+}: {
+  companyId: string
+  initialStrategy: CompanyStrategyRow | null
+  canEdit: boolean
+}) {
+  const [goals, setGoals] = useState(initialStrategy?.company_goals ?? '')
+  const [valueProposition, setValueProposition] = useState(
+    initialStrategy?.value_proposition ?? '',
+  )
+  const [redFlags, setRedFlags] = useState(initialStrategy?.red_flags ?? '')
+  const [competition, setCompetition] = useState(initialStrategy?.competition ?? '')
+  const [nextSteps, setNextSteps] = useState(initialStrategy?.next_steps ?? '')
+  const [metricsPain, setMetricsPain] = useState(initialStrategy?.metrics_pain ?? '')
+  const [mhAssessment] = useState<Record<string, unknown>>(
+    initialStrategy?.mh_assessment ?? {},
+  )
+  const [strategySaving, setStrategySaving] = useState(false)
+
+  const lastSavedRef = useRef({
+    goals: initialStrategy?.company_goals ?? '',
+    valueProposition: initialStrategy?.value_proposition ?? '',
+    redFlags: initialStrategy?.red_flags ?? '',
+    competition: initialStrategy?.competition ?? '',
+    nextSteps: initialStrategy?.next_steps ?? '',
+    metricsPain: initialStrategy?.metrics_pain ?? '',
+    mhAssessment: initialStrategy?.mh_assessment ?? {},
+  })
+
+  const saveStrategy = async (opts?: { silent?: boolean }) => {
+    if (!canEdit) return
+    const snapshot = {
+      goals,
+      valueProposition,
+      redFlags,
+      competition,
+      nextSteps,
+      metricsPain,
+      mhAssessment,
+    }
+    const last = lastSavedRef.current
+    const changed =
+      snapshot.goals !== last.goals ||
+      snapshot.valueProposition !== last.valueProposition ||
+      snapshot.redFlags !== last.redFlags ||
+      snapshot.competition !== last.competition ||
+      snapshot.nextSteps !== last.nextSteps ||
+      snapshot.metricsPain !== last.metricsPain ||
+      JSON.stringify(snapshot.mhAssessment) !== JSON.stringify(last.mhAssessment)
+    if (!changed) return
+
+    setStrategySaving(true)
+    try {
+      const res = await upsertCompanyStrategy(companyId, {
+        metrics_pain: snapshot.metricsPain || null,
+        company_goals: snapshot.goals || null,
+        red_flags: snapshot.redFlags || null,
+        competition: snapshot.competition || null,
+        next_steps: snapshot.nextSteps || null,
+        value_proposition: snapshot.valueProposition || null,
+        mh_assessment: snapshot.mhAssessment,
+      })
+      if (!res.success) {
+        toast.error(res.error ?? 'Speichern fehlgeschlagen.')
+        return
+      }
+      lastSavedRef.current = snapshot
+      if (!opts?.silent) toast.success('Gespeichert.')
+    } finally {
+      setStrategySaving(false)
+    }
+  }
+
+  const strategyFields = useMemo(
+    () => [
+      {
+        key: 'metrics_pain',
+        label: 'Metrics & Pain',
+        value: metricsPain,
+        set: setMetricsPain,
+      },
+      { key: 'company_goals', label: 'Geschäftsziele', value: goals, set: setGoals },
+      {
+        key: 'value_proposition',
+        label: 'Value Proposition',
+        value: valueProposition,
+        set: setValueProposition,
+      },
+      {
+        key: 'red_flags',
+        label: 'Risiken / Red Flags',
+        value: redFlags,
+        set: setRedFlags,
+      },
+      {
+        key: 'competition',
+        label: 'Wettbewerb / Incumbent',
+        value: competition,
+        set: setCompetition,
+      },
+      {
+        key: 'next_steps',
+        label: 'Nächste Schritte',
+        value: nextSteps,
+        set: setNextSteps,
+      },
+    ],
+    [metricsPain, goals, valueProposition, redFlags, competition, nextSteps],
+  )
+
+  return {
+    strategySaving,
+    strategyFields,
+    saveStrategy,
+  }
+}

--- a/docs/tech-debt-offen-backlog.md
+++ b/docs/tech-debt-offen-backlog.md
@@ -28,7 +28,7 @@
 | **2** | E7 Schema-Sync | ✅ T1–T4 | Types bei Migrationen regenerieren (`db:types`) | XS ongoing | bei Schema-Change |
 | **3** | Typed-Supabase Cast-Abbau | ✅ T1–T4 | Rest-Casts nur Boundaries (HTTP/RPC/Json); Boy-Scout bei Touch | — | CI: `typecheck` vor Build |
 | **4** | P1-6 Accounts Naming | ✅ App/Lib | DB-Tabelle `companies` / `company_id` / Firmennamen-Helfer **bewusst offen** | — | nicht anfassen ohne Produktentscheid |
-| **5** | God-File-Nacharbeit | Slice 1–11 ✅ | … + nda-popover, workflow-tab | M ongoing | nächster: account-detail-client Hooks / Boy-Scout |
+| **5** | God-File-Nacharbeit | Slice 1–12 ✅ | … + workflow-tab, account-detail-client Hooks | M ongoing | Boy-Scout bei Touch / nächste ~500+-Dateien |
 | **6** | `{ ok }` → `{ success }` | Lib ✅ | Slices 1–4; Rest nur Cron/Push-HTTP-Body | XS | Cron/Push separat wenn Monitoring-Clients ok |
 | **7** | P3-3 DE/EN-Dateinamen | ✅ Slice | `ai-draft-*`, `customer-control-link-email`; API `/api/ai-draft` + Redirect; UI-Copy „Sperrlink“/Event `ki_entwurf_generated` bleiben | — | Rest nur bei Touch |
 | **8** | `references`/`evidence` Pfade | ✅ | App = `references` (Routen/Ordner/`ROUTES`); Redirects `/dashboard/evidence` bleiben; `evidence_events` bleibt | — | Rest-`evidence` nur Domänenbegriff (RFP-Belege) |


### PR DESCRIPTION
## Summary
- Split `account-detail-client.tsx` (~576 → ~219) into `useAccountDetailStrategy` and `useAccountDetailBuyingCenter`
- Tab trigger class + tab parse helpers moved to `account-detail-constants`
- Behavior unchanged (strategy autosave fields, stakeholder/contact dialogs, buying-center role exclusivity, tab URL sync)

## Test plan
- [ ] Account detail: Strategie tab edit + save
- [ ] Set stakeholder / external buying-center roles (exclusive clear)
- [ ] Buying center: add/edit/delete stakeholder and internal contact
- [ ] Ref-approval contact checkbox on internal contact
- [ ] Tab URL `?tab=` sync; edit account dialog; NDA openOnMount


Made with [Cursor](https://cursor.com)